### PR TITLE
Options - Always use `for in`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,30 @@ Width-sensitive formatter for Julia code. Inspired by gofmt and refmt.
 `JuliaFormatter` exports `format_text`, `format_file` and `format`:
 
 ```julia
-format_text(text::AbstractString; indent = 4, margin = 92)
-format_file(file::AbstractString; indent = 4, margin = 92, overwrite = true, verbose = false)
-format(paths...; indent = 4, margin = 92, overwrite = true, verbose = false)
+format_text(
+    text::AbstractString;
+    indent = 4,
+    margin = 92,
+    always_for_in = false,
+)
+
+format_file(
+    file::AbstractString;
+    indent = 4,
+    margin = 92,
+    overwrite = true,
+    verbose = false,
+    always_for_in = false,
+)
+
+format(
+    paths...;
+    indent = 4,
+    margin = 92,
+    overwrite = true,
+    verbose = false,
+    always_for_in = false,
+)
 ```
 
 The `text` argument to `format_text` is a string containing the code to be formatted; the formatted code is retuned as a new string. The `file` argument to `format_file` is the path of a file to be formatted. The `format` function is either called with a singe string to format if it is a `.jl` file or to recuse into looking for `.jl` files if it is a directory. It can also be called with a collection of such paths to iterate over.
@@ -27,6 +48,7 @@ the limit will be wrapped if possible. There are cases where lines cannot be wra
 and they will still end up wider than the requested margin.
 * `overwrite` - If the file should be overwritten by the formatted output. If set to false, the formatted version of file named `foo.jl` will be written to `foo_fmt.jl`.
 * `verbose` - Whether to print the name of the file being formatted along with relevant details to `stdout`.
+* `always_for_in` - Always use `in` keyword for `for` loops. This defaults to `false`.
 
 There is also a command-line tool `bin/format.jl` which can be invoked with `-i`/`--indent` and `-m`/`--margin` and with paths which will be passed to `format`.
 
@@ -182,7 +204,9 @@ end
 
 ### `for in` vs. `for =`
 
