### PR TITLE
Dedent block types more accurately

### DIFF
--- a/src/nest.jl
+++ b/src/nest.jl
@@ -483,15 +483,23 @@ function n_binarycall!(x, s)
             arg2.typ === CSTParser.Block && (arg2 = arg2[1])
             cst = arg2.ref[]
 
+            line_margin = s.line_offset
             if (
                 arg2.typ === CSTParser.BinaryOpCall && (
                     !(is_lazy_op(cst) && !has_eq) && cst[2].kind !== Tokens.IN
                 )
-            ) || arg2.typ === CSTParser.UnaryOpCall || is_block(cst)
-                line_margin = s.line_offset + 1 + length(x[end])
+            ) || arg2.typ === CSTParser.UnaryOpCall
+                line_margin += length(x[end])
+            elseif is_block(cst)
+                idx = findfirst(n -> n.typ === NEWLINE, arg2.nodes)
+                if idx === nothing
+                    line_margin += length(x[end])
+                else
+                    line_margin += sum(length.(arg2[1:idx-1]))
+                end
             else
                 rw, _ = length_to(x, [NEWLINE], start = i2 + 1)
-                line_margin = s.line_offset + rw
+                line_margin += rw
             end
 
             # @info "" arg2.typ has_eq s.line_offset line_margin x.extra_margin length(x[end])

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -1263,9 +1263,8 @@ is_iterable(x) =
     x.typ === CSTParser.Ref || x.typ === CSTParser.TypedVcat
 
 is_block(x::CSTParser.EXPR) =
-    x.typ === CSTParser.If ||
-    x.typ === CSTParser.Do || x.typ === CSTParser.Try || x.typ === CSTParser.For ||
-    x.typ === CSTParser.While || x.typ === CSTParser.Let
+    x.typ === CSTParser.If || x.typ === CSTParser.Do || x.typ === CSTParser.Try ||
+    x.typ === CSTParser.For || x.typ === CSTParser.While || x.typ === CSTParser.Let
 
 nest_assignment(x::CSTParser.EXPR) = CSTParser.precedence(x[2].kind) == 1
 

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -1265,7 +1265,7 @@ is_iterable(x) =
 is_block(x::CSTParser.EXPR) =
     x.typ === CSTParser.If ||
     x.typ === CSTParser.Do || x.typ === CSTParser.Try || x.typ === CSTParser.For ||
-    x.typ === CSTParser.While || (x.typ === CSTParser.Let && length(x) > 3)
+    x.typ === CSTParser.While || x.typ === CSTParser.Let
 
 nest_assignment(x::CSTParser.EXPR) = CSTParser.precedence(x[2].kind) == 1
 

--- a/test/files/reverse.jl
+++ b/test/files/reverse.jl
@@ -108,15 +108,14 @@ function instrument_global!(ir, v, ex)
     if istrackable(ex)
         ir[v] = xcall(Zygote, :unwrap, QuoteNode(ex), ex)
     else
-        ir[v] =
-            prewalk(ex) do x
-                istrackable(x) || return x
-                insert!(
-                    ir,
-                    v,
-                    stmt(xcall(Zygote, :unwrap, QuoteNode(x), x), type = exprtype(x)),
-                )
-            end
+        ir[v] = prewalk(ex) do x
+            istrackable(x) || return x
+            insert!(
+                ir,
+                v,
+                stmt(xcall(Zygote, :unwrap, QuoteNode(x), x), type = exprtype(x)),
+            )
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3642,6 +3642,15 @@ some_function(
             @test X <: Y
         end"""
         @test fmt(str, 4, 90) == str
+
+        str = """
+        ys = map(xs) do x
+            return (
+                very_very_very_very_very_very_very_very_very_very_very_long_expr,
+                very_very_very_very_very_very_very_very_very_very_very_long_expr,
+            )
+        end"""
+        @test fmt(str) == str
     end
 
 end


### PR DESCRIPTION
For block types check whether it can be put on the above line by calculating the length until the first newline (newline before the first body) in the block type.

fixes #131 