### PR TITLE
Improve formatting CLI script

### DIFF
--- a/bin/format.jl
+++ b/bin/format.jl
@@ -26,6 +26,9 @@ Flags:
         Print the name of the files being formatted.
     -h, --help
         Print this message.
+    -o, --overwrite
+        Writes the formatted source to a new file where the original
+        filename is suffixed with _fmt, i.e. `filename_fmt.jl`.
 """
 
 function parse_opts!(args::Vector{String})
@@ -45,19 +48,24 @@ function parse_opts!(args::Vector{String})
             opt = :verbose
         elseif arg == "-h" || arg == "--help"
             opt = :help
+        elseif arg == "-o" || arg == "--overwrite"
+            opt = :overwrite
         else
             error("invalid option $arg")
         end
         if opt == :verbose || opt == :help
             opts[opt] = true
             deleteat!(args, i)
-            continue
+        elseif opt == :overwrite
+            opts[opt] = false
+            deleteat!(args, i)
+        else
+            i < length(args) || error("option $arg requires and argument")
+            val = tryparse(Int, args[i+1])
+            val != nothing || error("invalid value for option $arg: $(args[i+1])")
+            opts[opt] = val
+            deleteat!(args, i:i+1)
         end
-        i < length(args) || error("option $arg requires and argument")
-        val = tryparse(Int, args[i+1])
-        val != nothing || error("invalid value for option $arg: $(args[i+1])")
-        opts[opt] = val
-        deleteat!(args, i:i+1)
     end
     return opts
 end

--- a/bin/format.jl
+++ b/bin/format.jl
@@ -70,10 +70,7 @@ function parse_opts!(args::Vector{String})
     return opts
 end
 
-@info "" ARGS
 opts = parse_opts!(ARGS)
-@info "" opts
-
 if isempty(ARGS) || haskey(opts, :help)
     write(stdout, help)
     exit(0)

--- a/bin/format.jl
+++ b/bin/format.jl
@@ -2,32 +2,68 @@
 
 using JuliaFormatter
 
+help = """
+JuliaFormatter formats Julia (.jl) programs. The formatter is width-sensitive.
+
+Without an explicit file or path, this help message is written to stdout.
+Given a file, it operates on that file; given a directory, it operates on
+all .jl files in that directory, recursively (Files starting with a nofmt comment are ignored).
+By default, JuliaFormatter overwrites files with the reformatted source.
+
+Usage:
+
+    format.jl [flags] [path ...]
+
+Flags:
+
+    -i, --indent
+        The number of spaces used for an indentation.
+    -m, --margin
+        The maximum number of characters of code on a single line.  Lines over the
+        limit will be wrapped if possible. There are cases where lines cannot be wrapped
+        and they will still end up wider than the requested margin.
+"""
+
 function parse_opts!(args::Vector{String})
     i = 1
-    opts = Dict{Symbol,Int}()
+    opts = Dict{Symbol,Union{Int,Bool}}()
     while i ≤ length(args)
         arg = args[i]
         if arg[1] != '-'
-            i += 1; continue
+            i += 1
+            continue
         end
         if arg == "-i" || arg == "--indent"
             opt = :indent
         elseif arg == "-m" || arg == "--margin"
             opt = :margin
+        elseif arg == "-v" || arg == "--verbose"
+            opt = :verbose
+        elseif arg == "-h" || arg == "--help"
+            opt = :help
         else
             error("invalid option $arg")
         end
-        i < length(args) ||
-            error("option $arg requires and argument")
-        val = tryparse(Int, args[i + 1])
-        val != nothing ||
-            error("invalid value for option $arg: $(args[i+1])")
+        if opt == :verbose || opt == :help
+            opts[opt] = true
+            deleteat!(args, i)
+            continue
+        end
+        i < length(args) || error("option $arg requires and argument")
+        val = tryparse(Int, args[i+1])
+        val != nothing || error("invalid value for option $arg: $(args[i+1])")
         opts[opt] = val
         deleteat!(args, i:i+1)
     end
     return opts
 end
 
+@info "" ARGS
 opts = parse_opts!(ARGS)
-isempty(ARGS) && push!(ARGS, ".")
+@info "" opts
+
+if isempty(ARGS) || haskey(opts, :help) 
+    write(stdout, help)
+    exit(0)
+end
 format(ARGS; opts...)

--- a/bin/format.jl
+++ b/bin/format.jl
@@ -22,6 +22,10 @@ Flags:
         The maximum number of characters of code on a single line.  Lines over the
         limit will be wrapped if possible. There are cases where lines cannot be wrapped
         and they will still end up wider than the requested margin.
+    -v, --verbose
+        Print the name of the files being formatted.
+    -h, --help
+        Print this message.
 """
 
 function parse_opts!(args::Vector{String})
@@ -62,7 +66,7 @@ end
 opts = parse_opts!(ARGS)
 @info "" opts
 
-if isempty(ARGS) || haskey(opts, :help) 
+if isempty(ARGS) || haskey(opts, :help)
     write(stdout, help)
     exit(0)
 end

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -179,7 +179,9 @@ be written to `foo_fmt.jl` instead.
 """
 function format_file(
     filename::AbstractString;
-    indent::Integer = 4, margin::Integer = 92, overwrite::Bool = true,
+    indent::Integer = 4,
+    margin::Integer = 92,
+    overwrite::Bool = true,
     verbose::Bool = false,
 )
     path, ext = splitext(filename)

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -180,11 +180,13 @@ be written to `foo_fmt.jl` instead.
 function format_file(
     filename::AbstractString;
     indent::Integer = 4, margin::Integer = 92, overwrite::Bool = true,
+    verbose::Bool = false,
 )
     path, ext = splitext(filename)
     if ext != ".jl"
         error("$filename must be a Julia (.jl) source file")
     end
+    verbose && println("Formatting $filename with indent = $indent, margin = $margin")
     str = read(filename) |> String
     str = format_text(str, indent = indent, margin = margin)
     overwrite ? write(filename, str) : write(path * "_fmt" * ext, str)


### PR DESCRIPTION
- Adds `--verbose`, `--help`, and `--overwrite` flags.
- If no arguments are passed a help message will be written to stdout.
- Adds a help message describing the program and available flags.
- Add verbose printing option to `format_file`. If `verbose = true` a short message will be printing to stdout detailing the filename being formatted along with the indent and margin.