### PR TITLE
WIP: More accurate length/margin

### DIFF
--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -132,6 +132,7 @@ function format_text(text::AbstractString; indent::Integer = 4, margin::Integer 
 
     s = State(d, indent, margin)
     t = pretty(x, s)
+    @info "" length(t)
     add_node!(t, InlineComment(t.endline))
     nest!(t, s)
 

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -132,7 +132,6 @@ function format_text(text::AbstractString; indent::Integer = 4, margin::Integer 
 
     s = State(d, indent, margin)
     t = pretty(x, s)
-    @info "" length(t)
     add_node!(t, InlineComment(t.endline))
     nest!(t, s)
 

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -152,6 +152,7 @@ function format_text(text::AbstractString; indent::Integer = 4, margin::Integer 
     print_tree(io, t, s)
 
     text = String(take!(io))
+
     _, ps = CSTParser.parse(CSTParser.ParseState(text), true)
     ps.errored && error("Parsing error for formatted $text")
     return text

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -607,7 +607,11 @@ function p_function(x, s)
             add_node!(t, pretty(x.args[4], s), join_lines = true)
         else
             s.indent += s.indent_size
-            add_node!(t, p_block(x.args[3], s, ignore_single_line = true), max_padding = s.indent_size)
+            add_node!(
+                t,
+                p_block(x.args[3], s, ignore_single_line = true),
+                max_padding = s.indent_size
+            )
             s.indent -= s.indent_size
             add_node!(t, pretty(x.args[4], s))
         end
@@ -631,7 +635,11 @@ function p_struct(x, s)
         add_node!(t, pretty(x.args[4], s), join_lines = true)
     else
         s.indent += s.indent_size
-        add_node!(t, p_block(x.args[3], s, ignore_single_line = true), max_padding = s.indent_size)
+        add_node!(
+            t,
+            p_block(x.args[3], s, ignore_single_line = true),
+            max_padding = s.indent_size
+        )
         s.indent -= s.indent_size
         add_node!(t, pretty(x.args[4], s))
     end
@@ -651,7 +659,11 @@ function p_mutable(x, s)
         add_node!(t, pretty(x.args[5], s), join_lines = true)
     else
         s.indent += s.indent_size
-        add_node!(t, p_block(x.args[4], s, ignore_single_line = true), max_padding = s.indent_size)
+        add_node!(
+            t,
+            p_block(x.args[4], s, ignore_single_line = true),
+            max_padding = s.indent_size
+        )
         s.indent -= s.indent_size
         add_node!(t, pretty(x.args[5], s))
     end

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -816,37 +816,52 @@ end
 # If
 function p_if(x, s)
     t = PTree(x, nspaces(s))
-    add_node!(t, pretty(x.args[1], s))
     if x.args[1].typ === CSTParser.KEYWORD && x.args[1].kind === Tokens.IF
+        add_node!(t, pretty(x.args[1], s))
         add_node!(t, Whitespace(1))
         add_node!(t, pretty(x.args[2], s), join_lines = true)
         s.indent += s.indent_size
         add_node!(t, p_block(x.args[3], s, ignore_single_line = true), max_padding= s.indent_size)
         s.indent -= s.indent_size
-        add_node!(t, pretty(x.args[4], s))
+
+        len = length(t)
         if length(x.args) > 4
+            add_node!(t, pretty(x.args[4], s), max_padding = 0)
             if x.args[4].kind === Tokens.ELSEIF
                 add_node!(t, Whitespace(1))
-                add_node!(t, pretty(x.args[5], s), join_lines = true)
+                n = pretty(x.args[5], s)
+                add_node!(t, n, join_lines = true)
+                # "elseif n"
+                t.len = max(len, length(n))
             else
+                # ELSE KEYWORD
                 s.indent += s.indent_size
                 add_node!(t, p_block(x.args[5], s, ignore_single_line = true), max_padding = s.indent_size)
                 s.indent -= s.indent_size
             end
-            # END KEYWORD
-            add_node!(t, pretty(x.args[6], s))
         end
+        # END KEYWORD
+        add_node!(t, pretty(x.args[end], s))
     else
+        # "cond" part of "elseif cond"
+        t.len += 7
+        add_node!(t, pretty(x.args[1], s))
+
         s.indent += s.indent_size
         add_node!(t, p_block(x.args[2], s, ignore_single_line = true), max_padding = s.indent_size)
         s.indent -= s.indent_size
-        if length(x.args) > 2
-            add_node!(t, pretty(x.args[3], s))
 
-            # this either else or elseif
+        len = length(t)
+        if length(x.args) > 2
+            # this either else or elseif keyword
+            add_node!(t, pretty(x.args[3], s), max_padding = 0)
+
             if x.args[3].kind === Tokens.ELSEIF
                 add_node!(t, Whitespace(1))
-                add_node!(t, pretty(x.args[4], s), join_lines = true)
+                n = pretty(x.args[4], s)
+                add_node!(t, n, join_lines = true)
+                # "elseif n"
+                t.len = max(len, length(n))
             else
                 s.indent += s.indent_size
                 add_node!(t, p_block(x.args[4], s, ignore_single_line = true), max_padding = s.indent_size)

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -50,7 +50,7 @@ end
 
 
 
-function add_node!(t::PTree, n::PTree; join_lines = false, max_padding=-1)
+function add_node!(t::PTree, n::PTree; join_lines = false, max_padding = -1)
     if n.typ isa PLeaf
         t.len += length(n)
         # Don't want to alter the startline/endline of these types
@@ -101,7 +101,7 @@ function add_node!(t::PTree, n::PTree; join_lines = false, max_padding=-1)
 
     if !join_lines && is_end(n)
         # end keyword isn't useful w.r.t margin lengths
-    elseif t.typ === CSTParser.StringH 
+    elseif t.typ === CSTParser.StringH
         # The length of this node is the length of
         # the longest string
         t.len = max(t.len, length(n))
@@ -697,7 +697,11 @@ function p_begin(x, s)
         add_node!(t, pretty(x.args[3], s), join_lines = true)
     else
         s.indent += s.indent_size
-        add_node!(t, p_block(x.args[2], s, ignore_single_line = true), max_padding= s.indent_size)
+        add_node!(
+            t,
+            p_block(x.args[2], s, ignore_single_line = true),
+            max_padding = s.indent_size
+        )
         s.indent -= s.indent_size
         add_node!(t, pretty(x.args[3], s))
     end
@@ -715,7 +719,11 @@ function p_quote(x, s)
             add_node!(t, pretty(x.args[3], s), join_lines = true)
         else
             s.indent += s.indent_size
-            add_node!(t, p_block(x.args[2], s, ignore_single_line = true), max_padding = s.indent_size)
+            add_node!(
+                t,
+                p_block(x.args[2], s, ignore_single_line = true),
+                max_padding = s.indent_size
+            )
             s.indent -= s.indent_size
             add_node!(t, pretty(x.args[3], s))
         end
@@ -746,7 +754,11 @@ function p_let(x, s)
         add_node!(t, Whitespace(1))
         add_node!(t, pretty(x.args[2], s), join_lines = true)
         s.indent += s.indent_size
-        add_node!(t, p_block(x.args[3], s, ignore_single_line = true), max_padding= s.indent_size)
+        add_node!(
+            t,
+            p_block(x.args[3], s, ignore_single_line = true),
+            max_padding = s.indent_size
+        )
         s.indent -= s.indent_size
         add_node!(t, pretty(x.args[end], s))
     else
@@ -765,7 +777,11 @@ function p_loop(x, s)
     add_node!(t, Whitespace(1))
     add_node!(t, pretty(x.args[2], s), join_lines = true)
     s.indent += s.indent_size
-    add_node!(t, p_block(x.args[3], s, ignore_single_line = true), max_padding = s.indent_size)
+    add_node!(
+        t,
+        p_block(x.args[3], s, ignore_single_line = true),
+        max_padding = s.indent_size
+    )
     s.indent -= s.indent_size
     add_node!(t, pretty(x.args[4], s))
     t
@@ -783,7 +799,11 @@ function p_do(x, s)
     end
     if x.args[4].typ === CSTParser.Block
         s.indent += s.indent_size
-        add_node!(t, p_block(x.args[4], s, ignore_single_line = true), max_padding= s.indent_size)
+        add_node!(
+            t,
+            p_block(x.args[4], s, ignore_single_line = true),
+            max_padding = s.indent_size
+        )
         s.indent -= s.indent_size
     end
     add_node!(t, pretty(x.args[end], s))
@@ -799,7 +819,11 @@ function p_try(x, s)
             add_node!(t, pretty(a, s), max_padding = 0)
         elseif a.typ === CSTParser.Block
             s.indent += s.indent_size
-            add_node!(t, p_block(a, s, ignore_single_line = true), max_padding = s.indent_size)
+            add_node!(
+                t,
+                p_block(a, s, ignore_single_line = true),
+                max_padding = s.indent_size
+            )
             s.indent -= s.indent_size
         else
             len = length(t)
@@ -821,7 +845,11 @@ function p_if(x, s)
         add_node!(t, Whitespace(1))
         add_node!(t, pretty(x.args[2], s), join_lines = true)
         s.indent += s.indent_size
-        add_node!(t, p_block(x.args[3], s, ignore_single_line = true), max_padding= s.indent_size)
+        add_node!(
+            t,
+            p_block(x.args[3], s, ignore_single_line = true),
+            max_padding = s.indent_size
+        )
         s.indent -= s.indent_size
 
         len = length(t)
@@ -836,7 +864,11 @@ function p_if(x, s)
             else
                 # ELSE KEYWORD
                 s.indent += s.indent_size
-                add_node!(t, p_block(x.args[5], s, ignore_single_line = true), max_padding = s.indent_size)
+                add_node!(
+                    t,
+                    p_block(x.args[5], s, ignore_single_line = true),
+                    max_padding = s.indent_size
+                )
                 s.indent -= s.indent_size
             end
         end
@@ -848,7 +880,11 @@ function p_if(x, s)
         add_node!(t, pretty(x.args[1], s))
 
         s.indent += s.indent_size
-        add_node!(t, p_block(x.args[2], s, ignore_single_line = true), max_padding = s.indent_size)
+        add_node!(
+            t,
+            p_block(x.args[2], s, ignore_single_line = true),
+            max_padding = s.indent_size
+        )
         s.indent -= s.indent_size
 
         len = length(t)
@@ -864,7 +900,11 @@ function p_if(x, s)
                 t.len = max(len, length(n))
             else
                 s.indent += s.indent_size
-                add_node!(t, p_block(x.args[4], s, ignore_single_line = true), max_padding = s.indent_size)
+                add_node!(
+                    t,
+                    p_block(x.args[4], s, ignore_single_line = true),
+                    max_padding = s.indent_size
+                )
                 s.indent -= s.indent_size
             end
         end
@@ -1366,3 +1406,4 @@ function p_comprehension(x, s)
     end
     t
 end
+

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -33,6 +33,7 @@ is_leaf(x::PTree) = x.nodes === nothing
 empty_start(x::PTree) = x.startline == 1 && x.endline == 1 && x.val == ""
 
 is_punc(x) = CSTParser.ispunctuation(x)
+is_end(x) = x.typ === CSTParser.KEYWORD && x.val == "end"
 
 function parent_is(x, typs...)
     p = x.parent
@@ -49,15 +50,15 @@ end
 
 
 
-function add_node!(t::PTree, n; join_lines = false)
+function add_node!(t::PTree, n::PTree; join_lines = false, max_padding=-1)
     if n.typ isa PLeaf
-        push!(t.nodes, n)
         t.len += length(n)
         # Don't want to alter the startline/endline of these types
         if n.typ !== NOTCODE && n.typ !== INLINECOMMENT
             n.startline = t.startline
             n.endline = t.endline
         end
+        push!(t.nodes, n)
         return
     end
 
@@ -97,10 +98,15 @@ function add_node!(t::PTree, n; join_lines = false)
     if n.endline > t.endline || t.endline == -1
         t.endline = n.endline
     end
-    if t.typ === CSTParser.StringH
+
+    if !join_lines && is_end(n)
+        # end keyword isn't useful w.r.t margin lengths
+    elseif t.typ === CSTParser.StringH 
         # The length of this node is the length of
         # the longest string
         t.len = max(t.len, length(n))
+    elseif max_padding > -1
+        t.len = max(t.len, length(n) + max_padding)
     else
         t.len += length(n)
     end
@@ -519,6 +525,7 @@ function p_macrocall(x, s)
 end
 
 # Block
+# length Block is the length of the longest expr
 function p_block(x, s; ignore_single_line = false, from_quote = false)
     t = PTree(x, nspaces(s))
     single_line = ignore_single_line ? false :
@@ -534,7 +541,7 @@ function p_block(x, s; ignore_single_line = false, from_quote = false)
                 add_node!(t, n, join_lines = true)
             else
                 add_node!(t, Semicolon())
-                add_node!(t, n)
+                add_node!(t, n, max_padding = 0)
             end
         elseif single_line
             if i == 1 || CSTParser.is_comma(a)
@@ -553,10 +560,11 @@ function p_block(x, s; ignore_single_line = false, from_quote = false)
             elseif CSTParser.is_comma(a) && i != length(x)
                 add_node!(t, n, join_lines = true)
             else
-                add_node!(t, n)
+                add_node!(t, n, max_padding = 0)
             end
         end
     end
+    @info "" t.typ length(t)
     t
 end
 
@@ -651,57 +659,6 @@ function p_mutable(x, s)
     t
 end
 
-# For/While
-function p_loop(x, s)
-    t = PTree(x, nspaces(s))
-    add_node!(t, pretty(x.args[1], s))
-    add_node!(t, Whitespace(1))
-    add_node!(t, pretty(x.args[2], s), join_lines = true)
-    s.indent += s.indent_size
-    add_node!(t, p_block(x.args[3], s, ignore_single_line = true))
-    s.indent -= s.indent_size
-    add_node!(t, pretty(x.args[4], s))
-    t
-end
-
-# Do
-function p_do(x, s)
-    t = PTree(x, nspaces(s))
-    add_node!(t, pretty(x.args[1], s))
-    add_node!(t, Whitespace(1))
-    add_node!(t, pretty(x.args[2], s), join_lines = true)
-    if x.args[3].fullspan != 0
-        add_node!(t, Whitespace(1))
-        add_node!(t, pretty(x.args[3], s), join_lines = true)
-    end
-    if x.args[4].typ === CSTParser.Block
-        s.indent += s.indent_size
-        add_node!(t, p_block(x.args[4], s, ignore_single_line = true))
-        s.indent -= s.indent_size
-    end
-    add_node!(t, pretty(x.args[end], s))
-    t
-end
-
-# Try
-function p_try(x, s)
-    t = PTree(x, nspaces(s))
-    for (i, a) in enumerate(x)
-        if a.fullspan == 0
-        elseif a.typ === CSTParser.KEYWORD
-            add_node!(t, pretty(a, s))
-        elseif a.typ === CSTParser.Block
-            s.indent += s.indent_size
-            add_node!(t, p_block(a, s, ignore_single_line = true))
-            s.indent -= s.indent_size
-        else
-            add_node!(t, Whitespace(1))
-            add_node!(t, pretty(a, s), join_lines = true)
-        end
-    end
-    t
-end
-
 # ModuleH/BareModule
 function p_module(x, s)
     t = PTree(x, nspaces(s))
@@ -740,10 +697,11 @@ function p_begin(x, s)
         add_node!(t, pretty(x.args[3], s), join_lines = true)
     else
         s.indent += s.indent_size
-        add_node!(t, p_block(x.args[2], s, ignore_single_line = true))
+        add_node!(t, p_block(x.args[2], s, ignore_single_line = true), max_padding= s.indent_size)
         s.indent -= s.indent_size
         add_node!(t, pretty(x.args[3], s))
     end
+    # t.len = length(t.nodes[1])
     t
 end
 
@@ -757,10 +715,11 @@ function p_quote(x, s)
             add_node!(t, pretty(x.args[3], s), join_lines = true)
         else
             s.indent += s.indent_size
-            add_node!(t, p_block(x.args[2], s, ignore_single_line = true))
+            add_node!(t, p_block(x.args[2], s, ignore_single_line = true), max_padding = s.indent_size)
             s.indent -= s.indent_size
             add_node!(t, pretty(x.args[3], s))
         end
+        # t.len = length(t.nodes[1])
     else
         for a in x.args
             add_node!(t, pretty(a, s), join_lines = true)
@@ -770,6 +729,16 @@ function p_quote(x, s)
 end
 
 # Let
+#
+# two forms:
+#
+# let var1 = value1, var2
+#     body
+# end
+#
+# y, back = let
+#     body
+# end
 function p_let(x, s)
     t = PTree(x, nspaces(s))
     add_node!(t, pretty(x.args[1], s))
@@ -777,14 +746,70 @@ function p_let(x, s)
         add_node!(t, Whitespace(1))
         add_node!(t, pretty(x.args[2], s), join_lines = true)
         s.indent += s.indent_size
-        add_node!(t, p_block(x.args[3], s, ignore_single_line = true))
+        add_node!(t, p_block(x.args[3], s, ignore_single_line = true), max_padding= s.indent_size)
         s.indent -= s.indent_size
+        add_node!(t, pretty(x.args[end], s))
     else
         s.indent += s.indent_size
         add_node!(t, p_block(x.args[2], s, ignore_single_line = true))
         s.indent -= s.indent_size
+        add_node!(t, pretty(x.args[end], s))
+    end
+    t
+end
+
+# For/While
+function p_loop(x, s)
+    t = PTree(x, nspaces(s))
+    add_node!(t, pretty(x.args[1], s))
+    add_node!(t, Whitespace(1))
+    add_node!(t, pretty(x.args[2], s), join_lines = true)
+    s.indent += s.indent_size
+    add_node!(t, p_block(x.args[3], s, ignore_single_line = true), max_padding = s.indent_size)
+    s.indent -= s.indent_size
+    add_node!(t, pretty(x.args[4], s))
+    t
+end
+
+# Do
+function p_do(x, s)
+    t = PTree(x, nspaces(s))
+    add_node!(t, pretty(x.args[1], s))
+    add_node!(t, Whitespace(1))
+    add_node!(t, pretty(x.args[2], s), join_lines = true)
+    if x.args[3].fullspan != 0
+        add_node!(t, Whitespace(1))
+        add_node!(t, pretty(x.args[3], s), join_lines = true)
+    end
+    if x.args[4].typ === CSTParser.Block
+        s.indent += s.indent_size
+        add_node!(t, p_block(x.args[4], s, ignore_single_line = true), max_padding= s.indent_size)
+        s.indent -= s.indent_size
     end
     add_node!(t, pretty(x.args[end], s))
+    t
+end
+
+# Try
+function p_try(x, s)
+    t = PTree(x, nspaces(s))
+    for a in x.args
+        if a.fullspan == 0
+        elseif a.typ === CSTParser.KEYWORD
+            add_node!(t, pretty(a, s), max_padding = 0)
+        elseif a.typ === CSTParser.Block
+            s.indent += s.indent_size
+            add_node!(t, p_block(a, s, ignore_single_line = true), max_padding = s.indent_size)
+            s.indent -= s.indent_size
+        else
+            len = length(t)
+            add_node!(t, Whitespace(1))
+            n = pretty(a, s)
+            # "catch n"
+            t.len = max(len, 5 + 1 + length(n))
+            add_node!(t, n, join_lines = true, max_padding = 0)
+        end
+    end
     t
 end
 
@@ -796,7 +821,7 @@ function p_if(x, s)
         add_node!(t, Whitespace(1))
         add_node!(t, pretty(x.args[2], s), join_lines = true)
         s.indent += s.indent_size
-        add_node!(t, p_block(x.args[3], s, ignore_single_line = true))
+        add_node!(t, p_block(x.args[3], s, ignore_single_line = true), max_padding= s.indent_size)
         s.indent -= s.indent_size
         add_node!(t, pretty(x.args[4], s))
         if length(x.args) > 4
@@ -805,7 +830,7 @@ function p_if(x, s)
                 add_node!(t, pretty(x.args[5], s), join_lines = true)
             else
                 s.indent += s.indent_size
-                add_node!(t, p_block(x.args[5], s, ignore_single_line = true))
+                add_node!(t, p_block(x.args[5], s, ignore_single_line = true), max_padding = s.indent_size)
                 s.indent -= s.indent_size
             end
             # END KEYWORD
@@ -813,7 +838,7 @@ function p_if(x, s)
         end
     else
         s.indent += s.indent_size
-        add_node!(t, p_block(x.args[2], s, ignore_single_line = true))
+        add_node!(t, p_block(x.args[2], s, ignore_single_line = true), max_padding = s.indent_size)
         s.indent -= s.indent_size
         if length(x.args) > 2
             add_node!(t, pretty(x.args[3], s))
@@ -824,7 +849,7 @@ function p_if(x, s)
                 add_node!(t, pretty(x.args[4], s), join_lines = true)
             else
                 s.indent += s.indent_size
-                add_node!(t, p_block(x.args[4], s, ignore_single_line = true))
+                add_node!(t, p_block(x.args[4], s, ignore_single_line = true), max_padding = s.indent_size)
                 s.indent -= s.indent_size
             end
         end
@@ -868,19 +893,19 @@ function p_kw(x, s)
     t
 end
 
-_nest_arg2(arg2::CSTParser.EXPR) =
-    arg2.typ === CSTParser.If ||
-    arg2.typ === CSTParser.Do ||
-    arg2.typ === CSTParser.Begin ||
-    arg2.typ === CSTParser.Quote ||
-    arg2.typ === CSTParser.Try ||
-    arg2.typ === CSTParser.For || arg2.typ === CSTParser.While || arg2.typ === CSTParser.Let
+block_type(x::CSTParser.EXPR) =
+    x.typ === CSTParser.If ||
+    x.typ === CSTParser.Do ||
+    x.typ === CSTParser.Begin ||
+    x.typ === CSTParser.Quote ||
+    x.typ === CSTParser.Try ||
+    x.typ === CSTParser.For || x.typ === CSTParser.While || x.typ === CSTParser.Let
 
-nest_assignment(x::CSTParser.EXPR) = CSTParser.is_assignment(x) && _nest_arg2(x.args[3])
+nest_assignment(x::CSTParser.EXPR) = CSTParser.is_assignment(x) && block_type(x.args[3])
 
 function nestable(x::CSTParser.EXPR)
     CSTParser.defines_function(x) && (return true)
-    CSTParser.is_assignment(x) && (return _nest_arg2(x.args[3]))
+    CSTParser.is_assignment(x) && (return block_type(x.args[3]))
 
     op = x.args[2]
     op.kind === Tokens.ANON_FUNC && (return false)
@@ -915,7 +940,7 @@ function nest_arg2(x::CSTParser.EXPR)
     if CSTParser.defines_function(x)
         arg2 = x.args[3]
         arg2.typ === CSTParser.Block && (arg2 = arg2.args[1])
-        return _nest_arg2(arg2)
+        return block_type(arg2)
     end
     false
 end

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -48,8 +48,6 @@ function parent_is(x, typs...)
     false
 end
 
-
-
 function add_node!(t::PTree, n::PTree; join_lines = false, max_padding = -1)
     if n.typ isa PLeaf
         t.len += length(n)
@@ -105,7 +103,7 @@ function add_node!(t::PTree, n::PTree; join_lines = false, max_padding = -1)
         # The length of this node is the length of
         # the longest string
         t.len = max(t.len, length(n))
-    elseif max_padding > -1
+    elseif max_padding >= 0
         t.len = max(t.len, length(n) + max_padding)
     else
         t.len += length(n)
@@ -269,14 +267,14 @@ function pretty(x::CSTParser.EXPR, s::State)
     end
 
     t = PTree(x, nspaces(s))
-    join_lines = x.typ !== CSTParser.FileH
+    is_fileh = x.typ === CSTParser.FileH
     for a in x
         if a.kind === Tokens.NOTHING
             s.offset += a.fullspan
             continue
         end
         # @debug "" a a.typ
-        add_node!(t, pretty(a, s), join_lines = join_lines, max_padding = 0)
+        add_node!(t, pretty(a, s), join_lines = !is_fileh, max_padding = is_fileh ? 0 : -1)
     end
     t
 end
@@ -564,7 +562,7 @@ function p_block(x, s; ignore_single_line = false, from_quote = false)
             end
         end
     end
-    @info "" t.typ length(t)
+    # @info "" t.typ length(t)
     t
 end
 

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -276,7 +276,7 @@ function pretty(x::CSTParser.EXPR, s::State)
             continue
         end
         # @debug "" a a.typ
-        add_node!(t, pretty(a, s), join_lines = join_lines)
+        add_node!(t, pretty(a, s), join_lines = join_lines, max_padding = 0)
     end
     t
 end

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -468,7 +468,7 @@ function p_macrocall(x, s)
             )
         )
         if x.args[2].typ === CSTParser.LITERAL
-            add_node!(t, p_literal(x.args[2], s, include_quotes = false))
+            add_node!(t, p_literal(x.args[2], s, include_quotes = false), max_padding = 0)
         elseif x.args[2].typ == CSTParser.StringH
             add_node!(t, p_stringh(x.args[2], s, include_quotes = false))
         end
@@ -484,9 +484,10 @@ function p_macrocall(x, s)
                 "\"\"\"",
                 nothing,
                 nothing
-            )
+            ),
+            max_padding = 0
         )
