### PR TITLE
Format Generators + other stuff I stumbled into

### DIFF
--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -223,6 +223,7 @@ function format_text(
     hascomment(s.doc, t.endline) && (add_node!(t, InlineComment(t.endline), s))
     nest!(t, s)
 
+    s.line_offset = 0
     io = IOBuffer()
 
     # Print comments and whitespace before code.

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -446,11 +446,8 @@ function n_binarycall!(x, s; extra_width = 0)
     # If there's no placeholder the binary call is not nestable
     idxs = findall(n -> n.typ === PLACEHOLDER, x.nodes)
     line_width = s.line_offset + length(x) + extra_width
-    invis_args = x.nodes[1].typ === CSTParser.InvisBrackets ||
-                 x.nodes[end].typ === CSTParser.InvisBrackets
-    # arg2_invis = false
     # @info "ENTERING" x.typ extra_width s.line_offset length(x) idxs x.ref[][2]
-    if length(idxs) == 2 && (line_width > s.margin && !invis_args || x.force_nest)
+    if length(idxs) == 2 && (line_width > s.margin || x.force_nest)
         line_offset = s.line_offset
         i1 = idxs[1]
         i2 = idxs[2]

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -99,8 +99,6 @@ function nest!(x::PTree, s::State; extra_width = 0)
         n_for!(x, s, extra_width = extra_width)
     elseif x.typ === CSTParser.TypedVcat
         n_call!(x, s, extra_width = extra_width)
-    elseif x.typ === CSTParser.StringH
-        n_stringh!(x, s, extra_width = extra_width)
     elseif x.typ === CSTParser.Parameters
         n_tuple!(x, s, extra_width = extra_width)
     elseif x.typ === CSTParser.Braces
@@ -215,21 +213,6 @@ function n_tuple!(x, s; extra_width = 0)
         opener && (extra_width += 1)
         nest!(x.nodes, s, x.indent, extra_width = extra_width)
     end
-end
-
-
-function n_stringh!(x, s; extra_width = 0)
-    # The indent of StringH is set to the the offset
-    # of when the quote is first encountered in the source file.
-
-    # This difference notes if there is a change due to nesting.
-    diff = x.indent - s.line_offset
-    # @info "" x.indent s.line_offset diff max(x.nodes[1].indent - diff, 0)
-
-    # The new indent for the string is index of when a character in
-    # the multiline string is FIRST encountered in the source file - the above difference
-    diff != 0 && (x.indent = max(x.nodes[1].indent - diff, 0))
-    nest!(x.nodes, s, x.indent, extra_width = extra_width)
 end
 
 function n_for!(x, s; extra_width = 0)

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -224,10 +224,11 @@ function n_stringh!(x, s; extra_width = 0)
 
     # This difference notes if there is a change due to nesting.
     diff = x.indent - s.line_offset
+    @info "" x.indent s.line_offset diff max(x.nodes[1].indent - diff, 0)
 
     # The new indent for the string is index of when a character in
     # the multiline string is FIRST encountered in the source file - the above difference
-    x.indent = max(x.nodes[1].indent - diff, 0)
+    diff > 0 && (x.indent = max(x.nodes[1].indent - diff, 0))
     nest!(x.nodes, s, x.indent, extra_width = extra_width)
 end
 
@@ -488,7 +489,7 @@ function n_binarycall!(x, s; extra_width = 0)
                 line_width = s.line_offset + 1 + length(x.nodes[end])
                 can_unnest = line_width + extra_width <= s.margin
             else
-                rw, _ = length_to(x, (NEWLINE,), start = i2 + 1)
+                rw, _ = length_to(x, [NEWLINE], start = i2 + 1)
                 line_width = s.line_offset + 1 + rw
                 can_unnest = line_width + extra_width <= s.margin
             end
@@ -547,7 +548,7 @@ function n_binarycall!(x, s; extra_width = 0)
         if idx !== nothing && idx > 1
             return_width = length(x.nodes[idx].nodes[1]) + length(x.nodes[2])
         elseif idx === nothing
-            return_width, _ = length_to(x, (PLACEHOLDER, NEWLINE), start = 2)
+            return_width, _ = length_to(x, [PLACEHOLDER, NEWLINE], start = 2)
         end
 
         # @info "" return_width

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -238,7 +238,7 @@ end
 function n_call!(x, s; extra_width = 0)
     line_width = s.line_offset + length(x) + extra_width
     idx = findlast(n -> n.typ === PLACEHOLDER, x.nodes)
-    # @info "ENTERING" x.typ s.line_offset length(x) extra_width s.margin
+    # @info "ENTERING" x.typ s.line_offset length(x) extra_width s.margin x.nodes[1].val
     if idx !== nothing && (line_width > s.margin || x.force_nest)
         x.nodes[end].indent = x.indent
         line_offset = s.line_offset

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -355,17 +355,18 @@ function n_wherecall!(x, s; extra_width = 0)
             (!is_leaf(n) || n.typ === CSTParser.IDENTIFIER) && (last_typ = n.typ)
         end
 
+
         # @info "" s.line_offset x.typ extra_width has_braces
 
         # Properly reset line offset in the case the last
         # argument is an IDENTIFIER.
         # if over && has_braces && last_typ === CSTParser.IDENTIFIER && x.nodes[end-2].typ === TRAILINGCOMMA
-        if over &&
-           has_braces &&
-           last_typ === CSTParser.IDENTIFIER && x.nodes[end-2].typ === TRAILINGCOMMA
+        if over && has_braces
             s.line_offset = x.nodes[end].indent + 1
         end
 
+        # s.line_offset = line_offset
+        # walk(reset_line_offset!, x, s)
         # @info "" s.line_offset x.typ extra_width has_braces
     else
         nest!(x.nodes, s, x.indent, extra_width = extra_width)

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -224,11 +224,11 @@ function n_stringh!(x, s; extra_width = 0)
 
     # This difference notes if there is a change due to nesting.
     diff = x.indent - s.line_offset
-    @info "" x.indent s.line_offset diff max(x.nodes[1].indent - diff, 0)
+    # @info "" x.indent s.line_offset diff max(x.nodes[1].indent - diff, 0)
 
     # The new indent for the string is index of when a character in
     # the multiline string is FIRST encountered in the source file - the above difference
-    diff > 0 && (x.indent = max(x.nodes[1].indent - diff, 0))
+    diff != 0 && (x.indent = max(x.nodes[1].indent - diff, 0))
     nest!(x.nodes, s, x.indent, extra_width = extra_width)
 end
 

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -549,11 +549,21 @@ function p_literal(x, s)
 
     # @debug "" lines x.val loc loc[2] sidx
 
-    t = PTree(CSTParser.StringH, -1, -1, loc[2]-1, 0, nothing, PTree[], Ref(x), false)
+    t = PTree(CSTParser.StringH, -1, -1, loc[2] - 1, 0, nothing, PTree[], Ref(x), false)
     for (i, l) in enumerate(lines)
         ln = startline + i - 1
         l = i == 1 ? l : l[sidx:end]
-        tt = PTree(CSTParser.LITERAL, ln, ln, sidx-1, length(l), l, nothing, nothing, false)
+        tt = PTree(
+            CSTParser.LITERAL,
+            ln,
+            ln,
+            sidx - 1,
+            length(l),
+            l,
+            nothing,
+            nothing,
+            false,
+        )
         add_node!(t, tt, s)
     end
     t
@@ -584,11 +594,21 @@ function p_stringh(x, s)
 
     # @debug "" lines x.val loc loc[2] sidx
 
-    t = PTree(x, loc[2]-1)
+    t = PTree(x, loc[2] - 1)
     for (i, l) in enumerate(lines)
         ln = startline + i - 1
         l = i == 1 ? l : l[sidx:end]
-        tt = PTree(CSTParser.LITERAL, ln, ln, sidx-1, length(l), l, nothing, nothing, false)
+        tt = PTree(
+            CSTParser.LITERAL,
+            ln,
+            ln,
+            sidx - 1,
+            length(l),
+            l,
+            nothing,
+            nothing,
+            false,
+        )
         add_node!(t, tt, s)
     end
     t

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -1195,6 +1195,7 @@ closing_punc_type(x) =
     x.typ === CSTParser.Curly ||
     x.typ === CSTParser.Comprehension ||
     x.typ === CSTParser.MacroCall ||
+    x.typ === CSTParser.InvisBrackets ||
     x.typ === CSTParser.Ref || x.typ === CSTParser.TypedVcat
 
 # TODO: think of a better name?

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -130,7 +130,8 @@ function add_node!(t::PTree, n::PTree, s::State; join_lines = false, max_padding
         en = t.nodes[end]
         if en.typ === CSTParser.Generator ||
            en.typ === CSTParser.Filter ||
-           en.typ === CSTParser.Flatten || en.typ === CSTParser.MacroCall
+           en.typ === CSTParser.Flatten || en.typ === CSTParser.MacroCall ||
+           (is_comma(en) && t.typ === CSTParser.TupleH && n_args(t.ref[]) == 1)
             # don't insert trailing comma in these cases
         elseif is_comma(en)
             t.nodes[end] = n
@@ -1483,12 +1484,7 @@ end
 # TupleH
 function p_tuple(x, s)
     t = PTree(x, nspaces(s))
-    multi_arg = false
-    if CSTParser.is_lparen(x.args[1]) && length(x) > 2
-        multi_arg = true
-    elseif !CSTParser.is_lparen(x.args[1]) && length(x) > 0
-        multi_arg = true
-    end
+    multi_arg = n_args(x) > 0
 
     for (i, a) in enumerate(x)
         n = pretty(a, s)

--- a/src/print.jl
+++ b/src/print.jl
@@ -92,13 +92,13 @@ function print_stringh(io::IOBuffer, x::PTree, s::State)
     # of when the quote is first encountered in the source file.
 
     # This difference notes if there is a change due to nesting.
-    diff = x.indent - s.line_offset
+    diff = x.indent + 1 - s.line_offset
     # @info "" length(x) s.line_offset
 
     # The new indent for the string is index of when a character in
     # the multiline string is FIRST encountered in the source file - the above difference
-    # diff != 0 && (x.indent = max(x.nodes[1].indent - diff, 0))
-    x.indent = max(x.nodes[1].indent - diff, 0)
+    # +1 since the character is 1 space after the indent
+    x.indent = max(x.nodes[1].indent + 1 - diff, 0)
     print_tree(io, x, s)
 end
 

--- a/src/print.jl
+++ b/src/print.jl
@@ -52,6 +52,7 @@ function print_leaf(io::IOBuffer, x::PTree, s::State)
     else
         s.on && write(io, x.val)
     end
+    s.line_offset += length(x)
 end
 
 function print_tree(io::IOBuffer, x::PTree, s::State)
@@ -59,24 +60,46 @@ function print_tree(io::IOBuffer, x::PTree, s::State)
         print_leaf(io, x, s)
         return
     end
+    print_tree(io, x.nodes, s, x.indent)
+end
 
-    ws = repeat(" ", max(x.indent, 0))
-    for (i, n) in enumerate(x.nodes)
+function print_tree(io::IOBuffer, nodes::Vector{PTree}, s::State, indent::Int)
+    ws = repeat(" ", max(indent, 0))
+    for (i, n) in enumerate(nodes)
         if is_leaf(n)
             print_leaf(io, n, s)
+        elseif n.typ === CSTParser.StringH
+            print_stringh(io, n, s)
         else
             print_tree(io, n, s)
         end
 
-        if n.typ === NEWLINE && s.on && i < length(x.nodes)
-            if is_closer(x.nodes[i+1]) ||
-               x.nodes[i+1].typ === CSTParser.Block || x.nodes[i+1].typ === CSTParser.Begin
-                write(io, repeat(" ", x.nodes[i+1].indent))
-            elseif !skip_indent(x.nodes[i+1])
+        if n.typ === NEWLINE && s.on && i < length(nodes)
+            if is_closer(nodes[i+1]) ||
+                nodes[i+1].typ === CSTParser.Block || nodes[i+1].typ === CSTParser.Begin
+                write(io, repeat(" ", nodes[i+1].indent))
+                s.line_offset = nodes[i+1].indent
+            elseif !skip_indent(nodes[i+1])
                 write(io, ws)
+                s.line_offset = indent
             end
         end
     end
+end
+
+function print_stringh(io::IOBuffer, x::PTree, s::State)
+    # The indent of StringH is set to the the offset
+    # of when the quote is first encountered in the source file.
+
+    # This difference notes if there is a change due to nesting.
+    diff = x.indent - s.line_offset
+    # @info "" x.indent s.line_offset diff max(x.nodes[1].indent - diff, 0)
+
+    # The new indent for the string is index of when a character in
+    # the multiline string is FIRST encountered in the source file - the above difference
+    # diff != 0 && (x.indent = max(x.nodes[1].indent - diff, 0))
+    x.indent = max(x.nodes[1].indent - diff, 0)
+    print_tree(io, x, s)
 end
 
 function print_notcode(io::IOBuffer, x::PTree, s::State)

--- a/src/print.jl
+++ b/src/print.jl
@@ -76,7 +76,7 @@ function print_tree(io::IOBuffer, nodes::Vector{PTree}, s::State, indent::Int)
 
         if n.typ === NEWLINE && s.on && i < length(nodes)
             if is_closer(nodes[i+1]) ||
-                nodes[i+1].typ === CSTParser.Block || nodes[i+1].typ === CSTParser.Begin
+               nodes[i+1].typ === CSTParser.Block || nodes[i+1].typ === CSTParser.Begin
                 write(io, repeat(" ", nodes[i+1].indent))
                 s.line_offset = nodes[i+1].indent
             elseif !skip_indent(nodes[i+1])
@@ -93,7 +93,7 @@ function print_stringh(io::IOBuffer, x::PTree, s::State)
 
     # This difference notes if there is a change due to nesting.
     diff = x.indent - s.line_offset
-    # @info "" x.indent s.line_offset diff max(x.nodes[1].indent - diff, 0)
+    # @info "" length(x) s.line_offset
 
     # The new indent for the string is index of when a character in
     # the multiline string is FIRST encountered in the source file - the above difference

--- a/test/files/Docs.jl
+++ b/test/files/Docs.jl
@@ -358,24 +358,28 @@ end
 
 function keyworddoc(__source__, __module__, str, def::Base.BaseDocs.Keyword)
     @nospecialize str
-    docstr = esc(docexpr(
-        __source__,
-        __module__,
-        lazy_iterpolate(str),
-        metadata(__source__, __module__, def, false),
-    ))
+    docstr = esc(
+        docexpr(
+            __source__,
+            __module__,
+            lazy_iterpolate(str),
+            metadata(__source__, __module__, def, false),
+        ),
+    )
     return :($setindex!($(keywords), $docstr, $(esc(quot(def.name)))); nothing)
 end
 
 function objectdoc(__source__, __module__, str, def, expr, sig = :(Union{}))
     @nospecialize str def expr sig
     binding = esc(bindingexpr(namify(expr)))
-    docstr = esc(docexpr(
-        __source__,
-        __module__,
-        lazy_iterpolate(str),
-        metadata(__source__, __module__, expr, false),
-    ))
+    docstr = esc(
+        docexpr(
+            __source__,
+            __module__,
+            lazy_iterpolate(str),
+            metadata(__source__, __module__, expr, false),
+        ),
+    )
     # Note: we want to avoid introducing line number nodes here (issue #24468)
     return Expr(:block, esc(def), :($(doc!)($__module__, $binding, $docstr, $(esc(sig)))))
 end

--- a/test/files/PProf.jl
+++ b/test/files/PProf.jl
@@ -18,7 +18,9 @@ clear
 # Load in `deps.jl`, complaining if it does not exist
 const depsjl_path = joinpath(@__DIR__, "..", "deps", "deps.jl")
 if !isfile(depsjl_path)
-    error("PProf not installed properly, run Pkg.build(\"PProf\"), restart Julia and try again")
+    error(
+        "PProf not installed properly, run Pkg.build(\"PProf\"), restart Julia and try again",
+    )
 end
 include(depsjl_path)
 

--- a/test/files/cppwrapper.jl
+++ b/test/files/cppwrapper.jl
@@ -41,10 +41,9 @@ function JLFacet(f::CFacet{T}) where {T}
     JLFacet{T}(JLPolygon.(c_polys), holes)
 end
 
-function convert_poly(x::Vector{T}) where {T<:Union{
-    NgonFace{N,Cint},
-    NTuple{N,Cint},
-}} where {N}
+function convert_poly(
+    x::Vector{T},
+) where {T<:Union{NgonFace{N,Cint},NTuple{N,Cint}}} where {N}
     return map(1:length(x)) do i
         CPolygon(pointer(x, i), N)
     end

--- a/test/files/setup_databases.jl
+++ b/test/files/setup_databases.jl
@@ -29,7 +29,7 @@ function parse_commandline()
 
       It creates a `databases` folder in `--output` containing three folders:
       `pdb`, `uniclust` and `pdb70`
-      """,)
+      """)
 
     @add_arg_table settings begin
         "--output", "-o"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1469,6 +1469,46 @@ end
 
         str = raw"""@test :(x`s`flag) == :(@x_cmd "s" "flag")"""
         @test fmt(str) == str
+
+        str = raw"""
+        if free < min_space
+            throw(ErrorException(\"""
+            Free space: \$free Gb
+            Please make sure to have at least \$min_space Gb of free disk space
+            before downloading the $database_name database.
+            \"""))
+        end"""
+        @test fmt(str) == str
+
+        # Technically it nests sonner than it should but that's due to the 
+        # closing parenthesis. ATM I don't think it's worth factoring that in.
+
+        str_ = raw"""
+        if free < min_space
+            throw(
+                ErrorException(\"""
+          Free space: \$free Gb
+          Please make sure to have at least \$min_space Gb of free disk space
+          before downloading the $database_name database.
+          \"""),
+            )
+        end"""
+        @test fmt(str, 4, 71) == str_
+
+        str_ = raw"""
+        if free < min_space
+            throw(
+                ErrorException(
+                    \"""
+        Free space: \$free Gb
+        Please make sure to have at least \$min_space Gb of free disk space
+        before downloading the $database_name database.
+        \""",
+                ),
+            )
+        end"""
+        @test fmt(str, 4, 69) == str_
+
     end
 
     @testset "comments" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3136,17 +3136,17 @@ end
         str = """
         begin
             weights = Dict((file, i) => w for (file, subject) in subjects
-                for (i, w) in enumerate(weightfn.(eachrow(subject.events))))
+            for (i, w) in enumerate(weightfn.(eachrow(subject.events))))
         end"""
-        @test_broken fmt(str_, 4, 90) == str
+        @test fmt(str_, 4, 90) == str
 
         str = """
         begin
             weights = Dict((file, i) => w
-                for (file, subject) in subjects
-                for (i, w) in enumerate(weightfn.(eachrow(subject.events))))
+            for (file, subject) in subjects
+            for (i, w) in enumerate(weightfn.(eachrow(subject.events))))
         end"""
-        @test_broken fmt(str_, 4, 60) == str
+        @test fmt(str_, 4, 60) == str
     end
 
     @testset "Splitpath issue" begin
@@ -3165,7 +3165,8 @@ end
                very_very_very_very_very_very_very_very_very_very_very_very_long_function_name(
                    very_very_very_very_very_very_very_very_very_very_very_very_long_argument,
                    very_very_very_very_very_very_very_very_very_very_very_very_long_argument,
-               ) for x in xs
+               )
+               for x in xs
             ))),
             another_argument,
         )"""
@@ -3230,7 +3231,6 @@ some_function(
             end
         end"""
         @test fmt(str_, 4, 24) == str
