### PR TITLE
Project.toml: bump lower bound on Julia compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tokenize = "0796e94c-ce3b-5d07-9a54-7f471281c624"
 
 [compat]
-julia = "1"
+julia = "1.1"
 CSTParser = "0.6.2"
 Tokenize = "0.5.5"


### PR DESCRIPTION
"Fixes" #92. For a real fix, you could not use `splitpath` or copy its definition into here.