### PR TITLE
All the comments

### DIFF
--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -89,6 +89,7 @@ State(doc, indent_size, margin) = State(doc, indent_size, 0, 1, 0, margin)
 
 @inline nspaces(s::State) = s.indent
 @inline getline(d::Document, line::Int) = d.text[d.line_to_range[line]]
+@inline hascomment(d::Document, line::Int) = haskey(d.comments, line)
 
 @inline function cursor_loc(s::State, offset::Int)
     for (l, r) in enumerate(s.doc.ranges)
@@ -132,7 +133,7 @@ function format_text(text::AbstractString; indent::Integer = 4, margin::Integer 
 
     s = State(d, indent, margin)
     t = pretty(x, s)
-    add_node!(t, InlineComment(t.endline))
+    hascomment(s.doc, t.endline) && (add_node!(t, InlineComment(t.endline), s))
     nest!(t, s)
 
     io = IOBuffer()
@@ -144,8 +145,8 @@ function format_text(text::AbstractString; indent::Integer = 4, margin::Integer 
     end
 
     if t.endline < length(s.doc.ranges)
-        add_node!(t, Newline())
-        add_node!(t, Notcode(t.endline + 1, length(s.doc.ranges)))
+        add_node!(t, Newline(), s)
+        add_node!(t, Notcode(t.endline + 1, length(s.doc.ranges)), s)
     end
 
     print_tree(io, t, s)

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -359,26 +359,24 @@ function n_chainopcall!(x, s; extra_width = 0)
             end
         end
 
-        if !x.force_nest
-            s.line_offset = line_offset
-            for (i, n) in enumerate(x.nodes)
-                if n.typ === NEWLINE
-                    # +1 for newline to whitespace conversion
-                    l = 1
-                    if i == length(x.nodes) - 1
-                        l += sum(length.(x.nodes[i+1:end])) + extra_width
-                    else
-                        l += sum(length.(x.nodes[i+1:i+3]))
-                    end
-                    # @debug "" s.line_offset l  s.margin
-                    if s.line_offset + l <= s.margin
-                        x.nodes[i] = Whitespace(1)
-                    else
-                        s.line_offset = x.indent
-                    end
+        s.line_offset = line_offset
+        for (i, n) in enumerate(x.nodes)
+            if n.typ === NEWLINE && !is_comment(x.nodes[i+1]) && !is_comment(x.nodes[i-1])
+                # +1 for newline to whitespace conversion
+                width = s.line_offset + 1
+                if i == length(x.nodes) - 1
+                    width += sum(length.(x.nodes[i+1:end])) + extra_width
+                else
+                    width += sum(length.(x.nodes[i+1:i+3]))
                 end
-                s.line_offset += length(x.nodes[i])
+                # @debug "" s.line_offset l  s.margin
+                if width <= s.margin
+                    x.nodes[i] = Whitespace(1)
+                else
+                    s.line_offset = x.indent
+                end
             end
+            s.line_offset += length(x.nodes[i])
         end
 
         s.line_offset = line_offset

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -304,7 +304,7 @@ function n_wherecall!(x, s; extra_width = 0)
                     x.nodes[end].indent = s.line_offset
                 end
                 nest!(n, s)
-            elseif n.typ === PLACEHOLDER && over
+            elseif n.typ === PLACEHOLDER && (over || x.force_nest)
                 x.nodes[i+idx] = Newline()
                 s.line_offset = x.indent
             elseif has_braces

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -132,7 +132,7 @@ end
 function n_import!(x, s; extra_width = 0)
     line_width = s.line_offset + length(x) + extra_width
     idx = findfirst(n -> n.typ === PLACEHOLDER, x.nodes)
-    if idx !== nothing && line_width > s.margin
+    if idx !== nothing && (line_width > s.margin || x.force_nest)
         # -3 due to the placeholder being ahead of a comma
         # and another node
         x.indent = s.line_offset + sum(length.(x.nodes[1:idx-3]))
@@ -158,7 +158,7 @@ function n_tuple!(x, s; extra_width = 0)
     idx = findlast(n -> n.typ === PLACEHOLDER, x.nodes)
     opener = is_opener(x.nodes[1])
     # @info "ENTERING" x.typ s.line_offset length(x) extra_width
-    if idx !== nothing && line_width > s.margin
+    if idx !== nothing && (line_width > s.margin || x.force_nest)
         # @debug "ENTERING" x.indent s.line_offset x.typ
         if opener
             x.nodes[end].indent = x.indent
@@ -222,7 +222,7 @@ function n_call!(x, s; extra_width = 0)
     line_width = s.line_offset + length(x) + extra_width
     idx = findlast(n -> n.typ === PLACEHOLDER, x.nodes)
     # @info "ENTERING" x.typ s.line_offset length(x) extra_width
-    if idx !== nothing && line_width > s.margin
+    if idx !== nothing && (line_width > s.margin || x.force_nest)
         x.nodes[end].indent = x.indent
         line_offset = s.line_offset
 
@@ -265,7 +265,7 @@ n_macrocall!(x, s; extra_width = 0) = n_call!(x, s, extra_width = extra_width)
 function n_wherecall!(x, s; extra_width = 0)
     line_width = s.line_offset + length(x) + extra_width
     # @debug "" s.line_offset x.typ line_width extra_width length(x)
-    if line_width > s.margin
+    if line_width > s.margin || x.force_nest
         line_offset = s.line_offset
         # after "A where "
         idx = findfirst(n -> n.typ === PLACEHOLDER, x.nodes)
@@ -323,7 +323,7 @@ end
 function n_chainopcall!(x, s; extra_width = 0)
     line_width = s.line_offset + length(x) + extra_width
     # @info "ENTERING" x.typ extra_width s.line_offset length(x)
-    if line_width > s.margin
+    if line_width > s.margin || x.force_nest
         line_offset = s.line_offset
         x.indent = s.line_offset
         phs = reverse(findall(n -> n.typ === PLACEHOLDER, x.nodes))
@@ -394,7 +394,7 @@ function n_binarycall!(x, s; extra_width = 0)
     idx = findlast(n -> n.typ === PLACEHOLDER, x.nodes)
     line_width = s.line_offset + length(x) + extra_width
     # @info "ENTERING" x.typ extra_width s.line_offset length(x) idx
-    if idx !== nothing && line_width > s.margin
+    if idx !== nothing && (line_width > s.margin || x.force_nest)
         line_offset = s.line_offset
         x.nodes[idx-1] = Newline()
 

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -25,7 +25,8 @@ Newline() = PTree(NEWLINE, -1, -1, 0, 0, "\n", nothing, nothing, false)
 Semicolon() = PTree(SEMICOLON, -1, -1, 0, 1, ";", nothing, nothing, false)
 Whitespace(n) = PTree(WHITESPACE, -1, -1, 0, n, " "^n, nothing, nothing, false)
 Placeholder(n) = PTree(PLACEHOLDER, -1, -1, 0, n, " "^n, nothing, nothing, false)
-Notcode(startline, endline) = PTree(NOTCODE, startline, endline, 0, 0, "", nothing, nothing, false)
+Notcode(startline, endline) =
+    PTree(NOTCODE, startline, endline, 0, 0, "", nothing, nothing, false)
 InlineComment(line) = PTree(INLINECOMMENT, line, line, 0, 0, "", nothing, nothing, false)
 
 Base.length(x::PTree) = x.len
@@ -107,7 +108,8 @@ function add_node!(t::PTree, n::PTree, s::State; join_lines = false, max_padding
         elseif !join_lines
             hascomment(s.doc, current_line) && add_node!(t, InlineComment(current_line), s)
             add_node!(t, Newline(), s)
-        elseif nt === PLACEHOLDER && current_line != n.startline && hascomment(s.doc, current_line)
+        elseif nt === PLACEHOLDER &&
+               current_line != n.startline && hascomment(s.doc, current_line)
             t.force_nest = true
             add_node!(t, InlineComment(current_line), s)
             idx = length(t.nodes)
@@ -301,7 +303,13 @@ function pretty(x::CSTParser.EXPR, s::State)
             continue
         end
         # @debug "" a a.typ
-        add_node!(t, pretty(a, s), s, join_lines = !is_fileh, max_padding = is_fileh ? 0 : -1)
+        add_node!(
+            t,
+            pretty(a, s),
+            s,
+            join_lines = !is_fileh,
+            max_padding = is_fileh ? 0 : -1
+        )
     end
     t
 end

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -87,8 +87,7 @@ function add_node!(t::PTree, n::PTree; join_lines = false, max_padding = -1)
 
         if notcode_startline <= notcode_endline && n.typ !== CSTParser.LITERAL
             # If there are comments in between node elements
-            # nesting is forced in an effort to preserve
-            # them.
+            # nesting is forced in an effort to preserve them.
             t.force_nest = true
 
             nt = t.nodes[end].typ
@@ -96,9 +95,8 @@ function add_node!(t::PTree, n::PTree; join_lines = false, max_padding = -1)
             if nt !== PLACEHOLDER
                 add_node!(t, Newline())
             elseif nt === PLACEHOLDER
-                # swap PLACEHOLDER (will be newline) with INLINECOMMENT node
+                # swap PLACEHOLDER (will be NEWLINE) with INLINECOMMENT node
                 idx = length(t.nodes)
-                # @info "HERE" nt idx
                 t.nodes[idx-1], t.nodes[idx] = t.nodes[idx], t.nodes[idx-1]
             end
 

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -11,21 +11,22 @@ mutable struct PTree
     val::Union{Nothing,AbstractString}
     nodes::Union{Nothing,Vector{PTree}}
     ref::Union{Nothing,Ref{CSTParser.EXPR}}
+    force_nest::Bool
 end
 
 PTree(x::CSTParser.EXPR, indent::Int) =
-    PTree(x.typ, -1, -1, indent, 0, nothing, PTree[], Ref(x))
+    PTree(x.typ, -1, -1, indent, 0, nothing, PTree[], Ref(x), false)
 
 function PTree(x::CSTParser.EXPR, startline::Int, endline::Int, val::AbstractString)
-    PTree(x.typ, startline, endline, 0, length(val), val, nothing, Ref(x))
+    PTree(x.typ, startline, endline, 0, length(val), val, nothing, Ref(x), false)
 end
 
-Newline() = PTree(NEWLINE, -1, -1, 0, 0, "\n", nothing, nothing)
-Semicolon() = PTree(SEMICOLON, -1, -1, 0, 1, ";", nothing, nothing)
-Whitespace(n) = PTree(WHITESPACE, -1, -1, 0, n, " "^n, nothing, nothing)
-Placeholder(n) = PTree(PLACEHOLDER, -1, -1, 0, n, " "^n, nothing, nothing)
-Notcode(startline, endline) = PTree(NOTCODE, startline, endline, 0, 0, "", nothing, nothing)
-InlineComment(line) = PTree(INLINECOMMENT, line, line, 0, 0, "", nothing, nothing)
+Newline() = PTree(NEWLINE, -1, -1, 0, 0, "\n", nothing, nothing, false)
+Semicolon() = PTree(SEMICOLON, -1, -1, 0, 1, ";", nothing, nothing, false)
+Whitespace(n) = PTree(WHITESPACE, -1, -1, 0, n, " "^n, nothing, nothing, false)
+Placeholder(n) = PTree(PLACEHOLDER, -1, -1, 0, n, " "^n, nothing, nothing, false)
+Notcode(startline, endline) = PTree(NOTCODE, startline, endline, 0, 0, "", nothing, nothing, false)
+InlineComment(line) = PTree(INLINECOMMENT, line, line, 0, 0, "", nothing, nothing, false)
 
 Base.length(x::PTree) = x.len
 
@@ -398,7 +399,7 @@ function p_literal(x, s)
     for (i, l) in enumerate(lines)
         ln = startline + i - 1
         l = i == 1 ? l : l[sidx:end]
-        tt = PTree(CSTParser.LITERAL, ln, ln, sidx, length(l), l, nothing, nothing)
+        tt = PTree(CSTParser.LITERAL, ln, ln, sidx, length(l), l, nothing, nothing, false)
         add_node!(t, tt)
     end
     t
@@ -433,7 +434,7 @@ function p_stringh(x, s)
     for (i, l) in enumerate(lines)
         ln = startline + i - 1
         l = i == 1 ? l : l[sidx:end]
-        tt = PTree(CSTParser.LITERAL, ln, ln, sidx, length(l), l, nothing, nothing)
+        tt = PTree(CSTParser.LITERAL, ln, ln, sidx, length(l), l, nothing, nothing, false)
         add_node!(t, tt)
     end
     t

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -84,13 +84,13 @@ function add_node!(t::PTree, n::PTree; join_lines = false, max_padding = -1)
         current_line = t.nodes[end].endline
         notcode_startline = current_line + 1
         notcode_endline = n.startline - 1
+        nt = t.nodes[end].typ
 
         if notcode_startline <= notcode_endline && n.typ !== CSTParser.LITERAL
             # If there are comments in between node elements
             # nesting is forced in an effort to preserve them.
             t.force_nest = true
 
-            nt = t.nodes[end].typ
             add_node!(t, InlineComment(current_line))
             if nt !== PLACEHOLDER
                 add_node!(t, Newline())
@@ -105,10 +105,11 @@ function add_node!(t::PTree, n::PTree; join_lines = false, max_padding = -1)
         elseif !join_lines
             add_node!(t, InlineComment(current_line))
             add_node!(t, Newline())
+        elseif nt === PLACEHOLDER
+            add_node!(t, InlineComment(current_line))
+            idx = length(t.nodes)
+            t.nodes[idx-1], t.nodes[idx] = t.nodes[idx], t.nodes[idx-1]
         end
-
-        # forces newline
-        # add_node!(t, Newline())
     end
 
     if n.startline < t.startline || t.startline == -1

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -37,6 +37,7 @@ empty_start(x::PTree) = x.startline == 1 && x.endline == 1 && x.val == ""
 is_punc(x) = CSTParser.ispunctuation(x)
 is_end(x) = x.typ === CSTParser.KEYWORD && x.val == "end"
 is_colon(x::PTree) = x.typ === CSTParser.OPERATOR && x.val == ":"
+is_comment(x::PTree) = x.typ === INLINECOMMENT || x.typ === NOTCODE
 
 is_colon_op(x) =
     (x.typ === CSTParser.BinaryOpCall && x.args[2].kind === Tokens.COLON) ||

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1160,6 +1160,88 @@ end
             # single comment ending in a subscriptₙ
             x- y
         end""") == str
+
+        str_ = """
+        var = foo(      # eat
+            a, b, # comment 1
+            c, # comment 2
+            # in between comment
+            d # comment 3
+        )        # pancakes"""
+        str = """
+        var = foo(      # eat
+            a,
+            b, # comment 1
+            c, # comment 2
+            # in between comment
+            d # comment 3
+        )        # pancakes"""
+        @test fmt(str_) == str
+
+        str_ = """
+        var = foo(      # eat
+            a, b, # comment 1
+            c, # comment 2
+            d # comment 3
+        )        # pancakes"""
+        str = """
+        var = foo(      # eat
+            a,
+            b, # comment 1
+            c, # comment 2
+            d # comment 3
+        )        # pancakes"""
+        @test fmt(str_) == str
+
+        str = """
+        A ? # foo
+        # comment 1
+
+        B :    # bar
+        # comment 2
+        C"""
+        @test fmt(str) == str
+
+        str_ = """
+        A ? # foo
+        # comment 1
+
+        B : C"""
+        str = """
+        A ? # foo
+        # comment 1
+
+        B :
+        C"""
+        @test fmt(str_) == str
+
+        str = """
+        begin
+            var = a +
+                # comment
+                  b
+        end
+        """
+        @test fmt(str) == str
+
+        str = """
+        begin
+            var = a +  # inline
+            # comment
+
+                  b
+        end
+        """
+        @test fmt(str) == str
+
+        str = """
+        begin
+            var = a +  # inline
+                  b
+        end
+        """
+        @test fmt(str) == str
+
     end
 
     @testset "pretty" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1202,18 +1202,19 @@ end
         C"""
         @test fmt(str) == str
 
-        str_ = """
-        A ? # foo
-        # comment 1
+        str = """
+        A ? B :
+         # comment
 
-        B : C"""
+        C"""
+        @test fmt(str) == str
+
         str = """
         A ? # foo
         # comment 1
 
-        B :
-        C"""
-        @test fmt(str_) == str
+        B : C"""
+        @test fmt(str) == str
 
         str = """
         begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1243,6 +1243,30 @@ end
         """
         @test fmt(str) == str
 
+        str = """
+        foo() = 10 where {
+            A,
+                # comment
+            B
+        }"""
+        @test fmt(str) == str
+
+        str = """
+        foo() = 10 where Foo{
+            A,
+                # comment
+            B
+        }"""
+        @test fmt(str) == str
+
+        str = """
+        foo() = Foo(
+            A,
+                # comment
+            B
+        )"""
+        @test fmt(str) == str
+
     end
 
     @testset "pretty" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,9 +32,9 @@ end
 @testset "All" begin
 
     @testset "basic" begin
+        @test fmt("") == ""
         @test fmt("a") == "a"
         @test fmt("a  #foo") == "a  #foo"
-        @test fmt("") == ""
     end
 
     @testset "nofmt" begin
@@ -1553,6 +1553,7 @@ end
         e4"""
         @test fmt("cond1 ? e1 : cond2 ? e2 : cond3 ? e3 : e4", 4, 13) == str
 
+        # I'm an importer/exporter
         str = """
         export a,
                b"""


### PR DESCRIPTION
Prints all the comments, solves #28.

Essentially if any comment if detected (inline or otherwise) inside a `PTree`, a nest is forced. This allows   all the comments to be collected and printed appropriately.

Example:

```julia
var = foo(
    a, b, # comment 1
    c, # comment 2
    d # comment 3
)
```

Will be formatted to

```julia
var = foo(
    a, 
    b, # comment 1
    c, # comment 2
    d # comment 3
)
```

Staying as the former makes more sense if the comment relates to all the argument on the line. This could be done with some more effort but the current result is not far from optimal anyway.

A case where the comment still gets eaten is if there is a single argument with a comment:

```julia
var = foo(
    a # comment
)
```

Will be formatted to

```julia
var = foo(a)
```

Again with a bit more effort we could make this change, but 

1. This use of an inline comment is very rare
2. Debatable whether it's a good use

### TODO

- [x] Possibly un-nest if no leading comments are detected
- [x] Test comments inside `{...}` of `WhereOpCall`