-        add_node!(t, pretty(x.args[3], s))
+        add_node!(t, pretty(x.args[3], s), max_padding = 0)
         return t
     end
 
@@ -606,7 +607,7 @@ function p_function(x, s)
             add_node!(t, pretty(x.args[4], s), join_lines = true)
         else
             s.indent += s.indent_size
-            add_node!(t, p_block(x.args[3], s, ignore_single_line = true))
+            add_node!(t, p_block(x.args[3], s, ignore_single_line = true), max_padding = s.indent_size)
             s.indent -= s.indent_size
             add_node!(t, pretty(x.args[4], s))
         end
@@ -630,7 +631,7 @@ function p_struct(x, s)
         add_node!(t, pretty(x.args[4], s), join_lines = true)
     else
         s.indent += s.indent_size
-        add_node!(t, p_block(x.args[3], s, ignore_single_line = true))
+        add_node!(t, p_block(x.args[3], s, ignore_single_line = true), max_padding = s.indent_size)
         s.indent -= s.indent_size
         add_node!(t, pretty(x.args[4], s))
     end
@@ -650,7 +651,7 @@ function p_mutable(x, s)
         add_node!(t, pretty(x.args[5], s), join_lines = true)
     else
         s.indent += s.indent_size
-        add_node!(t, p_block(x.args[4], s, ignore_single_line = true))
+        add_node!(t, p_block(x.args[4], s, ignore_single_line = true), max_padding = s.indent_size)
         s.indent -= s.indent_size
         add_node!(t, pretty(x.args[5], s))
     end