-        @test fmt(str_, 4, 23) == str
 
         str = """
         begin
@@ -3243,7 +3243,7 @@ some_function(
             else
             end
         end"""
-        @test fmt(str_, 4, 21) == str
+        @test fmt(str_, 4, 23) == str
         @test fmt(str_, 4, 15) == str
 
         str = """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1411,6 +1411,35 @@ end
                          llvm2
                          \""")"""
         @test fmt(str) == str
+        # nests and then unnests
+        @test fmt(str, 2, 20) == str
+
+        str_ = """
+        foo() =
+          llvmcall(\"""
+                   llvm1
+                   llvm2
+                   \""")"""
+        @test fmt(str, 2, 19) == str_
+
+        # the length calculation is kind of wonky here
+        # but it's still a worthwhile test
+        str_ = """
+        foo() =
+            llvmcall(\"""
+                     llvm1
+                     llvm2
+                     \""")"""
+        @test fmt(str, 4, 19) == str_
+        str_ = """
+        foo() = llvmcall(
+            \"""
+            llvm1
+            llvm2
+            \""",
+        )"""
+        @test fmt(str, 4, 18) == str_
+
 
         str_ = """
         foo() =
@@ -1421,14 +1450,6 @@ end
             \""",
           )"""
         @test fmt(str, 2, 10) == str_
