### PR TITLE
Multi variable `for`/`let`

### DIFF
--- a/src/nest.jl
+++ b/src/nest.jl
@@ -255,7 +255,7 @@ function n_for!(x, s; extra_width = 0)
     n = x.nodes[idx]
     if n.typ === NOTCODE && n.startline == n.endline
         res = get(s.doc.comments, n.startline, (0, ""))
-        res == (0, "") && deleteat!(x.nodes, idx-1)
+        res == (0, "") && deleteat!(x.nodes, idx - 1)
     end
 end
 

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -95,7 +95,7 @@ function nest!(x::PTree, s::State; extra_width = 0)
     elseif x.typ === CSTParser.Vcat
         n_tuple!(x, s, extra_width = extra_width)
     elseif x.typ === CSTParser.Block
-        n_tuple!(x, s, extra_width = extra_width, line_offset_as_indent=true)
+        n_tuple!(x, s, extra_width = extra_width, line_offset_as_indent = true)
     elseif x.typ === CSTParser.TypedVcat
         n_call!(x, s, extra_width = extra_width)
     elseif x.typ === CSTParser.StringH
@@ -175,7 +175,7 @@ function n_import!(x, s; extra_width = 0)
     end
 end
 
-function n_tuple!(x, s; extra_width = 0, line_offset_as_indent=false)
+function n_tuple!(x, s; extra_width = 0, line_offset_as_indent = false)
     line_width = s.line_offset + length(x) + extra_width
     idx = findlast(n -> n.typ === PLACEHOLDER, x.nodes)
     opener = is_opener(x.nodes[1])
@@ -187,7 +187,7 @@ function n_tuple!(x, s; extra_width = 0, line_offset_as_indent=false)
         line_offset = s.line_offset
 
 
-        if line_offset_as_indent 
+        if line_offset_as_indent
             x.indent = s.line_offset
         else
             x.indent += s.indent_size

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -922,7 +922,7 @@ function p_loop(x, s)
         eq_to_in_normalization!(x.args[2], s.always_for_in)
     end
     if x.args[2].typ === CSTParser.Block
-        add_node!(t, p_block(x.args[2], s, join_args= true), s, join_lines = true)
+        add_node!(t, p_block(x.args[2], s, join_args = true), s, join_lines = true)
         # join_args && add_node!(t, Placeholder(0), s)
     else
         add_node!(t, pretty(x.args[2], s), s, join_lines = true)

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -942,7 +942,7 @@ function p_loop(x, s)
         max_padding = s.indent_size,
     )
     s.indent -= s.indent_size
-    # @info idx t.nodes[end-2].typ
+
     # Possible newline after args if nested to act as a separator
     # to the block body.
     if x.args[2].typ === CSTParser.Block && t.nodes[end-2].typ !== NOTCODE

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -854,6 +854,7 @@ function p_let(x, s)
         else
             add_node!(t, pretty(x.args[2], s), s, join_lines = true)
         end
+        idx = length(t.nodes)
         s.indent += s.indent_size
         add_node!(
             t,
@@ -862,6 +863,11 @@ function p_let(x, s)
             max_padding = s.indent_size,
         )
         s.indent -= s.indent_size
+        # Possible newline after args if nested to act as a separator
+        # to the block body.
+        if x.args[2].typ === CSTParser.Block && t.nodes[end-2].typ !== NOTCODE
+            add_node!(t.nodes[idx], Placeholder(0), s)
+        end
         add_node!(t, pretty(x.args[end], s), s)
     else
         s.indent += s.indent_size
@@ -927,6 +933,7 @@ function p_loop(x, s)
     else
         add_node!(t, pretty(x.args[2], s), s, join_lines = true)
     end
+    idx = length(t.nodes)
     s.indent += s.indent_size
     add_node!(
         t,
@@ -935,6 +942,12 @@ function p_loop(x, s)
         max_padding = s.indent_size,
     )
     s.indent -= s.indent_size