@@ -667,7 +668,7 @@ function p_module(x, s)
         add_node!(t, Whitespace(1))
         add_node!(t, pretty(x.args[4], s), join_lines = true)
     else
-        add_node!(t, pretty(x.args[3], s))
+        add_node!(t, pretty(x.args[3], s), max_padding = 0)
         add_node!(t, pretty(x.args[4], s))
     end
     t
@@ -946,6 +947,7 @@ function p_kw(x, s)
     t
 end
 
+# TODO: think of a better name?
 block_type(x::CSTParser.EXPR) =
     x.typ === CSTParser.If ||
     x.typ === CSTParser.Do ||
@@ -987,7 +989,6 @@ function nestable(x::CSTParser.EXPR)
     end
     true
 end
-
 
 function nest_arg2(x::CSTParser.EXPR)
     if CSTParser.defines_function(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1661,7 +1661,7 @@ end
                 body3
             end
         )"""
-        @test fmt(str_, 4, 50) == str
+        @test fmt(str_, 4, 20) == str
 
 
         str = "export @esc, isexpr, isline, iscall, rmlines, unblock, block, inexpr, namify, isdef"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,12 +60,16 @@ end
             a::A
         end"""
         @test fmt(str) == str
+        t = run_pretty(str, 80)
+        @test length(t) == 55
 
         str = """
         struct Foo{A<:Bar,Union{B<:Fizz,C<:Buzz},<:Any}
             a::A
         end"""
         @test fmt(str) == str