-
-        # str_ = """
-        # foo() =
-        #   llvmcall(\"""
-        #            llvm1
-        #            llvm2
-        #            \""")"""
-        # @test fmt(str, 2, 10) == str_
 
         str = """
         str = \"""

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -348,6 +348,7 @@ end
     end
 
     @testset "tuples" begin
+        @test fmt("(a,)") == "(a,)"
         @test fmt("a,b") == "a, b"
         @test fmt("a ,b") == "a, b"
         @test fmt("(a,b)") == "(a, b)"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1386,7 +1386,7 @@ end
                                 can be created at https://gist.github.com/.\"""))
            end
         end"""
-        @test fmt(str_,4,200) == str
+        @test fmt(str_, 4, 200) == str
 
         str = """
         begin
@@ -1965,7 +1965,9 @@ end
                          e8
                      end
                  end"""
-        @test fmt("begin if cond1 e1; e2 elseif cond2 e3; e4 elseif cond3 e5;e6 else e7;e8  end end") == str
+        @test fmt(
+            "begin if cond1 e1; e2 elseif cond2 e3; e4 elseif cond3 e5;e6 else e7;e8  end end",
+        ) == str
 
         str = """if cond1
                      e1
@@ -2423,14 +2425,25 @@ end
         @test fmt("begin\n a && b || c && d\nend", 4, 1) == str
 
         str = """
