### PR TITLE
Improve assignment op unnest

### DIFF
--- a/src/nest.jl
+++ b/src/nest.jl
@@ -464,27 +464,48 @@ function n_binarycall!(x, s; extra_width = 0)
             nest!(n, s)
         end
 
-
         # Undo nest if possible
         if !x.force_nest
-            rw, _ =  length_to(x, (NEWLINE,), start=i2+1)
-            # +1 for whitespace
-            line_width = s.line_offset + rw + 1
             # @info "" s.line_offset rw line_width length_to(x, (NEWLINE,), start=1)
-            if line_width + extra_width <= s.margin
+            arg2 = x.nodes[end]
+            arg2.typ === CSTParser.Block && (arg2 = arg2.nodes[1])
+
+            line_width = 0
+            can_unnest = false
+            if arg2.typ === CSTParser.BinaryOpCall
+                line_width = s.line_offset + 1 + length(x.nodes[end])
+                can_unnest = line_width + extra_width <= s.margin
+            else
+                rw, _ = length_to(x, (NEWLINE,), start = i2 + 1)
+                line_width = s.line_offset + 1 + rw
+                can_unnest = line_width + extra_width <= s.margin
+            end
+
+            if can_unnest
                 x.nodes[i1] = Whitespace(1)
                 if has_eq
                     x.nodes[i2] = Placeholder(0)
-                    arg2 = x.nodes[end]
 
                     if !is_leaf(arg2)
                         add_indent!(arg2, s, -s.indent_size)
-                        arg2.typ === CSTParser.Block && (arg2 = arg2.nodes[1])
 
                         # There might need to be an additional
-                        if arg2.typ in (CSTParser.TupleH, CSTParser.Vect, CSTParser.Vcat, CSTParser.Braces, CSTParser.Call, CSTParser.Curly, CSTParser.MacroCall, CSTParser.Ref, CSTParser.TypedVcat)
+                        if arg2.typ in (
+                            CSTParser.TupleH,
+                            CSTParser.Vect,
+                            CSTParser.Vcat,
+                            CSTParser.Braces,
+                            CSTParser.Call,
+                            CSTParser.Curly,
+                            CSTParser.MacroCall,
+                            CSTParser.Ref,
+                            CSTParser.TypedVcat,
+                        )
                             close_indent = arg2.nodes[end].indent
-                            diff = min(s.indent_size - arg2.indent, line_width - arg2.indent) 
+                            diff = min(
+                                s.indent_size - arg2.indent,
+                                line_width - arg2.indent,
+                            )
                             add_indent!(arg2, s, diff)
                             arg2.nodes[end].indent = close_indent
                         end
@@ -523,7 +544,7 @@ function n_binarycall!(x, s; extra_width = 0)
         if idx !== nothing && idx > 1
             return_width = length(x.nodes[idx].nodes[1]) + length(x.nodes[2])
         elseif idx === nothing
-            return_width, _ = length_to(x, (PLACEHOLDER, NEWLINE), start=2)
+            return_width, _ = length_to(x, (PLACEHOLDER, NEWLINE), start = 2)
         end
 
         # @info "" return_width

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -33,6 +33,7 @@ function reset_line_offset!(x::PTree, s::State)
     s.line_offset += length(x)
 end
 
+
 function add_indent!(x, s, indent)
     indent == 0 && return
     lo = s.line_offset
@@ -78,11 +79,11 @@ function nest!(x::PTree, s::State; extra_width = 0)
     elseif x.typ === CSTParser.BinaryOpCall
         n_binarycall!(x, s, extra_width = extra_width)
     elseif x.typ === CSTParser.Curly
-        n_curly!(x, s, extra_width = extra_width)
+        n_call!(x, s, extra_width = extra_width)
     elseif x.typ === CSTParser.Call
         n_call!(x, s, extra_width = extra_width)
     elseif x.typ === CSTParser.MacroCall
-        n_macrocall!(x, s, extra_width = extra_width)
+        n_call!(x, s, extra_width = extra_width)
     elseif x.typ === CSTParser.Ref
         n_call!(x, s, extra_width = extra_width)
     elseif x.typ === CSTParser.ChainOpCall
@@ -92,17 +93,17 @@ function nest!(x::PTree, s::State; extra_width = 0)
     elseif x.typ === CSTParser.TupleH
         n_tuple!(x, s, extra_width = extra_width)
     elseif x.typ === CSTParser.Vect
