### PR TITLE
Normalize all `=` to `in` in for loops

### DIFF
--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -861,33 +861,12 @@ function p_let(x, s)
     t
 end
 
-
-
-# Transforms
-#
-# for i = iter body end
-#
-# =>
-#
-# for i in iter body end
-#
-# AND
-#
-# for i in 1:10 body end
-#
-# =>
-#
-# for i = 1:10 body end
-#
-# https://github.com/domluna/JuliaFormatter.jl/issues/34
+# Transform all `for i = iter body end` to `for i in iter body end` with no
+# exceptions.
 function eq_to_in_normalization!(x)
     if x.typ === CSTParser.BinaryOpCall
-        op = x.args[2]
-        arg2 = x.args[3]
-        if op.kind === Tokens.EQ && !is_colon_op(arg2)
+        if x.args[2].kind === Tokens.EQ
             x.args[2].kind = Tokens.IN
-        elseif op.kind === Tokens.IN && is_colon_op(arg2)
-            x.args[2].kind = Tokens.EQ
         end
     elseif x.typ === CSTParser.Block || x.typ === CSTParser.InvisBrackets
         for a in x.args

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -77,7 +77,7 @@ function add_node!(t::PTree, n::PTree, s::State; join_lines = false, max_padding
         join_lines = true
         loc = s.offset > length(s.doc.text) && t.typ === CSTParser.TopLevel ?
               loc = cursor_loc(s, s.offset - 1) : cursor_loc(s)
-        for l = t.endline:loc[1]
+        for l in t.endline:loc[1]
             if has_semicolon(s.doc, l)
                 # @info "found semicolon" l
                 n.startline = l
@@ -209,7 +209,7 @@ function length_to_newline(x::PTree, start = 1)
     x.typ === PLACEHOLDER && (return 0, true)
     is_leaf(x) && (return length(x), false)
     len = 0
-    for i = start:length(x.nodes)
+    for i in start:length(x.nodes)
         n = x.nodes[i]
         ln, nl = length_to_newline(n)
         len += ln
@@ -1570,7 +1570,7 @@ function p_comprehension(x, s)
             add_node!(t, pretty(a, s), s, join_lines = true)
             add_node!(t, Whitespace(1), s)
             if a.kind === Tokens.FOR
-                for j = i+1:length(x)
+                for j in i+1:length(x)
                     eq_to_in_normalization!(x.args[j])
                 end
             end

--- a/src/print.jl
+++ b/src/print.jl
@@ -47,7 +47,7 @@ end
 
 @inline function print_notcode(io, x, s)
     prev_nl = true
-    for l = x.startline:x.endline
+    for l in x.startline:x.endline
         v = getline(s.doc, l)
         v == "" && continue
         if l == x.endline && v[end] == '\n'

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,19 +88,21 @@ end
         for i = 1:n
             println(i)
         end"""
-        @test fmt(str) == str
-
-        str = """
-        for i in itr
+        @test fmt(str) == """
+        for i in 1:n
             println(i)
         end"""
-        @test fmt(str) == str
 
         str = """
-        for i = 1:n
+        for i = iter
             println(i)
         end"""
-        str_ = """
+        @test fmt(str) == """
+        for i in iter
+            println(i)
+        end"""
+
+        str = """
         for i in 1:n
             println(i)
         end"""
@@ -110,47 +112,34 @@ end
         for i in itr
             println(i)
         end"""
-        str_ = """
-        for i = itr
-            println(i)
-        end"""
-        @test fmt(str_) == str
+        @test fmt(str) == str
 
-        str_ = """
+        str = """
         for i = I1, j in I2
             println(i, j)
         end"""
-        str = """
+        @test fmt(str) == """
         for i in I1, j in I2
             println(i, j)
         end"""
-        @test fmt(str_) == str
 
         str = """
         for i = 1:30, j = 100:-2:1
             println(i, j)
         end"""
-        str_ = """
-        for i = 1:30, j in 100:-2:1
+        @test fmt(str) == """
+        for i in 1:30, j in 100:-2:1
             println(i, j)
         end"""
+
+        @test fmt("[(i,j) for i=I1,j=I2]") == "[(i, j) for i in I1, j in I2]"
+        @test fmt("((i,j) for i=I1,j=I2)") == "((i, j) for i in I1, j in I2)"
+
+        str = "[(i, j) for i in 1:2:10, j in 100:-1:10]"
         @test fmt(str) == str
 
-        str_ = "[(i,j) for i=I1,j=I2]"
-        str = "[(i, j) for i in I1, j in I2]"
-        @test fmt(str_) == str
-
-        str_ = "((i,j) for i=I1,j=I2)"
-        str = "((i, j) for i in I1, j in I2)"
-        @test fmt(str_) == str
-
-        str_ = "[(i,j) for i in 1:2:10,j  in 100:-1:10]"
-        str = "[(i, j) for i = 1:2:10, j = 100:-1:10]"
-        @test fmt(str_) == str
-
-        str_ = "((i,j) for i in 1:2:10,j  in 100:-1:10)"
-        str = "((i, j) for i = 1:2:10, j = 100:-1:10)"
-        @test fmt(str_) == str
+        str = "((i, j) for i in 1:2:10, j in 100:-1:10)"
+        @test fmt(str) == str
     end
 
     @testset "tuples" begin
@@ -270,7 +259,7 @@ end
         str_ = """foo() = for i=1:10 body end"""
         str = """
         foo() =
-            for i = 1:10
+            for i in 1:10
                 body
             end"""
         @test fmt(str_) == str
@@ -334,7 +323,7 @@ end
         str_ = """foo = for i=1:10 body end"""
         str = """
         foo =
-          for i = 1:10
+          for i in 1:10
             body
           end"""
         @test fmt(str_, 2, 1) == str
@@ -634,7 +623,7 @@ end
             body
         end"""
         t = run_pretty(str, 80)
-        @test length(t) == 12
+        @test length(t) == 13
 
         str = """
         for i in 1:10
@@ -1432,7 +1421,7 @@ end
         # NOTE: `str_` has extra whitespace after
         # keywords on purpose
         str_ = """
-        begin 
+        begin
             # comment
         end"""
         str = """
@@ -1442,11 +1431,11 @@ end
         @test fmt(str_) == str
 
         str_ = """
-        try 
+        try
             # comment
-        catch 
+        catch
             # comment
-        finally 
+        finally
             # comment
         end"""
         str = """
@@ -1489,7 +1478,7 @@ end
                      AbstractFoo
                 end""") == str
 