+        func(
+            a,
+            \"""this
+            is another
+            multi-line
+            string.
+            Longest line
+            \""",
+            foo(b, c),
+        )"""
+
+        str_ = """
         func(a, \"""this
                 is another
                 multi-line
                 string.
                 Longest line
                 \""", foo(b, c))"""
-        @test fmt(str, 4, 100) == str
-
+        @test fmt(str_) == str
         str_ = """
         func(
             a,
@@ -2447,18 +2460,6 @@ end
         )"""
         @test fmt(str, 4, 1) == str_
 
-        str = """
-        func(
-            a,
-            \"""this
-            is another
-            multi-line
-            string.
-            Longest line
-            \""",
-            foo(b, c),
-        )"""
-        @test fmt(str, 4, 31) == str
 
 
         # Ref
@@ -2659,7 +2660,7 @@ end
         str = "f(a, b, c) where {A<:S}"
         s = run_nest(str, 100)
         @test s.line_offset == length(str)
-        s = run_nest(str, length(str)-1)
+        s = run_nest(str, length(str) - 1)
         @test s.line_offset == 14
         s = run_nest(str, 1)
         @test s.line_offset == 1
@@ -2994,7 +2995,7 @@ end
         )"""
         @test fmt(str, 4, length(str)) == str_
         @test fmt(str_) == str
-        @test fmt(str_,4,79) == str
+        @test fmt(str_, 4, 79) == str
 
         str = """
         a_long_function_name(
@@ -3005,7 +3006,7 @@ end
                 [0.5 0.5; 0.5 0.5],
             ],
         )"""
-        @test fmt(str_,4,78) == str
+        @test fmt(str_, 4, 78) == str
 
         # unary op
         str_ = "[1, 1]'"


### PR DESCRIPTION
This started out as a fix for #116 and #114 but turned into somewhat as a grab-bag. Additionally to generators formatting better:

- the margin introduced by a multiline string is far more accurate
- fix corner case bug during printing multiline strings by deferring final indent calculation to printing stage
- determine nesting for invisbrackets during pretty stage - fixed a bug
- allow nesting even for 1 argument in closing punc types, i.e. Call, MacroCall, TupleH, etc.