+        t = run_pretty(str, 80)
+        @test length(t) == 47
     end
 
     @testset "where op" begin
@@ -778,6 +782,8 @@ end
         function f()
             20
         end"""
+        t = run_pretty(str, 80)
+        @test length(t) == 12
 
         @test fmt("""
         \"""doc
@@ -831,6 +837,8 @@ end
                  \"""
                  Foo"""
         @test fmt("\"\"\"doc for Foo\"\"\"\nFoo") == str
+        t = run_pretty(str, 80)
+        @test length(t) == 11
 
         str = """
         \"""
@@ -959,6 +967,8 @@ end
 
         end"""
         @test fmt(str) == str
+        t = run_pretty(str, 80)
+        @test length(t) == 14
 
         str_ = """
         module Foo
@@ -1044,17 +1054,23 @@ end
         @test fmt("""
             function  foo
             end""") == str
+        t = run_pretty(str, 80)
+        @test length(t) == 16
 
         str = """function foo() end"""
         @test fmt("""
                      function  foo()
             end""") == str
+        t = run_pretty(str, 80)
+        @test length(t) == 18
 
         str = """function foo()
                      10
                      20
                  end"""
         @test fmt("""function foo() 10;  20 end""") == str
+        t = run_pretty(str, 80)
+        @test length(t) == 14
 
         str = """abstract type AbstractFoo end"""
         @test fmt("""abstract type
