### PR TITLE
Nest WhereOpCall front-to-back in all cases

### DIFF
--- a/src/nest.jl
+++ b/src/nest.jl
@@ -537,19 +537,19 @@ function n_binarycall!(x, s)
         idx = findfirst(n -> n.typ === CSTParser.WhereOpCall, x.nodes)
         return_width = 0
         if idx !== nothing && idx > 1
-            return_width = length(x[idx][1]) + length(x[2])
+            return_width = length(x[idx]) + length(x[2])
         elseif idx === nothing
             return_width, _ = length_to(x, [NEWLINE], start = 2)
         end
 
-        # @info "" return_width
-        # @info "" s.line_offset return_width length(x[1])
+        # @info "" idx map(n -> n.typ, x.nodes)
+        # @info "" s.line_offset length(x[1]) return_width x.extra_margin
 
         for (i, n) in enumerate(x.nodes)
             if n.typ === NEWLINE
                 s.line_offset = x.indent
             elseif i == 1
-                n.extra_margin = return_width
+                n.extra_margin = return_width + x.extra_margin
                 nest!(n, s)
             elseif i == idx
                 n.extra_margin = x.extra_margin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3097,12 +3097,46 @@ end
         @test fmt(str, 4, 33) == str_
 
         str_ = """
-        foo(a, b, c)::Rtype where {
+        foo(
+            a,
+            b,
+            c,
+        )::Rtype where {A,B} = 10"""
+        @test fmt(str, 4, 32) == str_
+        @test fmt(str, 4, 25) == str_
+
+        str_ = """
+        foo(
+            a,
+            b,
+            c,
+        )::Rtype where {A,B} =
+            10"""
+        @test fmt(str, 4, 24) == str_
+        @test fmt(str, 4, 22) == str_
+
+        str_ = """
+        foo(
+            a,
+            b,
+            c,
+        )::Rtype where {
             A,
             B,
         } = 10"""
-        @test fmt(str, 4, 32) == str_
-        @test fmt(str, 4, 19) == str_
+        @test fmt(str, 4, 21) == str_
+
+        str_ = """
+        foo(
+          a,
+          b,
+          c,
+        )::Rtype where {
+          A,
+          B,
+        } =
+          10"""
+        @test fmt(str, 2, 1) == str_
 
         str_ = """
         foo(


### PR DESCRIPTION
Fixes a bug where the return type width and extra margin for WhereOpCall was not correct causing the node to nest back to front.