### PR TITLE
Fix implementation of splitpath

### DIFF
--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -109,7 +109,7 @@ function Document(text::AbstractString)
                 comments[line] = (ws, cs[idx:end])
             end
 
-            # There should not be more than 1 
+            # There should not be more than 1
             # "off" tag on the stack at a time.
             if occursin(r"^#!\s*format\s*:\s*off\s*$", t.val) && length(stack) == 0
                 push!(stack, t.startpos[1])
@@ -302,6 +302,13 @@ if VERSION < v"1.1.0"
     # longer supports Julia 1.0.
     _splitdir_nodrive(path::String) = _splitdir_nodrive("", path)
     function _splitdir_nodrive(a::String, b::String)
+        path_dir_splitter = if Sys.isunix()
+            r"^(.*?)(/+)([^/]*)$"
+        elseif Sys.iswindows()
+            r"^(.*?)([/\\]+)([^/\\]*)$"
+        else
+            error("JuliaFormatter.jl does not work on this OS.")
+        end
         m = match(path_dir_splitter, b)
         m === nothing && return (a, b)
         a = string(a, isempty(m.captures[1]) ? m.captures[2][1] : m.captures[1])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3085,6 +3085,6 @@ end
         dirs = JuliaFormatter.splitpath(@__DIR__)
         @test length(dirs) > 2
         @test dirs[end] == "test"
-        @test dirs[end - 1] == "JuliaFormatter"
+        @test occursin("JuliaFormatter", dirs[end - 1])
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3079,4 +3079,12 @@ end
         @test fmt(str_, 4, 60) == str
     end
 
+    @testset "Splitpath issue" begin
+        # TODO(odow): seet the TODO in src/JuliaFormatter.jl. Remove once
+        # JuliaFormatter.jl drops support for Julia 1.0.
+        dirs = splitpath(@__DIR__)
+        @test length(dirs) > 2
+        @test dirs[end] == "test"
+        @test dirs[end - 1] == "JuliaFormatter"
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3082,7 +3082,7 @@ end
     @testset "Splitpath issue" begin
         # TODO(odow): seet the TODO in src/JuliaFormatter.jl. Remove once
         # JuliaFormatter.jl drops support for Julia 1.0.
-        dirs = splitpath(@__DIR__)
+        dirs = JuliaFormatter.splitpath(@__DIR__)
         @test length(dirs) > 2
         @test dirs[end] == "test"
         @test dirs[end - 1] == "JuliaFormatter"


### PR DESCRIPTION
So I have to apologize, and own up to the fact that my fix in https://github.com/domluna/JuliaFormatter.jl/pull/94 was incorrect: `path_dir_splitter` was undefined.

It would be useful to have codecov, which would have shown that the lines I added weren't tested.