-        str = """for i = 1:10
+        str = """for i in 1:10
                      1
                      2
                      3
@@ -1639,8 +1628,7 @@ end
         str = """T[e for e in x]"""
         @test fmt("T[e  for e= x  ]") == str
 
-        str = """T[e for e = 1:2:50]"""
-        @test fmt("T[e  for e= 1:2:50  ]") == str
+        @test fmt("T[e  for e= 1:2:50  ]") == "T[e for e in 1:2:50]"
 
         str = """struct Foo end"""
         @test fmt("struct Foo\n      end") == str
@@ -1898,7 +1886,7 @@ end
         @test fmt("(a;b;c)", 4, 100) == str
         @test fmt("(a;b;c)", 4, 1) == str
 
-        str = "(x for x = 1:10)"
+        str = "(x for x in 1:10)"
         @test fmt("(x   for x  in  1 : 10)", 4, 100) == str
         @test fmt("(x   for x  in  1 : 10)", 4, 1) == str
 


### PR DESCRIPTION
Since #34 was closed, there has been a steady stream of people disagreeing. I get that it is a contentious issue with no settled style in the community, but this simplifies the rule:

- Use `for i in iter` except it `iter` is a literal range, then use `for i = 1:n`.

to

- Always use `for i in iter`.

Revises https://github.com/domluna/JuliaFormatter.jl/pull/35. Re-closes the already closed issue: https://github.com/domluna/JuliaFormatter.jl/issues/34