### PR TITLE
Format InvisBrackets

### DIFF
--- a/src/nest.jl
+++ b/src/nest.jl
@@ -134,23 +134,7 @@ function n_do!(x, s; extra_width = 0)
     nest!(x.nodes[2:end], s, x.indent, extra_width = extra_width)
 end
 
-function n_invisbrackets!(x, s; extra_width = 0)
-    for (i, n) in enumerate(x.nodes)
-        if n.typ === NEWLINE && x.nodes[i+1].typ === CSTParser.Block
-            s.line_offset = x.nodes[i+1].indent
-        elseif n.typ === NEWLINE
-            s.line_offset = x.indent
-        elseif n.typ === NOTCODE && x.nodes[i+1].typ === CSTParser.Block
-            s.line_offset = x.nodes[i+1].indent
-        elseif is_leaf(n)
-            s.line_offset += length(n)
-        elseif i == length(x.nodes) - 1
-            nest!(n, s, extra_width = extra_width + 1)
-        else
-            nest!(n, s, extra_width = extra_width)
-        end
-    end
-end
+n_invisbrackets!(x, s; extra_width = 0) = n_tuple!(x, s, extra_width = extra_width)
 
 # Import,Using,Export,ImportAll
 function n_import!(x, s; extra_width = 0)

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -450,7 +450,7 @@ function n_binarycall!(x, s; extra_width = 0)
                  x.nodes[end].typ === CSTParser.InvisBrackets
     # arg2_invis = false
     # @info "ENTERING" x.typ extra_width s.line_offset length(x) idxs x.ref[][2]
-    if length(idxs) == 2 && (line_width > s.margin || x.force_nest) && !invis_args
+    if length(idxs) == 2 && (line_width > s.margin && !invis_args || x.force_nest)
         line_offset = s.line_offset
         i1 = idxs[1]
         i2 = idxs[2]

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -1443,7 +1443,8 @@ end
 # InvisBrackets
 function p_invisbrackets(x, s; nonest = false, nospace = false)
     t = PTree(x, nspaces(s))
-    multi_arg = length(x) > 4
+    parent_invis = x[2].typ === CSTParser.InvisBrackets
+    # @info "" x parent_invis
 
     for (i, a) in enumerate(x)
         if a.typ === CSTParser.Block
@@ -1462,15 +1463,14 @@ function p_invisbrackets(x, s; nonest = false, nospace = false)
                 s,
                 join_lines = true,
             )
-        elseif is_opener(a) && multi_arg
+        elseif is_opener(a) && !parent_invis && !nonest
+            # @info "opening"
             add_node!(t, pretty(a, s), s, join_lines = true)
             add_node!(t, Placeholder(0), s)
-        elseif is_closer(a) && multi_arg
+        elseif is_closer(a) && !parent_invis && !nonest
+            # @info "closing"
             add_node!(t, Placeholder(0), s)
             add_node!(t, pretty(a, s), s, join_lines = true)
-        elseif CSTParser.is_comma(a) && i < length(x) && !is_punc(x.args[i+1])
-            add_node!(t, pretty(a, s), s, join_lines = true)
-            add_node!(t, Placeholder(1), s)
         else
             add_node!(t, pretty(a, s), s, join_lines = true)
         end

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -1283,8 +1283,10 @@ function p_binarycall(x, s; nonest = false, nospace = false)
         add_node!(t, Whitespace(1), s)
         add_node!(t, pretty(op, s), s, join_lines = true)
         nest ? add_node!(t, Placeholder(1), s) : add_node!(t, Whitespace(1), s)
-    elseif (nospace || (CSTParser.precedence(op) in (8, 13, 14, 16) &&
-             op.kind !== Tokens.ANON_FUNC)) && op.kind !== Tokens.IN
+    elseif (
+        nospace ||
+        (CSTParser.precedence(op) in (8, 13, 14, 16) && op.kind !== Tokens.ANON_FUNC)
+    ) && op.kind !== Tokens.IN
         add_node!(t, pretty(op, s), s, join_lines = true)
     else
         add_node!(t, Whitespace(1), s)

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -58,8 +58,7 @@ is_comma(x::PTree) =
 is_comment(x::PTree) = x.typ === INLINECOMMENT || x.typ === NOTCODE
 
 is_colon_op(x) =
