### PR TITLE
Misc fixes

### DIFF
--- a/src/nest.jl
+++ b/src/nest.jl
@@ -206,6 +206,10 @@ function n_tuple!(x, s; extra_width = 0)
                 x.nodes[i].val = ","
                 x.nodes[i].len = 1
                 nest!(x.nodes[i], s)
+            elseif n.typ === TRAILINGSEMICOLON
+                x.nodes[i].val = ""
+                x.nodes[i].len = 0
+                nest!(x.nodes[i], s)
             elseif opener && (i == 1 || i == length(x.nodes))
                 nest!(n, s)
             else
@@ -270,6 +274,10 @@ function n_call!(x, s; extra_width = 0)
             elseif n.typ === TRAILINGCOMMA
                 x.nodes[i].val = ","
                 x.nodes[i].len = 1
+                nest!(x.nodes[i], s)
+            elseif n.typ === TRAILINGSEMICOLON
+                x.nodes[i].val = ""
+                x.nodes[i].len = 0
                 nest!(x.nodes[i], s)
             elseif i == 1 || i == length(x.nodes)
                 n.typ === CSTParser.Parameters && (n.force_nest = true)

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -114,7 +114,8 @@ function add_node!(t::PTree, n::PTree, s::State; join_lines = false, max_padding
         return
     elseif n.typ === CSTParser.Parameters
         add_node!(t, Semicolon(), s)
-        add_node!(t, Placeholder(1), s)
+        multi_arg = length(CSTParser.get_args(t.ref[])) > 1
+        multi_arg ? add_node!(t, Placeholder(1), s) : add_node!(t, Whitespace(1), s)
     end
 
     if length(t.nodes) == 0
@@ -531,14 +532,12 @@ end
 function p_macrocall(x, s)
     t = PTree(x, nspaces(s))
     if x.args[1].typ === CSTParser.GlobalRefDoc
-        loc = cursor_loc(s)
         # x.args[1] is empty and fullspan is 0 so we can skip it
         if x.args[2].typ === CSTParser.LITERAL
             add_node!(t, p_literal(x.args[2], s), s, max_padding = 0)
         elseif x.args[2].typ == CSTParser.StringH
             add_node!(t, p_stringh(x.args[2], s), s)
         end
-        loc = cursor_loc(s)
         add_node!(t, pretty(x.args[3], s), s, max_padding = 0)
         return t
     end
@@ -1550,7 +1549,7 @@ function p_vcat(x, s)
         elseif !is_closer(a) && i > st
             add_node!(t, n, s, join_lines = true)
             if i != length(x) - 1
-                add_node!(t, Semicolon(), s)
+                has_semicolon(s.doc, n.startline) && add_node!(t, Semicolon(), s)
                 add_node!(t, Placeholder(1), s)
             # Keep trailing semicolon if there's only one arg
             elseif !multi_arg

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -9,6 +9,7 @@
     NOTCODE,
     INLINECOMMENT,
     TRAILINGCOMMA,
+    TRAILINGSEMICOLON,
 )
 
 mutable struct PTree
@@ -37,6 +38,7 @@ end
 Newline() = PTree(NEWLINE, -1, -1, 0, 0, "\n", nothing, nothing, false)
 Semicolon() = PTree(SEMICOLON, -1, -1, 0, 1, ";", nothing, nothing, false)
 TrailingComma() = PTree(TRAILINGCOMMA, -1, -1, 0, 0, "", nothing, nothing, false)
+TrailingSemicolon() = PTree(TRAILINGSEMICOLON, -1, -1, 0, 1, ";", nothing, nothing, false)
 Whitespace(n) = PTree(WHITESPACE, -1, -1, 0, n, " "^n, nothing, nothing, false)
 Placeholder(n) = PTree(PLACEHOLDER, -1, -1, 0, n, " "^n, nothing, nothing, false)
 Notcode(startline, endline) =
@@ -1549,7 +1551,7 @@ function p_vcat(x, s)
         elseif !is_closer(a) && i > st
             add_node!(t, n, s, join_lines = true)
             if i != length(x) - 1
-                has_semicolon(s.doc, n.startline) && add_node!(t, Semicolon(), s)
+                has_semicolon(s.doc, n.startline) && add_node!(t, TrailingSemicolon(), s)
                 add_node!(t, Placeholder(1), s)
             # Keep trailing semicolon if there's only one arg
             elseif !multi_arg

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -413,6 +413,7 @@ end
         @test fmt("func(  a, b; c)") == "func(a, b; c)"
         @test fmt("func(a  ,b; c)") == "func(a, b; c)"
         @test fmt("func(a=1,b; c=1)") == "func(a = 1, b; c = 1)"
+        @test fmt("func(; c = 1)", 4, 1) == "func(; c = 1)"
     end
 
     @testset "begin" begin
