### PR TITLE
Begin to attempt to add trailing zeros to Float literals

### DIFF
--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -385,14 +385,13 @@ end
 function p_literal(x, s)
     loc = cursor_loc(s)
     if !is_str_or_cmd(x.kind)
-        if x.val[end] == '.'
+        val = x.val
+        if x.kind === Tokens.FLOAT && x.val[end] == '.'
             # If a floating point ends in `.`, add trailing zero.
-            x.val *= '0'
-            x.fullspan += 1
-            x.span += 1
+            val *= '0'
         end
         s.offset += x.fullspan
-        return PTree(x, loc[1], loc[1], x.val)
+        return PTree(x, loc[1], loc[1], val)
     end
 
     # Strings are unescaped by CSTParser

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -385,6 +385,12 @@ end
 function p_literal(x, s)
     loc = cursor_loc(s)
     if !is_str_or_cmd(x.kind)
+        if x.val[end] == '.'
+            # If a floating point ends in `.`, add trailing zero.
+            x.val *= '0'
+            x.fullspan += 1
+            x.span += 1
+        end
         s.offset += x.fullspan
         return PTree(x, loc[1], loc[1], x.val)
     end
@@ -395,7 +401,7 @@ function p_literal(x, s)
     # So we'll just look at the source directly!
     str_info = get(s.doc.lit_strings, s.offset - 1, nothing)
 
-    # Tokenize treats the `ix` part of r"^(=?[^=]+)=(.*)$"ix as an 
+    # Tokenize treats the `ix` part of r"^(=?[^=]+)=(.*)$"ix as an
     # IDENTIFIER where as CSTParser parses it as a LITERAL.
     # An IDENTIFIER won't show up in the string literal lookup table.
     if str_info === nothing && x.parent.typ === CSTParser.x_Str

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2332,6 +2332,17 @@ end
         @test fmt(str_, 2, 67) == str
     end
 
+    @testset "Trailing zeros" begin
+        @test fmt("1.") == "1.0"
+        @test fmt("a * 1. + b") == "a * 1.0 + b"
+        @test fmt("1. + 2. * im") == "1.0 + 2.0 * im"
+        @test fmt("[1., 2.]") == "[1.0, 2.0]"
+        @test fmt("""
+        1. +
+            2.
+        """) == "1.0 + 2.0\n"
+    end
+
 # @testset "meta-format" begin
 #     str = String(read("./runtests.jl"))
 #     str = fmt(str)


### PR DESCRIPTION
So I wanted to implement adding trailing zeros to Float literals (https://github.com/domluna/JuliaFormatter.jl/issues/61), but I quickly got stuck. 

I haven't quite got my head around `PTree`s, so I'm stumbling around in the dark.

Is this the correct way to implement this? Or do I need to add a node to the tree like you did here:
https://github.com/domluna/JuliaFormatter.jl/commit/8944eaad622b8b88fa8b0f1d9e0dd7ef506fc742#diff-9915f66306b42c958fcd076dc0eee523R1228

At the moment I get
```Julia
julia> JuliaFormatter.format_text("1.")
"1.0"

julia> JuliaFormatter.format_text("1. + 1")
ERROR: Indexing range 1 - 6, index used = 7
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] cursor_loc at /Users/oscar/.julia/dev/JuliaFormatter/src/JuliaFormatter.jl:100 [inlined]
 [3] cursor_loc at /Users/oscar/.julia/dev/JuliaFormatter/src/JuliaFormatter.jl:102 [inlined]
 [4] p_literal(::CSTParser.EXPR, ::JuliaFormatter.State) at /Users/oscar/.julia/dev/JuliaFormatter/src/pretty.jl:386
 [5] pretty(::CSTParser.EXPR, ::JuliaFormatter.State) at /Users/oscar/.julia/dev/JuliaFormatter/src/pretty.jl:192
 [6] #p_binarycall#11(::Bool, ::Bool, ::Function, ::CSTParser.EXPR, ::JuliaFormatter.State) at /Users/oscar/.julia/dev/JuliaFormatter/src/pretty.jl:1139
 [7] p_binarycall(::CSTParser.EXPR, ::JuliaFormatter.State) at /Users/oscar/.julia/dev/JuliaFormatter/src/pretty.jl:1091
 [8] pretty(::CSTParser.EXPR, ::JuliaFormatter.State) at /Users/oscar/.julia/dev/JuliaFormatter/src/pretty.jl:252
 [9] pretty(::CSTParser.EXPR, ::JuliaFormatter.State) at /Users/oscar/.julia/dev/JuliaFormatter/src/pretty.jl:307
 [10] #format_text#52(::Int64, ::Int64, ::Function, ::String) at /Users/oscar/.julia/dev/JuliaFormatter/src/JuliaFormatter.jl:135
 [11] format_text(::String) at /Users/oscar/.julia/dev/JuliaFormatter/src/JuliaFormatter.jl:123
 [12] top-level scope at none:0
```