-    (x.typ === CSTParser.BinaryOpCall && x.args[2].kind === Tokens.COLON) ||
-    x.typ === CSTParser.ColonOpCall
+    (x.typ === CSTParser.BinaryOpCall && x.args[2].kind === Tokens.COLON) || x.typ === CSTParser.ColonOpCall
 
 # f a function which returns a bool
 function parent_is(x, f; ignore_typs = (CSTParser.InvisBrackets,))
@@ -507,8 +506,9 @@ function p_literal(x, s)
     # Tokenize treats the `ix` part of r"^(=?[^=]+)=(.*)$"ix as an
     # IDENTIFIER where as CSTParser parses it as a LITERAL.
     # An IDENTIFIER won't show up in the string literal lookup table.
-    if str_info === nothing &&
-       (x.parent.typ === CSTParser.x_Str || x.parent.typ === CSTParser.x_Cmd)
+    if str_info === nothing && (
+        x.parent.typ === CSTParser.x_Str || x.parent.typ === CSTParser.x_Cmd
+    )
         s.offset += x.fullspan
         return PTree(x, loc[1], loc[1], x.val)
     end
@@ -1284,8 +1284,9 @@ function p_binarycall(x, s; nonest = false, nospace = false)
         add_node!(t, pretty(op, s), s, join_lines = true)
         nest ? add_node!(t, Placeholder(1), s) : add_node!(t, Whitespace(1), s)
     elseif (
-        nospace ||
-        (CSTParser.precedence(op) in (8, 13, 14, 16) && op.kind !== Tokens.ANON_FUNC)
+        nospace || (
+            CSTParser.precedence(op) in (8, 13, 14, 16) && op.kind !== Tokens.ANON_FUNC
+        )
     ) && op.kind !== Tokens.IN
         add_node!(t, pretty(op, s), s, join_lines = true)
     else

--- a/test/files/Docs.jl
+++ b/test/files/Docs.jl
@@ -280,8 +280,8 @@ function astname(x::Expr, ismacro::Bool)
     if isexpr(x, :.)
         ismacro ? macroname(x) : x
     # Call overloading, e.g. `(a::A)(b) = b` or `function (a::A)(b) b end` should document `A(b)`
-    elseif (isexpr(x, :function) || isexpr(x, :(=))) &&
-           isexpr(x.args[1], :call) && isexpr(x.args[1].args[1], :(::))
+    elseif (isexpr(x, :function) || isexpr(x, :(=))) && isexpr(x.args[1], :call) &&
+                                                        isexpr(x.args[1].args[1], :(::))
         return astname(x.args[1].args[1].args[end], ismacro)
     else
         n = isexpr(x, (:module, :struct)) ? 2 : 1
@@ -297,8 +297,9 @@ macroname(x::Expr) = Expr(x.head, x.args[1], macroname(x.args[end].value))
 
 isfield(@nospecialize x) =
     isexpr(x, :.) &&
-    (isa(x.args[1], Symbol) || isfield(x.args[1])) &&
-    (isa(x.args[2], QuoteNode) || isexpr(x.args[2], :quote))
+    (isa(x.args[1], Symbol) || isfield(x.args[1])) && (
+        isa(x.args[2], QuoteNode) || isexpr(x.args[2], :quote)
+    )
 
 # @doc expression builders.
 # =========================
@@ -342,8 +343,9 @@ function metadata(__source__, __module__, expr, ismodule)
                 break
             elseif isa(each, String) ||
                    isexpr(each, :string) ||
-                   isexpr(each, :call) ||
-                   (isexpr(each, :macrocall) && each.args[1] === Symbol("@doc_str"))
+                   isexpr(each, :call) || (
+                isexpr(each, :macrocall) && each.args[1] === Symbol("@doc_str")
+            )
                 # forms that might be doc strings
                 last_docstr = each
             end

--- a/test/files/reverse.jl
+++ b/test/files/reverse.jl
@@ -48,18 +48,16 @@ unwrapquote(x) = x
 unwrapquote(x::QuoteNode) = x.value
 
 is_literal_getproperty(ex) =