-If the RHS is a range, i.e. `1:10` then `for in` is converted to `for =`. Otherwise `for =` is converted to `for in`. See [this issue](https://github.com/domluna/JuliaFormatter.jl/issues/34) for the rationale and further explanation.
+By default if the RHS is a range, i.e. `1:10` then `for in` is converted to `for =`. Otherwise `for =` is converted to `for in`. See [this issue](https://github.com/domluna/JuliaFormatter.jl/issues/34) for the rationale and further explanation.
+
+Alternative to the above - setting `always_for_in` to `true`, i.e. `format_text(..., always_for_in = true)` will always convert `=` to `in` even if the RHS is a range.
 
 ### Trailing Commas
 

--- a/bin/format.jl
+++ b/bin/format.jl
@@ -30,7 +30,7 @@ Flags:
         Writes the formatted source to a new file where the original
         filename is suffixed with _fmt, i.e. `filename_fmt.jl`.
     --always_use_in
-        Always replaces `=` with `in` with respect to for loops.
+        Always replaces `=` with `in` for `for` loops.
         For example, `for i = 1:10` will be transformed to `for i in 1:10`.
 """
 

--- a/bin/format.jl
+++ b/bin/format.jl
@@ -53,7 +53,7 @@ function parse_opts!(args::Vector{String})
             opt = :help
         elseif arg == "-o" || arg == "--overwrite"
             opt = :overwrite
-        elseif arg "--always_use_in"
+        elseif arg == "--always_use_in"
             opt = :always_use_in
         else
             error("invalid option $arg")

--- a/bin/format.jl
+++ b/bin/format.jl
@@ -29,7 +29,7 @@ Flags:
     -o, --overwrite
         Writes the formatted source to a new file where the original
         filename is suffixed with _fmt, i.e. `filename_fmt.jl`.
-    --always_use_in
+    --always_for_in
         Always replaces `=` with `in` for `for` loops.
         For example, `for i = 1:10` will be transformed to `for i in 1:10`.
 """
@@ -53,12 +53,12 @@ function parse_opts!(args::Vector{String})
             opt = :help
         elseif arg == "-o" || arg == "--overwrite"
             opt = :overwrite
-        elseif arg == "--always_use_in"
-            opt = :always_use_in
+        elseif arg == "--always_for_in"
+            opt = :always_for_in
         else
             error("invalid option $arg")
         end
-        if opt in (:verbose, :help, :always_use_in)
+        if opt in (:verbose, :help, :always_for_in)
             opts[opt] = true
             deleteat!(args, i)
         elseif opt == :overwrite

--- a/bin/format.jl
+++ b/bin/format.jl
@@ -29,6 +29,9 @@ Flags:
     -o, --overwrite
         Writes the formatted source to a new file where the original
         filename is suffixed with _fmt, i.e. `filename_fmt.jl`.
+    --always_use_in
+        Always replaces `=` with `in` with respect to for loops.
+        For example, `for i = 1:10` will be transformed to `for i in 1:10`.
 """
 
 function parse_opts!(args::Vector{String})
@@ -50,10 +53,12 @@ function parse_opts!(args::Vector{String})
             opt = :help
         elseif arg == "-o" || arg == "--overwrite"
             opt = :overwrite
+        elseif arg "--always_use_in"
+            opt = :always_use_in
         else
             error("invalid option $arg")
         end
-        if opt == :verbose || opt == :help
+        if opt in (:verbose, :help, :always_use_in)
             opts[opt] = true
             deleteat!(args, i)
         elseif opt == :overwrite

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -108,7 +108,8 @@ mutable struct State
     margin::Int
     always_use_in::Bool
 end
-State(doc, indent_size, margin; always_use_in=false) = State(doc, indent_size, 0, 1, 0, margin, always_use_in)
+State(doc, indent_size, margin; always_use_in = false) =
+    State(doc, indent_size, 0, 1, 0, margin, always_use_in)
 
 @inline nspaces(s::State) = s.indent
 @inline hascomment(d::Document, line::Integer) = haskey(d.comments, line)
@@ -145,7 +146,12 @@ code as another string. The formatting options are:
 If `always_use_in` is true `=` is always replaced with `in` with respect to for loops.
 For example, `for i = 1:10` will be transformed to `for i in 1:10`.
 """
-function format_text(text::AbstractString; indent::Int = 4, margin::Int = 92, always_use_in::Bool=false)
+function format_text(
+    text::AbstractString;
+    indent::Int = 4,
+    margin::Int = 92,
+    always_use_in::Bool = false,
+)
     isempty(text) && return text
 
     x, ps = CSTParser.parse(CSTParser.ParseState(text), true)
@@ -158,7 +164,7 @@ function format_text(text::AbstractString; indent::Int = 4, margin::Int = 92, al
     # If "nofmt" occurs in a comment on line 1 do not format
     occursin("nofmt", get(d.comments, 1, (0, ""))[2]) && return text
 
-    s = State(d, indent, margin, always_use_in=always_use_in)
+    s = State(d, indent, margin, always_use_in = always_use_in)
     t = pretty(x, s)
     hascomment(s.doc, t.endline) && (add_node!(t, InlineComment(t.endline), s))
     nest!(t, s)

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -106,8 +106,9 @@ mutable struct State
     offset::Int
     line_offset::Int
     margin::Int
+    always_use_in::Bool
 end
-State(doc, indent_size, margin) = State(doc, indent_size, 0, 1, 0, margin)
+State(doc, indent_size, margin; always_use_in=false) = State(doc, indent_size, 0, 1, 0, margin, always_use_in)
 
 @inline nspaces(s::State) = s.indent
 @inline hascomment(d::Document, line::Integer) = haskey(d.comments, line)
@@ -130,8 +131,9 @@ include("print.jl")
 """
     format_text(
         text::AbstractString;
-        indent::Integer = 4,
-        margin::Integer = 92,
+        indent::Int = 4,
+        margin::Int = 92,
+        always_use_in::Bool = false,
     ) :: String
 
 Formats a Julia source passed in as a string, returning the formatted
@@ -140,11 +142,11 @@ code as another string. The formatting options are:
 - `indent` which defaults to 4 spaces
 - `margin` which defaults to 92 columns
 
+If `always_use_in` is true `=` is always replaced with `in` with respect to for loops.
+For example, `for i = 1:10` will be transformed to `for i in 1:10`.
 """
-function format_text(text::AbstractString; indent::Integer = 4, margin::Integer = 92)
-    if isempty(text)
-        return text
-    end
+function format_text(text::AbstractString; indent::Int = 4, margin::Int = 92, always_use_in::Bool=false)
+    isempty(text) && return text
 
     x, ps = CSTParser.parse(CSTParser.ParseState(text), true)
     ps.errored && error("Parsing error for input $text")
@@ -154,9 +156,9 @@ function format_text(text::AbstractString; indent::Integer = 4, margin::Integer 
 
     d = Document(text)
     # If "nofmt" occurs in a comment on line 1 do not format
-    occursin("nofmt", get(d.comments, 1, (0, ""))[2]) && (return text)
+    occursin("nofmt", get(d.comments, 1, (0, ""))[2]) && return text
 
-    s = State(d, indent, margin)
+    s = State(d, indent, margin, always_use_in=always_use_in)
     t = pretty(x, s)
     hascomment(s.doc, t.endline) && (add_node!(t, InlineComment(t.endline), s))
     nest!(t, s)
@@ -190,6 +192,7 @@ end
         margin::Integer = 92,
         overwrite::Bool = true,
         verbose::Bool = false,
+        always_use_in::Bool = false,
     )
 
 Formats the contents of `filename` assuming it's a Julia source file.
@@ -205,6 +208,9 @@ be written to `foo_fmt.jl` instead.
 
 If `verbose` is `true` details related to formatting the file will be printed
 to `stdout`.
+
+If `always_use_in` is true `=` is always replaced with `in` with respect to for loops.
+For example, `for i = 1:10` will be transformed to `for i in 1:10`.
 """
 function format_file(
     filename::AbstractString;
@@ -212,6 +218,7 @@ function format_file(
     margin::Integer = 92,
     overwrite::Bool = true,
     verbose::Bool = false,
+    always_use_in::Bool = false,
 )
     path, ext = splitext(filename)
     if ext != ".jl"
@@ -219,7 +226,7 @@ function format_file(
     end
     verbose && println("Formatting $filename with indent = $indent, margin = $margin")
     str = read(filename) |> String
-    str = format_text(str, indent = indent, margin = margin)
+    str = format_text(str, indent = indent, margin = margin, always_use_in = always_use_in)
     overwrite ? write(filename, str) : write(path * "_fmt" * ext, str)
     nothing
 end
@@ -231,6 +238,7 @@ end
         margin::Integer = 92,
         overwrite::Bool = true,
         verbose::Bool = false,
+        always_use_in::Bool = false,
     )
 
 Recursively descend into files and directories, formatting and `.jl`

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -106,10 +106,10 @@ mutable struct State
     offset::Int
     line_offset::Int
     margin::Int
-    always_use_in::Bool
+    always_for_in::Bool
 end
-State(doc, indent_size, margin; always_use_in = false) =
-    State(doc, indent_size, 0, 1, 0, margin, always_use_in)
+State(doc, indent_size, margin; always_for_in = false) =
+    State(doc, indent_size, 0, 1, 0, margin, always_for_in)
 
 @inline nspaces(s::State) = s.indent
 @inline hascomment(d::Document, line::Integer) = haskey(d.comments, line)
@@ -134,7 +134,7 @@ include("print.jl")
         text::AbstractString;
         indent::Int = 4,
         margin::Int = 92,
-        always_use_in::Bool = false,
+        always_for_in::Bool = false,
     ) :: String
 
 Formats a Julia source passed in as a string, returning the formatted
@@ -143,7 +143,7 @@ code as another string. The formatting options are:
 - `indent` which defaults to 4 spaces
 - `margin` which defaults to 92 columns
 
-If `always_use_in` is true `=` is always replaced with `in` if part of a
+If `always_for_in` is true `=` is always replaced with `in` if part of a
 `for` loop condition.  For example, `for i = 1:10` will be transformed
 to `for i in 1:10`.
 """
@@ -151,7 +151,7 @@ function format_text(
     text::AbstractString;
     indent::Int = 4,
     margin::Int = 92,
-    always_use_in::Bool = false,
+    always_for_in::Bool = false,
 )
     isempty(text) && return text
 
@@ -165,7 +165,7 @@ function format_text(
     # If "nofmt" occurs in a comment on line 1 do not format
     occursin("nofmt", get(d.comments, 1, (0, ""))[2]) && return text
 
-    s = State(d, indent, margin, always_use_in = always_use_in)
+    s = State(d, indent, margin, always_for_in = always_for_in)
     t = pretty(x, s)
     hascomment(s.doc, t.endline) && (add_node!(t, InlineComment(t.endline), s))
     nest!(t, s)
@@ -199,7 +199,7 @@ end
         margin::Integer = 92,
         overwrite::Bool = true,
         verbose::Bool = false,
-        always_use_in::Bool = false,
+        always_for_in::Bool = false,
     )
 
 Formats the contents of `filename` assuming it's a Julia source file.
@@ -216,7 +216,7 @@ be written to `foo_fmt.jl` instead.
 If `verbose` is `true` details related to formatting the file will be printed
 to `stdout`.
 
-If `always_use_in` is true `=` is always replaced with `in` if part of a
+If `always_for_in` is true `=` is always replaced with `in` if part of a
 `for` loop condition.  For example, `for i = 1:10` will be transformed
 to `for i in 1:10`.
 """
@@ -226,7 +226,7 @@ function format_file(
     margin::Integer = 92,
     overwrite::Bool = true,
     verbose::Bool = false,
-    always_use_in::Bool = false,
+    always_for_in::Bool = false,
 )
     path, ext = splitext(filename)
     if ext != ".jl"
@@ -234,7 +234,7 @@ function format_file(
     end
     verbose && println("Formatting $filename with indent = $indent, margin = $margin")
     str = read(filename) |> String
-    str = format_text(str, indent = indent, margin = margin, always_use_in = always_use_in)
+    str = format_text(str, indent = indent, margin = margin, always_for_in = always_for_in)
     overwrite ? write(filename, str) : write(path * "_fmt" * ext, str)
     nothing
 end
@@ -246,7 +246,7 @@ end
         margin::Integer = 92,
         overwrite::Bool = true,
         verbose::Bool = false,
-        always_use_in::Bool = false,
+        always_for_in::Bool = false,
     )
 
 Recursively descend into files and directories, formatting and `.jl`

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -143,8 +143,9 @@ code as another string. The formatting options are:
 - `indent` which defaults to 4 spaces
 - `margin` which defaults to 92 columns
 
-If `always_use_in` is true `=` is always replaced with `in` with respect to for loops.
-For example, `for i = 1:10` will be transformed to `for i in 1:10`.
+If `always_use_in` is true `=` is always replaced with `in` if part of a
+`for` loop condition.  For example, `for i = 1:10` will be transformed
+to `for i in 1:10`.
 """
 function format_text(
     text::AbstractString;
@@ -215,8 +216,9 @@ be written to `foo_fmt.jl` instead.
 If `verbose` is `true` details related to formatting the file will be printed
 to `stdout`.
 
-If `always_use_in` is true `=` is always replaced with `in` with respect to for loops.
-For example, `for i = 1:10` will be transformed to `for i in 1:10`.
+If `always_use_in` is true `=` is always replaced with `in` if part of a
+`for` loop condition.  For example, `for i = 1:10` will be transformed
+to `for i in 1:10`.
 """
 function format_file(
     filename::AbstractString;

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -885,12 +885,12 @@ end
 # for i = 1:10 body end
 #
 # https://github.com/domluna/JuliaFormatter.jl/issues/34
-function eq_to_in_normalization!(x, always_use_in)
+function eq_to_in_normalization!(x, always_for_in)
     if x.typ === CSTParser.BinaryOpCall
         op = x.args[2]
         arg2 = x.args[3]
 
-        if always_use_in
+        if always_for_in
             x.args[2].kind = Tokens.IN
             return
         end
@@ -902,7 +902,7 @@ function eq_to_in_normalization!(x, always_use_in)
         end
     elseif x.typ === CSTParser.Block || x.typ === CSTParser.InvisBrackets
         for a in x.args
-            eq_to_in_normalization!(a, always_use_in)
+            eq_to_in_normalization!(a, always_for_in)
         end
     end
 end
@@ -913,7 +913,7 @@ function p_loop(x, s)
     add_node!(t, pretty(x.args[1], s), s)
     add_node!(t, Whitespace(1), s)
     if x.args[1].kind === Tokens.FOR
-        eq_to_in_normalization!(x.args[2], s.always_use_in)
+        eq_to_in_normalization!(x.args[2], s.always_for_in)
     end
     add_node!(t, pretty(x.args[2], s), s, join_lines = true)
     s.indent += s.indent_size
@@ -1616,7 +1616,7 @@ function p_comprehension(x, s)
             add_node!(t, Whitespace(1), s)
             if a.kind === Tokens.FOR
                 for j = i+1:length(x)
-                    eq_to_in_normalization!(x.args[j], s.always_use_in)
+                    eq_to_in_normalization!(x.args[j], s.always_for_in)
                 end
             end
         elseif CSTParser.is_comma(a) && i < length(x) && !is_punc(x.args[i+1])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,11 +3,12 @@ using JuliaFormatter
 using CSTParser
 using Test
 
-fmt1(s, i, m, always_use_in) = JuliaFormatter.format_text(s, indent = i, margin = m, always_use_in = always_use_in)
+fmt1(s, i, m, always_use_in) =
+    JuliaFormatter.format_text(s, indent = i, margin = m, always_use_in = always_use_in)
 
 # Verifies formatting the formatted text
 # results in the same output
-function fmt(s; i = 4, m = 80, always_use_in=false)
+function fmt(s; i = 4, m = 80, always_use_in = false)
     s1 = fmt1(s, i, m, always_use_in)
     fmt1(s1, i, m, always_use_in)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,14 +3,14 @@ using JuliaFormatter
 using CSTParser
 using Test
 
-fmt1(s, i, m, always_use_in) =
-    JuliaFormatter.format_text(s, indent = i, margin = m, always_use_in = always_use_in)
+fmt1(s, i, m, always_for_in) =
+    JuliaFormatter.format_text(s, indent = i, margin = m, always_for_in = always_for_in)
 
 # Verifies formatting the formatted text
 # results in the same output
-function fmt(s; i = 4, m = 80, always_use_in = false)
-    s1 = fmt1(s, i, m, always_use_in)
-    fmt1(s1, i, m, always_use_in)
+function fmt(s; i = 4, m = 80, always_for_in = false)
+    s1 = fmt1(s, i, m, always_for_in)
+    fmt1(s1, i, m, always_for_in)
 end
 fmt(s, i, m) = fmt(s; i = i, m = m)
 
@@ -171,8 +171,8 @@ end
         for i in 1:n
             println(i)
         end"""
-        @test fmt(str_, always_use_in = true) == str
-        @test fmt(str, always_use_in = true) == str
+        @test fmt(str_, always_for_in = true) == str
+        @test fmt(str, always_for_in = true) == str
 
         str_ = """
         for i = I1, j in I2
@@ -182,8 +182,8 @@ end
         for i in I1, j in I2
             println(i, j)
         end"""
-        @test fmt(str_, always_use_in = true) == str
-        @test fmt(str, always_use_in = true) == str
+        @test fmt(str_, always_for_in = true) == str
+        @test fmt(str, always_for_in = true) == str
 
         str_ = """
         for i = 1:30, j = 100:-2:1
@@ -193,23 +193,23 @@ end
         for i in 1:30, j in 100:-2:1
             println(i, j)
         end"""
-        @test fmt(str_, always_use_in = true) == str
-        @test fmt(str, always_use_in = true) == str
+        @test fmt(str_, always_for_in = true) == str
+        @test fmt(str, always_for_in = true) == str
 
         str_ = "[(i,j) for i=I1,j=I2]"
         str = "[(i, j) for i in I1, j in I2]"
-        @test fmt(str_, always_use_in = true) == str
-        @test fmt(str, always_use_in = true) == str
+        @test fmt(str_, always_for_in = true) == str
+        @test fmt(str, always_for_in = true) == str
 
         str_ = "((i,j) for i=I1,j=I2)"
         str = "((i, j) for i in I1, j in I2)"
-        @test fmt(str_, always_use_in = true) == str
-        @test fmt(str, always_use_in = true) == str
+        @test fmt(str_, always_for_in = true) == str
+        @test fmt(str, always_for_in = true) == str
 
         str_ = "[(i, j) for i = 1:2:10, j = 100:-1:10]"
         str = "[(i, j) for i in 1:2:10, j in 100:-1:10]"
-        @test fmt(str_, always_use_in = true) == str
-        @test fmt(str, always_use_in = true) == str
+        @test fmt(str_, always_for_in = true) == str
+        @test fmt(str, always_for_in = true) == str
     end
 
     @testset "tuples" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,16 +1,17 @@
 # fmt
-import JuliaFormatter
+using JuliaFormatter
 using CSTParser
 using Test
 
-fmt1(s, i = 4, m = 80) = JuliaFormatter.format_text(s, indent = i, margin = m)
+fmt1(s, i, m, always_use_in) = JuliaFormatter.format_text(s, indent = i, margin = m, always_use_in = always_use_in)
 
 # Verifies formatting the formatted text
 # results in the same output
-function fmt(s, i = 4, m = 80)
-    s1 = fmt1(s, i, m)
-    fmt1(s1, i, m)
+function fmt(s; i = 4, m = 80, always_use_in=false)
+    s1 = fmt1(s, i, m, always_use_in)
+    fmt1(s1, i, m, always_use_in)
 end
+fmt(s, i, m) = fmt(s; i = i, m = m)
 
 function run_pretty(text::String, print_width::Int)
     d = JuliaFormatter.Document(text)
@@ -158,6 +159,56 @@ end
         str_ = "((i,j) for i in 1:2:10,j  in 100:-1:10)"
         str = "((i, j) for i = 1:2:10, j = 100:-1:10)"
         @test fmt(str_) == str
+    end
+
+    @testset "always eq to in" begin
+        str_ = """
+        for i = 1:n
+            println(i)
+        end"""
+        str = """
+        for i in 1:n
+            println(i)
+        end"""
+        @test fmt(str_, always_use_in = true) == str
+        @test fmt(str, always_use_in = true) == str
+
+        str_ = """
+        for i = I1, j in I2
+            println(i, j)
+        end"""
+        str = """
+        for i in I1, j in I2
+            println(i, j)
+        end"""
+        @test fmt(str_, always_use_in = true) == str
+        @test fmt(str, always_use_in = true) == str
+
+        str_ = """
+        for i = 1:30, j = 100:-2:1
+            println(i, j)
+        end"""
+        str = """
+        for i in 1:30, j in 100:-2:1
+            println(i, j)
+        end"""
+        @test fmt(str_, always_use_in = true) == str
+        @test fmt(str, always_use_in = true) == str
+
+        str_ = "[(i,j) for i=I1,j=I2]"
+        str = "[(i, j) for i in I1, j in I2]"
+        @test fmt(str_, always_use_in = true) == str
+        @test fmt(str, always_use_in = true) == str
+
+        str_ = "((i,j) for i=I1,j=I2)"
+        str = "((i, j) for i in I1, j in I2)"
+        @test fmt(str_, always_use_in = true) == str
+        @test fmt(str, always_use_in = true) == str
+
+        str_ = "[(i, j) for i = 1:2:10, j = 100:-1:10]"
+        str = "[(i, j) for i in 1:2:10, j in 100:-1:10]"
+        @test fmt(str_, always_use_in = true) == str
+        @test fmt(str, always_use_in = true) == str
     end
 
     @testset "tuples" begin


### PR DESCRIPTION
Adds an initial option `always_for_in` which always uses `in` for `for` loops, by default this will be false. I think this is a very reasonable one to have, some people REALLY like always using `in` and I don't want them not using the formatter solely because it doesn't support this.

TODO

- [x] update README
- [x] update GH action script