### PR TITLE
Fix paramters in macro calls and format parameters better when no preceding args

### DIFF
--- a/test/files/PProf.jl
+++ b/test/files/PProf.jl
@@ -257,8 +257,7 @@ Start or restart the go pprof webserver.
 - `webport::Integer`: Which port to launch the webserver on.
 - `file::String`: Profile file to open.
 """
-function refresh(
-    ;
+function refresh(;
     webhost::AbstractString = "localhost",
     webport::Integer = 57599,
     file::AbstractString = "profile.pb.gz",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -638,6 +638,61 @@ end
         @test fmt("func(; c = 1)", 4, 1) == "func(; c = 1)"
         @test fmt("func(; c = 1,)") == "func(; c = 1)"
         @test fmt("func(a;)") == "func(a;)"
+
+        str = """
+        func(;
+            a,
+            b,
+        )"""
+        @test fmt(str, 4, 1) == str
+
+        str = """
+        func(
+            x;
+            a,
+            b,
+        )"""
+        @test fmt(str, 4, 1) == str
+    end
+
+    @testset "macro call" begin
+        str = """
+        @f(
+           a,
+           b;
+           x
+        )"""
+        str_ = "@f(a, b; x)"
+        @test fmt(str_) == str_
+        @test fmt(str_, 4, 1) == str
+
+        str = """
+        @f(
+           a;
+           x
+        )"""
+        str_ = "@f(a; x)"
+        @test fmt(str_) == str_
+        @test fmt(str_, 4, 1) == str
+
+        str = "@f(; x)"
+        @test fmt(str) == str
+        @test fmt(str, 4, 1) == str
+
+        str = """
+        @f(;
+           a,
+           b
+        )"""
+        @test fmt(str, 4, 1) == str
+
+        str = """
+        @f(
+           x;
+           a,
+           b
+        )"""
+        @test fmt(str, 4, 1) == str
     end
 
     @testset "begin" begin
@@ -1619,13 +1674,20 @@ end
         @test fmt(str) == str
 
         str = """
+        foo(;
+            a = b, # comment
+            c = d,
+            # comment
+        )"""
+
+        str_ = """
         foo(
             ;
             a = b, # comment
             c = d,
             # comment
         )"""
-        @test fmt(str) == str
+        @test fmt(str_) == str
 
         str_ = """
         foo(


### PR DESCRIPTION
fixes #118 

Also formats parameters better when there are no preceding arguments:

then

```julia
function refresh(
    ;
    webhost::AbstractString = "localhost",
    webport::Integer = 57599,
    file::AbstractString = "profile.pb.gz",
)
```

now

```julia
function refresh(;
    webhost::AbstractString = "localhost",
    webport::Integer = 57599,
    file::AbstractString = "profile.pb.gz",
)
```