-    (iscall(ex, Base, :getproperty) ||
-     iscall(ex, Core, :getfield) || iscall(ex, Base, :getfield)) &&
-    ex.args[3] isa Union{QuoteNode,Integer}
+    (
+     iscall(ex, Base, :getproperty) ||
+     iscall(ex, Core, :getfield) || iscall(ex, Base, :getfield)
+    ) && ex.args[3] isa Union{QuoteNode,Integer}
 
 function instrument_getproperty!(ir, v, ex)
     is_literal_getproperty(ex) ?
-    (ir[v] = xcall(
-        Zygote,
-        :literal_getproperty,
-        ex.args[2],
-        Val(unwrapquote(ex.args[3])),
-    )) :
+    (
+     ir[v] = xcall(Zygote, :literal_getproperty, ex.args[2], Val(unwrapquote(ex.args[3])))
+    ) :
     ex
 end
 
@@ -79,13 +77,15 @@ is_literal_iterate(ex) =
 
 function instrument_iterate!(ir, v, ex)
     is_literal_iterate(ex) ?
-    (ir[v] = xcall(
-        Zygote,
-        :literal_indexed_iterate,
-        ex.args[2],
-        Val(unwrapquote(ex.args[3])),
-        ex.args[4:end]...,
-    )) :
+    (
+     ir[v] = xcall(
+         Zygote,
+         :literal_indexed_iterate,
+         ex.args[2],
+         Val(unwrapquote(ex.args[3])),
+         ex.args[4:end]...,
+     )
+    ) :
     ex
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2269,83 +2269,6 @@ end
         )"""
         @test fmt("(arg1)", 4, 1) == str
 
-        str_ = """
-        begin
-        if foo
-        elseif baz
-        elseif (a || b) && c
-        elseif bar
-        else
-        end
-        end"""
-
-        str = """
-        begin
-            if foo
-            elseif baz
-            elseif (a || b) && c
-            elseif bar
-            else
-            end
-        end"""
-        @test fmt(str_, 4, 24) == str
-
-        str = """
-        begin
-            if foo
-            elseif baz
-            elseif (a || b) &&
-                   c
-            elseif bar
-            else
-            end
-        end"""
-        @test fmt(str_, 4, 23) == str
-
-        str = """
-        begin
-            if foo
-            elseif baz
-            elseif (
-                a || b
-            ) && c
-            elseif bar
-            else
-            end
-        end"""
-        @test fmt(str_, 4, 21) == str
-        @test fmt(str_, 4, 15) == str
-
-        str = """
-        begin
-            if foo
-            elseif baz
-            elseif (
-                a ||
-                b
-            ) && c
-            elseif bar
-            else
-            end
-        end"""
-        @test fmt(str_, 4, 14) == str
-        @test fmt(str_, 4, 11) == str
-
-        str = """
-        begin
-            if foo
-            elseif baz
-            elseif (
-                a ||
-                b
-            ) &&
-            c
-            elseif bar
-            else
-            end
-        end"""
-        @test_broken fmt(str_, 4, 10) == str
-        @test_broken fmt(str_, 4, 1) == str
 
 
         # https://github.com/domluna/JuliaFormatter.jl/issues/9#issuecomment-481607068
@@ -2568,6 +2491,19 @@ end
           b = 2,
         )"""
         @test fmt("f(a=1; b=2)", 4, 1) == str
+
+        str = """
+        begin
+            if foo
+            elseif baz
+            elseif a ||
+                   b &&
+                   c
+            elseif bar
+            else
+            end
+        end"""
+        @test fmt(str, 4, 1) == str
     end
 
     @testset "nesting line offset" begin