-        n_vect!(x, s, extra_width = extra_width)
+        n_tuple!(x, s, extra_width = extra_width)
     elseif x.typ === CSTParser.Vcat
-        n_vect!(x, s, extra_width = extra_width)
+        n_tuple!(x, s, extra_width = extra_width)
     elseif x.typ === CSTParser.TypedVcat
         n_call!(x, s, extra_width = extra_width)
     elseif x.typ === CSTParser.StringH
         n_stringh!(x, s, extra_width = extra_width)
     elseif x.typ === CSTParser.Parameters
-        n_params!(x, s, extra_width = extra_width)
+        n_tuple!(x, s, extra_width = extra_width)
     elseif x.typ === CSTParser.Braces
-        n_braces!(x, s, extra_width = extra_width)
+        n_tuple!(x, s, extra_width = extra_width)
     elseif x.typ === CSTParser.InvisBrackets
         n_invisbrackets!(x, s, extra_width = extra_width)
     elseif x.typ === CSTParser.UnaryOpCall && x.nodes[2].typ === CSTParser.OPERATOR
@@ -188,10 +189,7 @@ function n_tuple!(x, s; extra_width = 0)
         x.indent += s.indent_size
         if x.indent - s.line_offset > 1
             x.indent = s.line_offset
-            if opener
-                x.indent += 1
-                x.nodes[end].indent = s.line_offset
-            end
+            opener && (x.indent += 1)
         end
 
         # @debug "DURING" x.indent s.line_offset x.typ
@@ -242,10 +240,6 @@ function n_stringh!(x, s; extra_width = 0)
     nest!(x.nodes, s, x.indent, extra_width = extra_width)
 end
 
-n_braces!(x, s; extra_width = 0) = n_tuple!(x, s, extra_width = extra_width)
-n_vect!(x, s; extra_width = 0) = n_tuple!(x, s, extra_width = extra_width)
-n_params!(x, s; extra_width = 0) = n_tuple!(x, s, extra_width = extra_width)
-
 function n_call!(x, s; extra_width = 0)
     line_width = s.line_offset + length(x) + extra_width
     idx = findlast(n -> n.typ === PLACEHOLDER, x.nodes)
@@ -295,9 +289,6 @@ function n_call!(x, s; extra_width = 0)
         nest!(x.nodes, s, x.indent, extra_width = extra_width)
     end
 end
-
-n_curly!(x, s; extra_width = 0) = n_call!(x, s, extra_width = extra_width)
-n_macrocall!(x, s; extra_width = 0) = n_call!(x, s, extra_width = extra_width)
 
 # "A where B"
 function n_wherecall!(x, s; extra_width = 0)
@@ -473,15 +464,31 @@ function n_binarycall!(x, s; extra_width = 0)
             nest!(n, s)
         end
 
-        # @debug "BEFORE RESET" x.indent s.line_offset x.typ extra_width x.nodes[i2-2] length(x.nodes[i2+1])
-        # Undo nest if possible, +1 for whitespace
+
+        # Undo nest if possible
         if !x.force_nest
-            line_width = s.line_offset + length(x.nodes[i2+1]) + extra_width + 1
-            if line_width <= s.margin
+            rw, _ =  length_to(x, (NEWLINE,), start=i2+1)
+            # +1 for whitespace
+            line_width = s.line_offset + rw + 1
+            # @info "" s.line_offset rw line_width length_to(x, (NEWLINE,), start=1)
+            if line_width + extra_width <= s.margin
                 x.nodes[i1] = Whitespace(1)
                 if has_eq
                     x.nodes[i2] = Placeholder(0)
-                    add_indent!(x.nodes[end], s, -s.indent_size)
+                    arg2 = x.nodes[end]
+
+                    if !is_leaf(arg2)
+                        add_indent!(arg2, s, -s.indent_size)
+                        arg2.typ === CSTParser.Block && (arg2 = arg2.nodes[1])
+
+                        # There might need to be an additional
+                        if arg2.typ in (CSTParser.TupleH, CSTParser.Vect, CSTParser.Vcat, CSTParser.Braces, CSTParser.Call, CSTParser.Curly, CSTParser.MacroCall, CSTParser.Ref, CSTParser.TypedVcat)
+                            close_indent = arg2.nodes[end].indent
+                            diff = min(s.indent_size - arg2.indent, line_width - arg2.indent) 
+                            add_indent!(arg2, s, diff)
+                            arg2.nodes[end].indent = close_indent
+                        end
+                    end
                 end
             end
         end

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -516,7 +516,7 @@ function n_binarycall!(x, s; extra_width = 0)
         if idx !== nothing && idx > 1
             return_width = length(x.nodes[idx].nodes[1]) + length(x.nodes[2])
         elseif idx === nothing