@@ -2168,6 +2169,31 @@ end
         end"""
         @test fmt(str_) == str
 
+        # single function kwarg or param should not nest
+        @test fmt("f(;a=1)", 4, 1) == "f(; a = 1)"
+        @test fmt("f(a=1)", 4, 1) == "f(a = 1)"
+
+        # any pairing of argument, kawrg, or param should nest
+        str = """
+        f(
+          arg;
+          a = 1,
+        )"""
+        @test fmt("f(arg;a=1)", 4, 1) == str
+
+        str = """
+        f(
+          arg,
+          a = 1,
+        )"""
+        @test fmt("f(arg,a=1)", 4, 1) == str
+
+        str = """
+        f(
+          a = 1;
+          b = 2,
+        )"""
+        @test fmt("f(a=1; b=2)", 4, 1) == str
     end
 
     @testset "nesting line offset" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2150,32 +2150,6 @@ end
         @test fmt(str_, 4, 7) == str
         @test fmt(str_, 4, 1) == str
 
-        str_ = """
-        [ a b Expr()
-        d e Expr()]"""
-        str = """
-        [
-         a b Expr();
-         d e Expr()
-        ]"""
-        @test fmt(str_) == str
-        str_ = "[a b Expr(); d e Expr()]"
-        @test fmt(str_) == str_
-        @test fmt(str_, 4, 1) == str
-
-        str_ = """
-        T[ a b Expr()
-        d e Expr()]"""
-        str = """
-        T[
-          a b Expr();
-          d e Expr()
-        ]"""
-        @test fmt(str_) == str
-        str_ = "T[a b Expr(); d e Expr()]"
-        @test fmt(str_) == str_
-        @test fmt(str_, 4, 1) == str
-
         # https://github.com/domluna/JuliaFormatter.jl/issues/60
         str_ = """
         function write_subproblem_to_file(
@@ -2607,6 +2581,88 @@ end
         1. +
             2.
         """) == "1.0 + 2.0\n"
+    end
+
+    # https://github.com/domluna/JuliaFormatter.jl/issues/77
+    @testset "issue 77" begin
+        str_ = """
+        [ a b Expr()
+        d e Expr()]"""
+        str = """
+        [
+         a b Expr()
+         d e Expr()
+        ]"""
+        @test fmt(str_) == str
+
+        str_ = """
+        T[ a b Expr()
+        d e Expr()]"""
+        str = """
+        T[
+          a b Expr()
+          d e Expr()
+        ]"""
+        @test fmt(str_) == str
+
+        str_ = """
+        [ a b Expr();
+        d e Expr();]"""
+        str = """
+        [
+         a b Expr();
+         d e Expr()
+        ]"""
+        @test fmt(str_) == str
+        str_ = "[a b Expr(); d e Expr()]"
+        @test fmt(str_) == str_
+        @test fmt(str_, 4, 1) == str
+
+        str_ = """
+        T[ a b Expr();
+        d e Expr();]"""
+        str = """
+        T[
+          a b Expr();
+          d e Expr()
+        ]"""
+        @test fmt(str_) == str
+
+        str_ = "T[a b Expr(); d e Expr()]"
+        @test fmt(str_) == str_
+        @test fmt(str_, 4, 1) == str
+        str = """
+        [
+         0.0 0.0 0.0 1.0
+         0.0 0.0 0.1 1.0
+         0.0 0.0 0.2 1.0
+         0.0 0.0 0.3 1.0
+         0.0 0.0 0.4 1.0
+         0.0 0.0 0.5 1.0
+         0.0 0.0 0.6 1.0
+         0.0 0.0 0.7 1.0
+         0.0 0.0 0.8 1.0
+         0.0 0.0 0.9 1.0
+         0.0 0.0 1.0 1.0
+         0.0 0.0 0.0 1.0
+         0.0 0.1 0.1 1.0
+         0.0 0.2 0.2 1.0
+         0.0 0.3 0.3 1.0
+         0.0 0.4 0.4 1.0
+         0.0 0.5 0.5 1.0
+         0.0 0.6 0.6 1.0
+         0.0 0.7 0.7 1.0
+         0.0 0.8 0.8 1.0
+         0.0 0.9 0.9 1.0
+         0.0 1.0 1.0 1.0
+         0.0 0.0 0.0 1.0
+         0.1 0.1 0.1 1.0
+         0.2 0.2 0.2 1.0
+         0.3 0.3 0.3 1.0
+         0.4 0.4 0.4 1.0
+         0.5 0.5 0.5 1.0
+        ]"""
+        @test fmt(str) == str
     end
 
 # @testset "meta-format" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2636,7 +2636,7 @@ end
         d e Expr();]"""
         str = """
         [
-         a b Expr();
+         a b Expr()
          d e Expr()
         ]"""
         @test fmt(str_) == str
@@ -2649,7 +2649,7 @@ end
         d e Expr();]"""
         str = """
         T[
-          a b Expr();
+          a b Expr()
           d e Expr()
         ]"""
         @test fmt(str_) == str
@@ -2657,6 +2657,7 @@ end
         str_ = "T[a b Expr(); d e Expr()]"
         @test fmt(str_) == str_
         @test fmt(str_, 4, 1) == str
+
         str = """
         [
          0.0 0.0 0.0 1.0


### PR DESCRIPTION
- Should not nest if function has 0 arg, 0 kwargs, and 1 parameter
- Fixes #77. If Vcat/TypedVcat is nested removes trailing semicolons.