### PR TITLE
Always surround `.^` with whitespace

### DIFF
--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -1166,7 +1166,7 @@ function p_binarycall(x, s; nonest = false, nospace = false)
     elseif op.kind === Tokens.EX_OR
         add_node!(t, Whitespace(1), s)
         add_node!(t, pretty(op, s), s, join_lines = true)
-    elseif op.dot
+    elseif op.kind === Tokens.CIRCUMFLEX_ACCENT && op.dot
         add_node!(t, Whitespace(1), s)
         add_node!(t, pretty(op, s), s, join_lines = true)
         nest ? add_node!(t, Placeholder(1), s) : add_node!(t, Whitespace(1), s)

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -1163,21 +1163,19 @@ function p_binarycall(x, s; nonest = false, nospace = false)
 
     if op.fullspan == 0 && x.args[3].typ === CSTParser.IDENTIFIER
         # do nothing
-    elseif (CSTParser.precedence(op) in (8, 13, 14, 16) && op.kind !== Tokens.ANON_FUNC) ||
-           nospace
-        add_node!(t, pretty(op, s), s, join_lines = true)
     elseif op.kind === Tokens.EX_OR
         add_node!(t, Whitespace(1), s)
         add_node!(t, pretty(op, s), s, join_lines = true)
-    elseif nest
+    elseif op.dot
         add_node!(t, Whitespace(1), s)
         add_node!(t, pretty(op, s), s, join_lines = true)
-        # for newline
-        add_node!(t, Placeholder(1), s)
+        nest ? add_node!(t, Placeholder(1), s) : add_node!(t, Whitespace(1), s)
+    elseif nospace || (CSTParser.precedence(op) in (8, 13, 14, 16) && op.kind !== Tokens.ANON_FUNC)
+        add_node!(t, pretty(op, s), s, join_lines = true)
     else
         add_node!(t, Whitespace(1), s)
         add_node!(t, pretty(op, s), s, join_lines = true)
-        add_node!(t, Whitespace(1), s)
+        nest ? add_node!(t, Placeholder(1), s) : add_node!(t, Whitespace(1), s)
     end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,14 @@ end
         @test fmt(str) == str
     end
 
+    @testset "dot op" begin
+        @test fmt("10 .^ a") == "10 .^ a"
+        @test fmt("10.0 .^ a") == "10.0 .^ a"
+        @test fmt("10. .^ a") == "10.0 .^ a"
+        @test fmt("b .^ a") == "b .^ a"
+        @test fmt("b .^ 10.") == "b .^ 10.0"
+    end
+
     @testset "toplevel" begin
         str = """
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,9 +59,8 @@ end
     @testset "dot op" begin
         @test fmt("10 .^ a") == "10 .^ a"
         @test fmt("10.0 .^ a") == "10.0 .^ a"
-        @test fmt("10. .^ a") == "10.0 .^ a"
-        @test fmt("b .^ a") == "b .^ a"
-        @test fmt("b .^ 10.") == "b .^ 10.0"
+        @test fmt("a.^b") == "a .^ b"
+        @test fmt("a.^10.") == "a .^ 10.0"
     end
 
     @testset "toplevel" begin


### PR DESCRIPTION
fixes #72 

I've debated whether to only do this only for when the LHS is a LITERAL but it's far less readable, i.e.

`a.^b` vs `a .^ b`

I'd argue the latter is desired.