+    # @info idx t.nodes[end-2].typ
+    # Possible newline after args if nested to act as a separator
+    # to the block body.
+    if x.args[2].typ === CSTParser.Block && t.nodes[end-2].typ !== NOTCODE
+        add_node!(t.nodes[idx], Placeholder(0), s)
+    end
     add_node!(t, pretty(x.args[4], s), s)
     t
 end

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -166,7 +166,7 @@ function add_node!(t::PTree, n::PTree, s::State; join_lines = false, max_padding
             t.nodes[idx-1], t.nodes[idx] = t.nodes[idx], t.nodes[idx-1]
         end
 
-        if n.typ === CSTParser.Parameters && n.force_nest == true
+        if n.typ === CSTParser.Parameters && n.force_nest
             t.force_nest = true
         end
     end

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -590,12 +590,12 @@ end
 
 # Block
 # length Block is the length of the longest expr
-function p_block(x, s; ignore_single_line = false, from_quote = false, join_args = false)
+function p_block(x, s; ignore_single_line = false, from_quote = false, join_body = false)
     t = PTree(x, nspaces(s))
     single_line = ignore_single_line ? false :
                   cursor_loc(s)[1] == cursor_loc(s, s.offset + x.span - 1)[1]
 
-    # @info "" from_quote single_line ignore_single_line join_args
+    # @info "" from_quote single_line ignore_single_line join_body
     for (i, a) in enumerate(x)
         n = pretty(a, s)
         if from_quote && !single_line
@@ -624,8 +624,8 @@ function p_block(x, s; ignore_single_line = false, from_quote = false, join_args
                 add_node!(t, n, s, join_lines = true)
             elseif CSTParser.is_comma(a) && i != length(x)
                 add_node!(t, n, s, join_lines = true)
-                join_args && add_node!(t, Placeholder(1), s)
-            elseif join_args
+                join_body && add_node!(t, Placeholder(1), s)
+            elseif join_body
                 add_node!(t, n, s, join_lines = true)
             else
                 add_node!(t, n, s, max_padding = 0)
@@ -850,7 +850,7 @@ function p_let(x, s)
     if length(x.args) > 3
         add_node!(t, Whitespace(1), s)
         if x.args[2].typ === CSTParser.Block
-            add_node!(t, p_block(x.args[2], s, join_args = true), s, join_lines = true)
+            add_node!(t, p_block(x.args[2], s, join_body = true), s, join_lines = true)
         else
             add_node!(t, pretty(x.args[2], s), s, join_lines = true)
         end
@@ -928,7 +928,7 @@ function p_loop(x, s)
         eq_to_in_normalization!(x.args[2], s.always_for_in)
     end
     if x.args[2].typ === CSTParser.Block
-        add_node!(t, p_block(x.args[2], s, join_args = true), s, join_lines = true)
+        add_node!(t, p_block(x.args[2], s, join_body = true), s, join_lines = true)
     else
         add_node!(t, pretty(x.args[2], s), s, join_lines = true)
     end

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -929,7 +929,6 @@ function p_loop(x, s)
     end
     if x.args[2].typ === CSTParser.Block
         add_node!(t, p_block(x.args[2], s, join_args = true), s, join_lines = true)
-        # join_args && add_node!(t, Placeholder(0), s)
     else
         add_node!(t, pretty(x.args[2], s), s, join_lines = true)
     end

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -590,11 +590,12 @@ end
 
 # Block
 # length Block is the length of the longest expr
-function p_block(x, s; ignore_single_line = false, from_quote = false)
+function p_block(x, s; ignore_single_line = false, from_quote = false, join_args = false)
     t = PTree(x, nspaces(s))
     single_line = ignore_single_line ? false :
                   cursor_loc(s)[1] == cursor_loc(s, s.offset + x.span - 1)[1]
-    # @debug "" from_quote single_line ignore_single_line
+
+    # @info "" from_quote single_line ignore_single_line join_args
     for (i, a) in enumerate(x)
         n = pretty(a, s)
         if from_quote && !single_line
@@ -611,7 +612,7 @@ function p_block(x, s; ignore_single_line = false, from_quote = false)
             if i == 1 || CSTParser.is_comma(a)
                 add_node!(t, n, s, join_lines = true)
             elseif CSTParser.is_comma(x.args[i-1])
-                add_node!(t, Whitespace(1), s)
+                add_node!(t, Placeholder(1), s)
                 add_node!(t, n, s, join_lines = true)
             else
                 add_node!(t, Semicolon(), s)
@@ -622,6 +623,9 @@ function p_block(x, s; ignore_single_line = false, from_quote = false)
             if i < length(x) && CSTParser.is_comma(a) && is_punc(x.args[i+1])
                 add_node!(t, n, s, join_lines = true)
             elseif CSTParser.is_comma(a) && i != length(x)
+                add_node!(t, n, s, join_lines = true)
+                join_args && add_node!(t, Placeholder(1), s)
+            elseif join_args
                 add_node!(t, n, s, join_lines = true)
             else
                 add_node!(t, n, s, max_padding = 0)
@@ -845,7 +849,11 @@ function p_let(x, s)
     add_node!(t, pretty(x.args[1], s), s)
     if length(x.args) > 3
         add_node!(t, Whitespace(1), s)
-        add_node!(t, pretty(x.args[2], s), s, join_lines = true)
+        if x.args[2].typ === CSTParser.Block
+            add_node!(t, p_block(x.args[2], s, join_args = true), s, join_lines = true)
+        else
+            add_node!(t, pretty(x.args[2], s), s, join_lines = true)
+        end
         s.indent += s.indent_size
         add_node!(
             t,
@@ -913,7 +921,12 @@ function p_loop(x, s)
     if x.args[1].kind === Tokens.FOR
         eq_to_in_normalization!(x.args[2], s.always_for_in)
     end
-    add_node!(t, pretty(x.args[2], s), s, join_lines = true)
+    if x.args[2].typ === CSTParser.Block
+        add_node!(t, p_block(x.args[2], s, join_args= true), s, join_lines = true)
+        # join_args && add_node!(t, Placeholder(0), s)
+    else
+        add_node!(t, pretty(x.args[2], s), s, join_lines = true)
+    end
     s.indent += s.indent_size
     add_node!(
         t,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -553,6 +553,7 @@ end
           let var1 = value1,
               var2,
               var3 = value3
+
             body
           end"""
         @test fmt(str_, 2, 1) == str
@@ -924,6 +925,7 @@ end
             # comment
             b,
             c
+
             body
         end"""
         @test fmt("""
@@ -966,7 +968,6 @@ end
         struct name
                 arg
             end""") == str
-
 
         str = """
         mutable struct name
@@ -2916,6 +2917,14 @@ end
             body
         end"""
         @test fmt(str_) == str
+
+        str_ = """
+        for a in x,
+            b in y,
+            c in z
+
+            body
+        end"""
         @test fmt(str, 4, 1) == str_
 
         str = """
@@ -2929,6 +2938,14 @@ end
             body
         end"""
         @test fmt(str_) == str
+
+        str_ = """
+        let a = x,
+            b = y,
+            c = z
+
+            body
+        end"""
         @test fmt(str, 4, 1) == str_
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2926,6 +2926,7 @@ end
             body
         end"""
         @test fmt(str, 4, 1) == str_
+        @test fmt(str_) == str
 
         str = """
         let a = x, b = y, c = z
@@ -2947,6 +2948,7 @@ end
             body
         end"""
         @test fmt(str, 4, 1) == str_
+        @test fmt(str_) == str
     end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ function fmt(s; i = 4, m = 80, always_for_in = false)
     fmt1(s1, i, m, always_for_in)
 end
 fmt(s, i, m) = fmt(s; i = i, m = m)
-fmt1(s, i, m) = fmt1(s; i = i, m = m)
+fmt1(s, i, m) = fmt1(s, i,m, false)
 
 function run_pretty(text::String, print_width::Int)
     d = JuliaFormatter.Document(text)
@@ -550,7 +550,9 @@ end
         str_ = """foo = let var1=value1,var2,var3=value3 body end"""
         str = """
         foo =
-          let var1 = value1, var2, var3 = value3
+          let var1 = value1,
+              var2,
+              var3 = value3
             body
           end"""
         @test fmt(str_, 2, 1) == str
@@ -917,12 +919,11 @@ end
           body
         end""") == str
 
-        # TODO: This should probably be aligned to match up with `a` ?
         str = """
         let x = a,
             # comment
-        b,
-        c
+            b,
+            c
             body
         end"""
         @test fmt("""
@@ -2901,6 +2902,34 @@ end
          0.5 0.5 0.5 1.0
         ]"""
         @test fmt(str) == str
+    end
+
+    @testset "multi-variable `for` and `let`" begin
+        str = """
+        for a in x, b in y, c in z
+            body
+        end"""
+        str_ = """
+        for a in x,
+            b in y,
+            c in z
+            body
+        end"""
+        @test fmt(str_) == str
+        @test fmt(str, 4, 1) == str_
+
+        str = """
+        let a = x, b = y, c = z
+            body
+        end"""
+        str_ = """
+        let a = x,
+            b = y,
+            c = z
+            body
+        end"""
+        @test fmt(str_) == str
+        @test fmt(str, 4, 1) == str_
     end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ function fmt(s; i = 4, m = 80, always_for_in = false)
     fmt1(s1, i, m, always_for_in)
 end
 fmt(s, i, m) = fmt(s; i = i, m = m)
-fmt1(s, i, m) = fmt1(s, i,m, false)
+fmt1(s, i, m) = fmt1(s, i, m, false)
 
 function run_pretty(text::String, print_width::Int)
     d = JuliaFormatter.Document(text)


### PR DESCRIPTION
Fixes #95 

At the moment this joins the arguments on 1 line and, if necessary, nests them like it would arguments in a tuple. 

TODO:

- [x] empty newline after argument and before body
