### PR TITLE
display help when command line script is invoked without parameters

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,5 +1,11 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[ArgParse]]
+deps = ["Compat", "Test", "TextWrap"]
+git-tree-sha1 = "14d5789a99e6bea3e258d668ec09359a9feaf2d1"
+uuid = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+version = "0.6.2"
+
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
@@ -11,6 +17,20 @@ repo-url = "https://github.com/julia-vscode/CSTParser.jl.git"
 uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
 version = "0.6.2-DEV"
 
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "84aa74986c5b9b898b0d1acaf3258741ee64754f"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "2.1.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
 [[Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
@@ -19,6 +39,16 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
@@ -26,21 +56,64 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
 [[Random]]
 deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[[TextWrap]]
+deps = ["Compat", "Test"]
+git-tree-sha1 = "8355cc559e85469cd4dbe927c375f61d3750e002"
+uuid = "b718987f-49a8-5099-9789-dcd902bef87d"
+version = "0.3.0"
+
 [[Tokenize]]
 git-tree-sha1 = "c8a8b00ae44a94950814ff77850470711a360225"
 uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
 version = "0.5.5"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Dominique Luna <dluna132@gmail.com>"]
 version = "0.1.5"
 
 [deps]
+ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tokenize = "0796e94c-ce3b-5d07-9a54-7f471281c624"

--- a/bin/format.jl
+++ b/bin/format.jl
@@ -1,33 +1,9 @@
 #!/usr/bin/env julia
 
-using JuliaFormatter
+using JuliaFormatter: parse_commandline, format
 
-function parse_opts!(args::Vector{String})
-    i = 1
-    opts = Dict{Symbol,Int}()
-    while i ≤ length(args)
-        arg = args[i]
-        if arg[1] != '-'
-            i += 1; continue
-        end
-        if arg == "-i" || arg == "--indent"
-            opt = :indent
-        elseif arg == "-m" || arg == "--margin"
-            opt = :margin
-        else
-            error("invalid option $arg")
-        end
-        i < length(args) ||
-            error("option $arg requires and argument")
-        val = tryparse(Int, args[i + 1])
-        val != nothing ||
-            error("invalid value for option $arg: $(args[i+1])")
-        opts[opt] = val
-        deleteat!(args, i:i+1)
-    end
-    return opts
-end
+opts = parse_commandline()
+file = opts[:path]
+delete!(opts, :path)
+format(file; opts...)
 
-opts = parse_opts!(ARGS)
-isempty(ARGS) && push!(ARGS, ".")
-format(ARGS; opts...)

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -103,6 +103,7 @@ end
 include("pretty.jl")
 include("nest.jl")
 include("print.jl")
+include("commandline.jl")
 
 """
     format_text(

--- a/src/commandline.jl
+++ b/src/commandline.jl
@@ -1,0 +1,21 @@
+using ArgParse
+
+function parse_commandline()
+    s = ArgParseSettings()
+
+    @add_arg_table s begin
+        "--margin", "-m"
+            help = "the maximum number of characters of code on a single line"
+            arg_type = Int
+            default = 92
+        "--indent", "-i"
+            help = "the number of spaces used for an indentation"
+            arg_type = Int
+            default = 4
+        "path"
+            help = "the path of a file to be formatted or the path of the directory to recursively format every .jl file in"
+            required = true
+    end
+
+    return parse_args(s, as_symbols=true)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2203,4 +2203,6 @@ end
 #
 # end
 
+include("testformatscript.jl")
+
 end

--- a/test/testformatscript.jl
+++ b/test/testformatscript.jl
@@ -1,0 +1,107 @@
+module TestFormatScript
+using Test
+using JuliaFormatter
+using JuliaFormatter: format_text
+
+@testset "Test format.jl script" begin
+    referencedir = mktempdir()
+    testdir = mktempdir()
+
+    # copy test files to reference and test directory
+    testfiles = ["prettify_demo.jl", "issue_38.jl"]
+    for file in testfiles
+        cp(joinpath("files", file),
+            joinpath(referencedir, file))
+        cp(joinpath("files", file),
+            joinpath(testdir, file))
+    end
+
+    # make sure that reference files where copied
+    for file in testfiles
+        @test isfile(joinpath(referencedir, file))
+        @test isfile(joinpath(testdir, file))
+    end
+
+    # create reference formated files
+    refformatstrings = []
+    for file in testfiles
+        format_file(joinpath(referencedir, file), overwrite=false)
+        path, ext = splitext(file)
+        formatedfile = joinpath(referencedir, "$(path)_fmt$(ext)")
+        @test isfile(formatedfile)
+        push!(refformatstrings, read(formatedfile, String))
+    end
+
+    # make sure the testscript path is valid
+    script = joinpath(@__DIR__, "../bin/format.jl")
+    @test isfile(script)
+
+
+
+    olddir = pwd()
+    try
+        cd(testdir)
+        @test pwd() == testdir
+
+        # make sure that test files exist in test directory
+        for file in testfiles
+            @test isfile(file)
+        end
+        # and nothing more exists in directory
+        @test length(readdir()) == length(testfiles)
+
+        @testset "Execute with no arguments (display help)" begin
+            # test script with no arguments
+            @test_throws Exception run(`$script`)
+
+            # make sure no files where changed or created
+            @test length(readdir()) == length(testfiles)
+            for (i, file) in enumerate(testfiles)
+                reffile = joinpath(referencedir, file)
+                testfile = joinpath(testdir, file)
+                @test (read(reffile, String) == read(testfile, String))
+            end
+        end
+        @testset "Format all files in directory" begin
+            # test script with no arguments
+            @test read(`$script .`, String) == ""
+
+            for (i, file) in enumerate(testfiles)
+                testfile = joinpath(testdir, file)
+                @test (refformatstrings[i] == read(testfile, String))
+            end
+        end
+
+        @testset "Test indent parameter" begin
+            refformat = format_text(refformatstrings[1], indent=8)
+            # make sure indent of 8 differs from normal formating
+            @test refformat != read(testfiles[1], String)
+
+            @test read(`$script $(testfiles[1]) --indent 8`, String) == ""
+            @test refformat == read(testfiles[1], String)
+        end
+
+        @testset "Test margin parameter" begin
+            refformat = format_text(refformatstrings[1], margin=60)
+            # make sure margin of 60 differs from normal formating
+            @test refformat != read(testfiles[1], String)
+
+            @test read(`$script $(testfiles[1]) --margin 60`, String) == ""
+            @test refformat == read(testfiles[1], String)
+        end
+
+        @testset "Test margin and indent parameter" begin
+            refformat = format_text(refformatstrings[1], margin=60, indent=8)
+            # make sure margin of 60 and indent of 8 differs from normal
+            # formating
+            @test refformat != read(testfiles[1], String)
+
+            @test read(`$script $(testfiles[1]) -m 60 -i 8`, String) == ""
+            @test refformat == read(testfiles[1], String)
+        end
+    finally
+        cd(olddir)
+    end
+end
+end
+


### PR DESCRIPTION
This is my take to solve ticket #42 

I used [ArgParse.jl](https://github.com/carlobaldassi/ArgParse.jl) for argument parsing since it also automatically displays help when no or wrong arguments are given.

I had to move the `parse_commandline` method to the module itself ("src/commandline.jl") to make sure that `ArgParse` package is available in the scope when the command line script is executed.

The script changed in the way thath it can only handle one file to format as argument now. I don't know how necessary it is for it to be able to handle multiple files as arguments at once.

I also added some tests for the script.

Let me know if everything looks ok to you.