@@ -1232,14 +1248,32 @@ end
         @test fmt("mutable struct Foo\n    body  end") == str
 
         str = """
-        module Foo
-        body
+        module A
+        bodybody
         end"""
-        @test fmt("module Foo\n    body  end") == str
+        @test fmt("module A\n    bodybody  end") == str
+        t = run_pretty(str, 80)
+        @test length(t) == 8
 
         str = """
         module Foo end"""
         @test fmt("module Foo\n    end") == str
+        t = run_pretty(str, 80)
+        @test length(t) == 14
+
+        str = """
+        baremodule A
+        bodybody
+        end"""
+        @test fmt("baremodule A\n    bodybody  end") == str
+        t = run_pretty(str, 80)
+        @test length(t) == 12
+
+        str = """
+        baremodule Foo end"""
+        @test fmt("baremodule Foo\n    end") == str
+        t = run_pretty(str, 80)
+        @test length(t) == 18
 
         str = """
         if cond1
@@ -1430,11 +1464,17 @@ end
         @test fmt("foo() = (one, x -> (true, false))", 4, 20) == str
 
         str = """
+        @somemacro function (fcall_ | fcall_)
+            body_
+        end"""
+        @test fmt("@somemacro function (fcall_ | fcall_) body_ end", 4, 37) == str
+
+        str = """
         @somemacro function (fcall_ |
                              fcall_)
             body_
         end"""
-        @test fmt("@somemacro function (fcall_ | fcall_) body_ end", 4, 1) == str
+        @test fmt("@somemacro function (fcall_ | fcall_) body_ end", 4, 36) == str
 
         str = "Val(x) = (@_pure_meta; Val{x}())"
         @test fmt("Val(x) = (@_pure_meta ; Val{x}())", 4, 80) == str


### PR DESCRIPTION
Some nodes, i.e.:

```julia
CSTParser.If
CSTParser.Do
CSTParser.Begin
CSTParser.Quote
CSTParser.Try
CSTParser.For
CSTParser.While
CSTParser.Let
...
```

previously `length(node)` would return the accumulated length of all the statements in the body plus the surrounded keywords.

Example:

```
begin
    a = foo(100)
end
```

The length of this `Begin` node would be 20. With PR the length is node the longest line (`a = foo(100)`) + indentation (4 spaces in this case), which is 16.

In light of #30 it's more important the length of these nodes is accurate.

TODO

- [x] `CSTParser.FunctionDef`
- [x] `CSTParser.Macro`
- [x] `CSTParser.Struct`
- [x] `CSTParser.Mutable`
- [x] `CSTParser.Module`
- [x] `CSTParser.BareModule`