### PR TITLE
Unnesting

### DIFF
--- a/src/print.jl
+++ b/src/print.jl
@@ -89,7 +89,7 @@ function print_stringh(io::IOBuffer, x::PTree, s::State)
     # The new indent for the string is index of when a character in
     # the multiline string is FIRST encountered in the source file - the above difference
     # +1 since the character is 1 space after the indent
-    x.indent = max(x.nodes[1].indent + 1 - diff, 0)
+    x.indent = max(x[1].indent + 1 - diff, 0)
     print_tree(io, x, s)
 end
 

--- a/test/files/reverse.jl
+++ b/test/files/reverse.jl
@@ -296,10 +296,7 @@ function adjoint(pr::Primal)
             if haskey(pr.pullbacks, v)
                 g = push!(
                     rb,
-                    stmt(
-                        Expr(:call, alpha(pr.pullbacks[v]), grad(v)),
-                        line = b[v].line,
-                    ),
+                    stmt(Expr(:call, alpha(pr.pullbacks[v]), grad(v)), line = b[v].line),
                 )
                 for (i, x) in enumerate(ex.args)
                     x isa Variable || continue
@@ -337,7 +334,7 @@ function adjoint(pr::Primal)
             Δ = push!(
                 rb,
                 pr.varargs == nothing ? xcall(Zygote, :tuple, gs...) :
-                xcall(Zygote, :tuple_va, Val(pr.varargs), gs...),
+                    xcall(Zygote, :tuple_va, Val(pr.varargs), gs...),
             )
             branches(rb)[1].args[1] = Δ
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -779,7 +779,7 @@ end
             )
         end"""
         @test fmt(str, 4, 32) == str
-        @test_broken fmt(str, 4, 27) == str
+        @test fmt(str, 4, 27) == str
         str = """
         begin
             foo() = (
@@ -791,18 +791,6 @@ end
             )
         end"""
         @test fmt(str, 4, 26) == str
-
-        str = """
-        begin
-                  foo() = (
-                           one,
-                           x -> (
-                                     true,
-                                     false,
-                           ),
-                  )
-        end"""
-        @test fmt(str, 10, 42) == str
 
         str = """
         ignored_f(f) = f in (
@@ -3567,6 +3555,33 @@ some_function(
         end"""
         @test fmt(str_, 4, 9) == str
         @test fmt(str_, 4, 1) == str
+    end
+
+    @testset "unnest" begin
+        str = """
+        let X = LinearAlgebra.Symmetric{T,S} where {S<:(AbstractArray{U,2} where {U<:T})} where {T},
+            Y = Union{
+                LinearAlgebra.Hermitian{T,S} where {S<:(AbstractArray{U,2} where {U<:T})} where T,
+                LinearAlgebra.Symmetric{T,S} where {S<:(AbstractArray{U,2} where {U<:T})} where T,
+            }
+
+            @test X <: Y
+        end"""
+        @test fmt(str, 4, 92) == str
+
+        str = """
+        let X = LinearAlgebra.Symmetric{
+                T,
+                S,
+            } where {S<:(AbstractArray{U,2} where {U<:T})} where {T},
+            Y = Union{
+                LinearAlgebra.Hermitian{T,S} where {S<:(AbstractArray{U,2} where {U<:T})} where T,
+                LinearAlgebra.Symmetric{T,S} where {S<:(AbstractArray{U,2} where {U<:T})} where T,
+            }
+
+            @test X <: Y
+        end"""
+        @test fmt(str, 4, 90) == str
     end
 
 end


### PR DESCRIPTION
_unnesting_ can occur when the RHS an assignment or function definition
is dedented, which may allow a previously nested expression to fit in the margin at full
length.

Motivating example:

```julia
let X = LinearAlgebra.Symmetric{T,S} where {S<:(AbstractArray{U,2} where {U<:T})} where {T},
    Y = Union{
	LinearAlgebra.Hermitian{T,S} where {S<:(AbstractArray{U,2} where {U<:T})} where T,
	LinearAlgebra.Symmetric{T,S} where {S<:(AbstractArray{U,2} where {U<:T})} where T,
    }

    @test X <: Y
end
```

The above fits in a margin of 92 and the arguments inside of

```julia
    ...
    Y = Union{
	LinearAlgebra.Hermitian{T,S} where {S<:(AbstractArray{U,2} where {U<:T})} where T,
	LinearAlgebra.Symmetric{T,S} where {S<:(AbstractArray{U,2} where {U<:T})} where T,
    }
    ...
```

fit in a margin of 90.

Previously `Y = Union{...` would initially be nested to

```julia
Y =
    Union{...
```

The formatter then notices it could fit the caller on the initial line
and the arguments would be dedented.

```julia
Y = Union{
    ...
}
```

However, there was no recursive check to see if nodes could be unnested
given the additional space. Now there is.

This also adds indexing methods from Base to make things a little
easier.