-            return_width, _ = length_to_newline(x, 2)
+            return_width, _ = length_to(x, (PLACEHOLDER, NEWLINE), start=2)
         end
 
         # @info "" return_width

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -1194,8 +1194,8 @@ function p_binarycall(x, s; nonest = false, nospace = false)
         add_node!(t, Whitespace(1), s)
         add_node!(t, pretty(op, s), s, join_lines = true)
         nest ? add_node!(t, Placeholder(1), s) : add_node!(t, Whitespace(1), s)
-    elseif nospace ||
-           (CSTParser.precedence(op) in (8, 13, 14, 16) && op.kind !== Tokens.ANON_FUNC)
+    elseif (nospace ||
+            (CSTParser.precedence(op) in (8, 13, 14, 16) && op.kind !== Tokens.ANON_FUNC)) && op.kind !== Tokens.IN
         add_node!(t, pretty(op, s), s, join_lines = true)
     else
         add_node!(t, Whitespace(1), s)

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -203,20 +203,18 @@ function is_prev_newline(x::PTree)
 end
 
 """
-`length_to_newline` returns the length to the next NEWLINE or PLACEHOLDER node
+    `length_to(x::PTree, ntyps; start::Int = 1)`
 
-based off the `start` index.
+Returns the length to any node type in `ntyps` based off the `start` index.
 """
-function length_to_newline(x::PTree, start = 1)
-    x.typ === NEWLINE && (return 0, true)
-    x.typ === PLACEHOLDER && (return 0, true)
-    is_leaf(x) && (return length(x), false)
+function length_to(x::PTree, ntyps; start::Int = 1)
+    x.typ in ntyps && return 0, true
+    is_leaf(x) && return length(x), false
     len = 0
     for i = start:length(x.nodes)
-        n = x.nodes[i]
-        ln, nl = length_to_newline(n)
-        len += ln
-        nl && (return len, nl)
+        l, found = length_to(x.nodes[i], ntyps)
+        len += l
+        found && return len, found
     end
     return len, false
 end

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -1118,13 +1118,13 @@ block_type(x::CSTParser.EXPR) =
 nest_assignment(x::CSTParser.EXPR) = CSTParser.is_assignment(x) && block_type(x.args[3])
 
 function nestable(x::CSTParser.EXPR)
-    CSTParser.defines_function(x) && (return true)
-    CSTParser.is_assignment(x) && (return block_type(x.args[3]))
+    CSTParser.defines_function(x) && return true
+    CSTParser.is_assignment(x) && return block_type(x.args[3])
 
     op = x.args[2]
-    op.kind === Tokens.ANON_FUNC && (return false)
-    op.kind === Tokens.PAIR_ARROW && (return false)
-    CSTParser.precedence(op) in (1, 6) && (return false)
+    op.kind === Tokens.ANON_FUNC && return false
+    op.kind === Tokens.PAIR_ARROW && return false
+    CSTParser.precedence(op) in (1, 6) && return false
     if op.kind == Tokens.LAZY_AND || op.kind == Tokens.LAZY_OR
         arg = x.args[1]
         while arg.typ === CSTParser.InvisBrackets
@@ -1194,8 +1194,8 @@ function p_binarycall(x, s; nonest = false, nospace = false)
         add_node!(t, Whitespace(1), s)
         add_node!(t, pretty(op, s), s, join_lines = true)
         nest ? add_node!(t, Placeholder(1), s) : add_node!(t, Whitespace(1), s)
-    elseif (nospace ||
-            (CSTParser.precedence(op) in (8, 13, 14, 16) && op.kind !== Tokens.ANON_FUNC)) && op.kind !== Tokens.IN
+    elseif (nospace || (CSTParser.precedence(op) in (8, 13, 14, 16) &&
+             op.kind !== Tokens.ANON_FUNC)) && op.kind !== Tokens.IN
         add_node!(t, pretty(op, s), s, join_lines = true)
     else
         add_node!(t, Whitespace(1), s)

