### PR TITLE
RFC: Assignment op RHS block nesting

### DIFF
--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -1105,10 +1105,8 @@ end
 block_type(x::CSTParser.EXPR) =
     x.typ === CSTParser.If ||
     x.typ === CSTParser.Do ||
-    x.typ === CSTParser.Begin ||
-    (x.typ === CSTParser.Quote && x.args[1].kind === Tokens.QUOTE) ||
     x.typ === CSTParser.Try ||
-    x.typ === CSTParser.For || x.typ === CSTParser.While || x.typ === CSTParser.Let
+    x.typ === CSTParser.For || x.typ === CSTParser.While || (x.typ === CSTParser.Let && length(x) > 3)
 
 nest_assignment(x::CSTParser.EXPR) = CSTParser.is_assignment(x) && block_type(x.args[3])
 

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -1106,7 +1106,8 @@ block_type(x::CSTParser.EXPR) =
     x.typ === CSTParser.If ||
     x.typ === CSTParser.Do ||
     x.typ === CSTParser.Try ||
-    x.typ === CSTParser.For || x.typ === CSTParser.While || (x.typ === CSTParser.Let && length(x) > 3)
+    x.typ === CSTParser.For ||
+    x.typ === CSTParser.While || (x.typ === CSTParser.Let && length(x) > 3)
 
 nest_assignment(x::CSTParser.EXPR) = CSTParser.is_assignment(x) && block_type(x.args[3])
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -265,21 +265,29 @@ end
             end"""
         @test fmt(str_) == str
 
-        str_ = """foo() = begin body end"""
+        str_ = """
+        foo() = begin
+            body
+        end"""
         str = """
         foo() =
             begin
                 body
             end"""
-        @test fmt(str_) == str
+        @test fmt(str_) == str_
+        @test fmt(str_, 4, 1) == str
 
-        str_ = """foo() = quote body end"""
+        str_ = """
+        foo() = quote
+            body
+        end"""
         str = """
         foo() =
             quote
                 body
             end"""
-        @test fmt(str_) == str
+        @test fmt(str_) == str_
+        @test fmt(str_, 4, 1) == str
 
         str = """foo() = :(Union{})"""
         @test fmt(str) == str
@@ -334,18 +342,16 @@ end
 
         str_ = """foo = begin body end"""
         str = """
-        foo =
-          begin
-            body
-          end"""
+        foo = begin
+          body
+        end"""
         @test fmt(str_, 2, 1) == str
 
         str_ = """foo = quote body end"""
         str = """
-        foo =
-          quote
-            body
-          end"""
+        foo = quote
+          body
+        end"""
         @test fmt(str_, 2, 1) == str
 
         str_ = """foo = for i=1:10 body end"""
@@ -383,6 +389,12 @@ end
             body
           end"""
         @test fmt(str_, 2, 1) == str
+
+        str = """
+        foo = let
+          body
+        end"""
+        @test fmt(str, 2, 1) == str
 
         str_ = """a, b = cond ? e1 : e2"""
         str = """


### PR DESCRIPTION
This spun off of #80.

If `Begin`, `Quote`, or `Let` (with no args) are on the RHS of an assignment op (not function def). Then don't nest over the assignment op. The idea is if it's *just* a keyword, keep it on the same line. `Try` is exempted from this, I think it fits better with being nested, but that's just my opinion.