@@ -3269,6 +3205,76 @@ some_function(
                 end
         end"""
         @test fmt(str, 8, 92) == str
+
+        #
+        # Don't nest the op if an arg is invisbrackets
+        #
+
+        str_ = """
+        begin
+        if foo
+        elseif baz
+        elseif (a || b) && c
+        elseif bar
+        else
+        end
+        end"""
+
+        str = """
+        begin
+            if foo
+            elseif baz
+            elseif (a || b) && c
+            elseif bar
+            else
+            end
+        end"""
+        @test fmt(str_, 4, 24) == str
+        @test fmt(str_, 4, 23) == str
+
+        str = """
+        begin
+            if foo
+            elseif baz
+            elseif (
+                a || b
+            ) && c
+            elseif bar
+            else
+            end
+        end"""
+        @test fmt(str_, 4, 21) == str
+        @test fmt(str_, 4, 15) == str
+
+        str = """
+        begin
+            if foo
+            elseif baz
+            elseif (
+                a ||
+                b
+            ) && c
+            elseif bar
+            else
+            end
+        end"""
+        @test fmt(str_, 4, 14) == str
+        @test fmt(str_, 4, 10) == str
+
+        str = """
+        begin
+            if foo
+            elseif baz
+            elseif (
+                a ||
+                b
+            ) && c
+            elseif bar
+            else
+            end
+        end"""
+        @test fmt(str_, 4, 9) == str
+        @test fmt(str_, 4, 1) == str
     end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -407,10 +407,12 @@ end
         str = raw"""
         if x
             if y
-                :($lhs = fffffffffffffffffffffff(
-                    xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
-                    yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy,
-                ))
+                :(
+                  $lhs = fffffffffffffffffffffff(
+                      xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
+                      yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy,
+                  )
+                )
             end
         end"""
         @test fmt(str) == str
@@ -2216,10 +2218,20 @@ end
 
         str = "(a; b; c)"
         @test fmt("(a;b;c)", 4, 100) == str
+
+        str = """
+        (
+         a; b; c
+        )"""
         @test fmt("(a;b;c)", 4, 1) == str
 
         str = "(x for x = 1:10)"
         @test fmt("(x   for x  in  1 : 10)", 4, 100) == str
+
+        str = """
+        (
+         x for x = 1:10
+        )"""
         @test fmt("(x   for x  in  1 : 10)", 4, 1) == str
 
         # indent for TupleH with no parens
@@ -2251,8 +2263,11 @@ end
         str = "{arg1}"
         @test fmt(str, 4, 1) == str
 
-        str = "(arg1)"
-        @test fmt(str, 4, 1) == str
+        str = """
+        (
+         arg1
+        )"""
+        @test fmt("(arg1)", 4, 1) == str
 
         str_ = """
         begin
@@ -2268,27 +2283,12 @@ end
         begin
             if foo
             elseif baz
-            elseif (a ||
-                    b) && c
+            elseif (a || b) && c
             elseif bar
             else
             end
         end"""
-        @test fmt(str_, 4, 21) == str
-        @test fmt(str_, 4, 19) == str
-
-        str = """
-        begin
-            if foo
-            elseif baz
-            elseif (a ||
-                    b) &&
-                   c
-            elseif bar
-            else
-            end
-        end"""
-        @test fmt(str_, 4, 18) == str
+        @test fmt(str_, 4, 24) == str
 
         str = """
         begin
@@ -2301,18 +2301,52 @@ end
             end
         end"""
         @test fmt(str_, 4, 23) == str
-        @test fmt(str_, 4, 22) == str
 
         str = """
         begin
             if foo
             elseif baz
-            elseif (a || b) && c
+            elseif (
+                a || b
+            ) && c
             elseif bar
             else
             end
         end"""
-        @test fmt(str_, 4, 24) == str
+        @test fmt(str_, 4, 21) == str
+        @test fmt(str_, 4, 15) == str
+
+        str = """
+        begin
+            if foo
+            elseif baz
+            elseif (
+                a ||
+                b
+            ) && c
+            elseif bar
+            else
+            end
+        end"""
+        @test fmt(str_, 4, 14) == str
+        @test fmt(str_, 4, 11) == str
+
+        str = """
+        begin
+            if foo
+            elseif baz
+            elseif (
+                a ||
+                b
+            ) &&
+            c
+            elseif bar
+            else
+            end
+        end"""
+        @test_broken fmt(str_, 4, 10) == str
+        @test_broken fmt(str_, 4, 1) == str
+
 
         # https://github.com/domluna/JuliaFormatter.jl/issues/9#issuecomment-481607068
         str = """
@@ -2420,36 +2454,74 @@ end
         str_ = "(a + b + c + d)"
         @test fmt(str_, 4, 15) == str_
 
-        str = "(a + b + c +\n d)"
+        str = """
+        (
+         a + b + c +
+         d
+        )"""
         @test fmt(str_, 4, 14) == str
         @test fmt(str_, 4, 12) == str
 
-        str = "(a + b +\n c + d)"
+        str = """
+        (
+         a + b +
+         c + d
+        )"""
         @test fmt(str_, 4, 11) == str
         @test fmt(str_, 4, 8) == str
 
-        str = "(a +\n b +\n c + d)"
+        str = """
+        (
+         a +
+         b +
+         c + d
+        )"""
         @test fmt(str_, 4, 7) == str
 
-        str = "(a +\n b +\n c +\n d)"
+        str = """
+        (
+         a +
+         b +
+         c +
+         d
+        )"""
         @test fmt(str_, 4, 1) == str
 
         str_ = "(a <= b <= c <= d)"
         @test fmt(str_, 4, 18) == str_
 
-        str = "(a <= b <= c <=\n d)"
+        str = """
+        (
+         a <= b <= c <=
+         d
+        )"""
         @test fmt(str_, 4, 17) == str
         @test fmt(str_, 4, 15) == str
 
-        str = "(a <= b <=\n c <= d)"
+        str = """
+        (
+         a <= b <=
+         c <= d
+        )"""
         @test fmt(str_, 4, 14) == str
         @test fmt(str_, 4, 10) == str
 
-        str = "(a <=\n b <=\n c <= d)"
+        str = """
+        (
+         a <=
+         b <=
+         c <= d
+        )"""
         @test fmt(str_, 4, 9) == str
         @test fmt(str_, 4, 8) == str
 
-        str = "(a <=\n b <=\n c <=\n d)"
+        str = """
+        (
+         a <=
+         b <=
+         c <=
+         d
+        )"""
         @test fmt(str_, 4, 7) == str
         @test fmt(str_, 4, 1) == str
 
@@ -3149,4 +3221,54 @@ end
         @test dirs[end] == "test"
         @test occursin("JuliaFormatter", dirs[end-1])
     end
+
+    @testset "invisbrackets" begin
+        str = """
+        some_function(
+            (((
+               very_very_very_very_very_very_very_very_very_very_very_very_long_function_name(
+                   very_very_very_very_very_very_very_very_very_very_very_very_long_argument,
+                   very_very_very_very_very_very_very_very_very_very_very_very_long_argument,
+               ) for x in xs
+            ))),
+            another_argument,
+        )"""
+        @test fmt(str) == str
+
+        str_ = """
+some_function(
+(((
+               very_very_very_very_very_very_very_very_very_very_very_very_long_function_name(
+                   very_very_very_very_very_very_very_very_very_very_very_very_long_argument,
+                   very_very_very_very_very_very_very_very_very_very_very_very_long_argument,
+               )
+               for x in xs
+               ))),
+           another_argument,
+       )"""
+       @test fmt(str_) == str
+
+       str = """
+       if ((
+         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ||
+         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ||
+         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+       ))
+         nothing
+       end"""
+       @test fmt(str,2,92) == str
+
+       str = """
+       begin
+               if ((
+                    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ||
+                    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ||
+                    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+               ))
+                       nothing
+               end
+       end"""
+       @test fmt(str,8,92) == str
+    end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3246,29 +3246,29 @@ some_function(
                ))),
            another_argument,
        )"""
-       @test fmt(str_) == str
+        @test fmt(str_) == str
 
-       str = """
-       if ((
-         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ||
-         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ||
-         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-       ))
-         nothing
-       end"""
-       @test fmt(str,2,92) == str
+        str = """
+        if ((
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ||
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ||
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        ))
+          nothing
+        end"""
+        @test fmt(str, 2, 92) == str
 
-       str = """
-       begin
-               if ((
-                    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ||
-                    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ||
-                    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-               ))
-                       nothing
-               end
-       end"""
-       @test fmt(str,8,92) == str
+        str = """
+        begin
+                if ((
+                     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ||
+                     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ||
+                     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+                ))
+                        nothing
+                end
+        end"""
+        @test fmt(str, 8, 92) == str
     end
 
 end


### PR DESCRIPTION
This allows nesting InvisBrackets if it has no child InvisBrackets. 

If InvisBrackets is either arg of a BinaryOpCall the op will not be nested unless forced. This avoids a complication which can occur and the formatted output turns out better anyway.

fixes #117, solves part of #116