--- a/test/files/reverse.jl
+++ b/test/files/reverse.jl
@@ -106,15 +106,14 @@ function instrument_global!(ir, v, ex)
     if istrackable(ex)
         ir[v] = xcall(Zygote, :unwrap, QuoteNode(ex), ex)
     else
-        ir[v] =
-            prewalk(ex) do x
-                istrackable(x) || return x
-                insert!(
-                    ir,
-                    v,
-                    stmt(xcall(Zygote, :unwrap, QuoteNode(x), x), type = exprtype(x)),
-                )
-            end
+        ir[v] = prewalk(ex) do x
+            istrackable(x) || return x
+            insert!(
+                ir,
+                v,
+                stmt(xcall(Zygote, :unwrap, QuoteNode(x), x), type = exprtype(x)),
+            )
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2785,9 +2785,4 @@ end
         @test fmt(str) == str
     end
 
-# @testset "meta-format" begin
-#     str = String(read("./runtests.jl"))
-#     str = fmt(str)
-# end
-
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ function fmt(s; i = 4, m = 80, always_for_in = false)
     fmt1(s1, i, m, always_for_in)
 end
 fmt(s, i, m) = fmt(s; i = i, m = m)
+fmt1(s, i, m) = fmt1(s; i = i, m = m)
 
 function run_pretty(text::String, print_width::Int)
     d = JuliaFormatter.Document(text)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -641,23 +641,22 @@ end
             body
         end"""
         str = """
-        model =
-            SDDP.LinearPolicyGraph(
-                stages = 2,
-                lower_bound = 1,
-                direct_mode = false,
-            ) do (
-                subproblem1,
-                subproblem2,
-                subproblem3,
-                subproblem4,
-                subproblem5,
-                subproblem6,
-                subproblem7,
-                subproblem8,
-            )
-                body
-            end"""
+        model = SDDP.LinearPolicyGraph(
+            stages = 2,
+            lower_bound = 1,
+            direct_mode = false,
+        ) do (
+            subproblem1,
+            subproblem2,
+            subproblem3,
+            subproblem4,
+            subproblem5,
+            subproblem6,
+            subproblem7,
+            subproblem8,
+        )
+            body
+        end"""
         @test fmt(str_) == str
 
         str_ = """
@@ -665,14 +664,13 @@ end
             body
         end"""
         str = """
-        model =
-            SDDP.LinearPolicyGraph(
-                stages = 2,
-                lower_bound = 1,
-                direct_mode = false,
-            ) do subproblem1, subproblem2
-                body
-            end"""
+        model = SDDP.LinearPolicyGraph(
+            stages = 2,
+            lower_bound = 1,
+            direct_mode = false,
+        ) do subproblem1, subproblem2
+            body
+        end"""
         @test fmt(str_) == str
 
     end
@@ -1817,6 +1815,7 @@ end
         @test fmt(str) == str
 
         @test fmt("ref[a: (b + c)]") == "ref[a:(b+c)]"
+        @test fmt("ref[a in b]") == "ref[a in b]"
     end
 
     @testset "nesting" begin
@@ -1959,15 +1958,24 @@ end
         @test fmt("foo() = (one, x -> (true, false))", 4, 30) == str
 
         str = """
-        foo() =
-            (
-             one,
-             x -> (
-                 true,
-                 false,
-             ),
-            )"""
+        foo() = (
+            one,
+            x -> (
+                true,
+                false,
+            ),
+        )"""
         @test fmt("foo() = (one, x -> (true, false))", 4, 20) == str
+
+        str = """
+        foo() = (
+                 one,
+                 x -> (
+                       true,
+                       false,
+                 ),
+        )"""
+        @test fmt("foo() = (one, x -> (true, false))", 10, 20) == str
 
         str = """
         @somemacro function (fcall_ | fcall_)


### PR DESCRIPTION
Fixes #84 

- fixes a bug where there would be no spaces are `in` in a `Ref` so `foo[a in b]` would become `foo[ainb]`. I'm leaning more towards just having spaces around ops generally, i.e. #59 and then add parens where needed, i.e. https://github.com/invenia/BlueStyle/#whitespace.
- fixes a bug where the closing punctuation in `(...), [...], {...}` would not align to the correct position. This seems have only come up if the indentation was large enough so I don't think it ever came up practically.