### PR TITLE
Several small improvements

### DIFF
--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -7,6 +7,8 @@ export format, format_text, format_file, format_dir
 
 is_str_or_cmd(x::Tokens.Kind) =
     x in (Tokens.CMD, Tokens.TRIPLE_CMD, Tokens.STRING, Tokens.TRIPLE_STRING)
+is_str_or_cmd(x::CSTParser.Head) =
+    x in (CSTParser.StringH, CSTParser.x_Str, CSTParser.x_Cmd)
 
 # on Windows lines can end in "\r\n"
 normalize_line_ending(s::AbstractString) = replace(s, "\r\n" => "\n")

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -76,9 +76,6 @@ function dedent!(x::PTree, s::State)
         return
     end
     x.typ === CSTParser.ConditionalOpCall && return
-    # x.typ === CSTParser.Comparison && return
-    # x.typ === CSTParser.ChainOpCall && return
-    # x.typ === CSTParser.BinaryOpCall && return
     x.typ === CSTParser.StringH && return
 
     # dedent
@@ -491,7 +488,8 @@ function n_binarycall!(x, s)
                 arg2.typ === CSTParser.BinaryOpCall && (
                     !(is_lazy_op(cst) && !indent_nest) && cst[2].kind !== Tokens.IN
                 )
-            ) || arg2.typ === CSTParser.UnaryOpCall || arg2.typ === CSTParser.ChainOpCall || arg2.typ === CSTParser.Comparison #|| arg2.typ === CSTParser.ConditionalOpCall
+            ) || arg2.typ === CSTParser.UnaryOpCall ||
+                 arg2.typ === CSTParser.ChainOpCall || arg2.typ === CSTParser.Comparison
                 line_margin += length(x[end])
             elseif is_block(cst)
                 idx = findfirst(n -> n.typ === NEWLINE, arg2.nodes)
@@ -506,12 +504,10 @@ function n_binarycall!(x, s)
             end
 
             # @info "" arg2.typ indent_nest s.line_offset line_margin x.extra_margin length(x[end])
-
             if line_margin + x.extra_margin <= s.margin
                 x[i1] = Whitespace(1)
                 if indent_nest
                     x[i2] = Whitespace(0)
-                    # s.line_offset = line_offset
                     walk(dedent!, arg2, s)
                 end
             end

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -485,11 +485,10 @@ function n_binarycall!(x, s)
 
             line_margin = s.line_offset
             if (
-                arg2.typ === CSTParser.BinaryOpCall && (
-                    !(is_lazy_op(cst) && !indent_nest) && cst[2].kind !== Tokens.IN
-                )
+                arg2.typ === CSTParser.BinaryOpCall &&
+                (!(is_lazy_op(cst) && !indent_nest) && cst[2].kind !== Tokens.IN)
             ) || arg2.typ === CSTParser.UnaryOpCall ||
-                 arg2.typ === CSTParser.ChainOpCall || arg2.typ === CSTParser.Comparison
+               arg2.typ === CSTParser.ChainOpCall || arg2.typ === CSTParser.Comparison
                 line_margin += length(x[end])
             elseif is_block(cst)
                 idx = findfirst(n -> n.typ === NEWLINE, arg2.nodes)

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -69,14 +69,12 @@ is_comma(pt::PTree) =
 is_comment(pt::PTree) = pt.typ === INLINECOMMENT || pt.typ === NOTCODE
 
 is_colon_op(x) =
-    (
-        x.typ === CSTParser.BinaryOpCall && x[2].kind === Tokens.COLON
-    ) || x.typ === CSTParser.ColonOpCall
+    (x.typ === CSTParser.BinaryOpCall && x[2].kind === Tokens.COLON) ||
+    x.typ === CSTParser.ColonOpCall
 
 is_lazy_op(x) =
-    x.typ === CSTParser.BinaryOpCall && (
-        x[2].kind === Tokens.LAZY_OR || x[2].kind === Tokens.LAZY_AND
-    )
+    x.typ === CSTParser.BinaryOpCall &&
+    (x[2].kind === Tokens.LAZY_OR || x[2].kind === Tokens.LAZY_AND)
 
 function is_multiline(pt::PTree)
     pt.typ === CSTParser.StringH && return true
@@ -183,9 +181,8 @@ function add_node!(t::PTree, n::PTree, s::State; join_lines = false, max_padding
     elseif n.typ === TRAILINGCOMMA
         en = t.nodes[end]
         if en.typ === CSTParser.Generator || en.typ === CSTParser.Filter ||
-           en.typ === CSTParser.Flatten || en.typ === CSTParser.MacroCall || (
-            is_comma(en) && t.typ === CSTParser.TupleH && n_args(t.ref[]) == 1
-        )
+           en.typ === CSTParser.Flatten || en.typ === CSTParser.MacroCall ||
+           (is_comma(en) && t.typ === CSTParser.TupleH && n_args(t.ref[]) == 1)
             # don't insert trailing comma in these cases
         elseif is_comma(en)
             t.nodes[end] = n
@@ -569,9 +566,8 @@ function p_literal(x, s)
     # Tokenize treats the `ix` part of r"^(=?[^=]+)=(.*)$"ix as an
     # IDENTIFIER where as CSTParser parses it as a LITERAL.
     # An IDENTIFIER won't show up in the string literal lookup table.
-    if str_info === nothing && (
-        x.parent.typ === CSTParser.x_Str || x.parent.typ === CSTParser.x_Cmd
-    )
+    if str_info === nothing &&
+       (x.parent.typ === CSTParser.x_Str || x.parent.typ === CSTParser.x_Cmd)
         s.offset += x.fullspan
         return PTree(x, loc[1], loc[1], x.val)
     end
@@ -1286,9 +1282,8 @@ is_block(x::CSTParser.EXPR) =
 nest_assignment(x::CSTParser.EXPR) = CSTParser.precedence(x[2].kind) == 1
 
 unnestable_arg(x) =
-    is_iterable(x) || is_str(x) || x.typ === CSTParser.LITERAL || (
-        x.typ === CSTParser.BinaryOpCall && x[2].kind === Tokens.DOT
-    )
+    is_iterable(x) || is_str(x) || x.typ === CSTParser.LITERAL ||
+    (x.typ === CSTParser.BinaryOpCall && x[2].kind === Tokens.DOT)
 
 function nestable(x::CSTParser.EXPR)
     CSTParser.defines_function(x) && x[1].typ !== CSTParser.UnaryOpCall && return true
@@ -1342,9 +1337,8 @@ function p_binarycall(x, s; nonest = false, nospace = false)
         add_node!(t, pretty(op, s), s, join_lines = true)
         nest ? add_node!(t, Placeholder(1), s) : add_node!(t, Whitespace(1), s)
     elseif (
-        nospace || (
-            CSTParser.precedence(op) in (8, 13, 14, 16) && op.kind !== Tokens.ANON_FUNC
-        )
+        nospace ||
+        (CSTParser.precedence(op) in (8, 13, 14, 16) && op.kind !== Tokens.ANON_FUNC)
     ) && op.kind !== Tokens.IN
         add_node!(t, pretty(op, s), s, join_lines = true)
     else

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -1282,8 +1282,6 @@ function nestable(x::CSTParser.EXPR)
     if x[1].typ === CSTParser.InvisBrackets || x[3].typ === CSTParser.InvisBrackets
         return false
     end
-    x[2].kind === Tokens.ANON_FUNC && return false
-    x[2].kind === Tokens.PAIR_ARROW && return false
     CSTParser.precedence(x[2]) in (1, 6) && return false
     true
 end

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -1279,9 +1279,6 @@ unnestable_arg(x) =
 function nestable(x::CSTParser.EXPR)
     CSTParser.defines_function(x) && x[1].typ !== CSTParser.UnaryOpCall && return true
     nest_assignment(x) && !is_str(x[3]) && return true
-    if x[1].typ === CSTParser.InvisBrackets || x[3].typ === CSTParser.InvisBrackets
-        return false
-    end
     CSTParser.precedence(x[2]) in (1, 6) && return false
     true
 end

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -1270,7 +1270,7 @@ function p_kw(x, s)
     t
 end
 
-is_str(x) = is_str_or_cmd(x.kind) || x.typ === CSTParser.StringH
+is_str(x) = is_str_or_cmd(x.kind) || is_str_or_cmd(x.typ)
 
 is_iterable(x) =
     x.typ === CSTParser.TupleH || x.typ === CSTParser.Vect ||

--- a/test/files/Docs.jl
+++ b/test/files/Docs.jl
@@ -281,9 +281,8 @@ function astname(x::Expr, ismacro::Bool)
     if isexpr(x, :.)
         ismacro ? macroname(x) : x
     # Call overloading, e.g. `(a::A)(b) = b` or `function (a::A)(b) b end` should document `A(b)`
-    elseif (
-        isexpr(x, :function) || isexpr(x, :(=))
-    ) && isexpr(x.args[1], :call) && isexpr(x.args[1].args[1], :(::))
+    elseif (isexpr(x, :function) || isexpr(x, :(=))) &&
+           isexpr(x.args[1], :call) && isexpr(x.args[1].args[1], :(::))
         return astname(x.args[1].args[1].args[end], ismacro)
     else
         n = isexpr(x, (:module, :struct)) ? 2 : 1
@@ -298,9 +297,8 @@ macroname(s::Symbol) = Symbol('@', s)
 macroname(x::Expr) = Expr(x.head, x.args[1], macroname(x.args[end].value))
 
 isfield(@nospecialize x) =
-    isexpr(x, :.) && (
-        isa(x.args[1], Symbol) || isfield(x.args[1])
-    ) && (isa(x.args[2], QuoteNode) || isexpr(x.args[2], :quote))
+    isexpr(x, :.) && (isa(x.args[1], Symbol) || isfield(x.args[1])) &&
+    (isa(x.args[2], QuoteNode) || isexpr(x.args[2], :quote))
 
 # @doc expression builders.
 # =========================
@@ -342,10 +340,8 @@ function metadata(__source__, __module__, expr, ismodule)
                 end
             elseif isexpr(each, :function) || isexpr(each, :(=))
                 break
-            elseif isa(each, String) || isexpr(each, :string) || isexpr(
-                each,
-                :call,
-            ) || (isexpr(each, :macrocall) && each.args[1] === Symbol("@doc_str"))
+            elseif isa(each, String) || isexpr(each, :string) || isexpr(each, :call) ||
+                   (isexpr(each, :macrocall) && each.args[1] === Symbol("@doc_str"))
                 # forms that might be doc strings
                 last_docstr = each
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3609,6 +3609,18 @@ some_function(
         begin
             if foo
             elseif baz
+            elseif (a || b) &&
+                   c
+            elseif bar
+            else
+            end
+        end"""
+        @test fmt(str_, 4, 23) == str
+
+        str = """
+        begin
+            if foo
+            elseif baz
             elseif (
                 a || b
             ) && c
@@ -3616,7 +3628,6 @@ some_function(
             else
             end
         end"""
-        @test fmt(str_, 4, 23) == str
         @test fmt(str_, 4, 15) == str
 
         str = """
@@ -3641,7 +3652,8 @@ some_function(
             elseif (
                 a ||
                 b
-            ) && c
+            ) &&
+                   c
             elseif bar
             else
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1663,6 +1663,23 @@ end
         @test fmt(str) == str
         @test fmt(str, 4, 1) == str
 
+        str = """foo(r"hello"x)"""
+        @test fmt(str, 4, 1) == str
+
+        str = """foo(r`hello`x)"""
+        @test fmt(str, 4, 1) == str
+
+        str = """foo(r\"""hello\"""x)"""
+        @test fmt(str, 4, 1) == str
+
+        str = """foo(r```hello```x)"""
+        @test fmt(str, 4, 1) == str
+
+        str = """foo(\"""hello\""")"""
+        @test fmt(str, 4, 1) == str
+
+        str = """foo(```hello```)"""
+        @test fmt(str, 4, 1) == str
     end
 
     @testset "comments" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3760,4 +3760,86 @@ some_function(
         @test fmt(str) == str
     end
 
+    @testset "multiline / issue 139" begin
+        str_ = """
+        m = match(r\"""
+                  (
+                      pattern1 |
+                      pattern2 |
+                      pattern3
+                  )
+                  \"""x, aaa, str)"""
+        str = """
+        m = match(
+            r\"""
+            (
+                pattern1 |
+                pattern2 |
+                pattern3
+            )
+            \"""x,
+            aaa,
+            str,
+        )"""
+        @test fmt(str_) == str
+
+        str_ = """
+        m = match(r```
+                  (
+                      pattern1 |
+                      pattern2 |
+                      pattern3
+                  )
+                  ```x, aaa, str)"""
+        str = """
+        m = match(
+            r```
+            (
+                pattern1 |
+                pattern2 |
+                pattern3
+            )
+            ```x,
+            aaa,
+            str,
+        )"""
+        @test fmt(str_) == str
+
+        str_ = """
+        y = similar([
+            1
+            2
+            3
+        ], (4, 5))"""
+        str = """
+        y = similar(
+            [
+                1
+                2
+                3
+            ],
+            (4, 5),
+        )"""
+        @test fmt(str_) == str
+
+        str_ = """
+        y = similar(T[
+            1
+            2
+            3
+        ], (4, 5))"""
+        str = """
+        y = similar(
+            T[
+                1
+                2
+                3
+            ],
+            (4, 5),
+        )"""
+        @test fmt(str_) == str
+
+
+    end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2572,11 +2572,16 @@ end
                   Symbol,
                   Any,
              }(
-                  :numberofpointattributes => NAttributes,
-                  :numberofpointmtrs => NMTr,
-                  :numberofcorners => NSimplex,
-                  :firstnumber => Cint(1),
-                  :mesh_dim => Cint(3),
+                  :numberofpointattributes =>
+                       NAttributes,
+                  :numberofpointmtrs =>
+                       NMTr,
+                  :numberofcorners =>
+                       NSimplex,
+                  :firstnumber =>
+                       Cint(1),
+                  :mesh_dim =>
+                       Cint(3),
              )"""
         @test fmt(str_, 5, 1) == str
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2675,6 +2675,7 @@ end
         @test fmt(str_, 2, length(str_) - 1) == str
         @test fmt(str_, 2, 1) == str
 
+
         str_ = "(a <= b <= c <= d)"
         @test fmt(str_, 4, length(str_)) == str_
 
@@ -2687,6 +2688,24 @@ end
         )"""
         @test fmt(str_, 3, length(str_) - 1) == str
         @test fmt(str_, 3, 1) == str
+
+        # Don't join the first argument in a comparison
+        # or chainopcall node, even if possible.
+        str_ = "const a = arg1 + arg2 + arg3"
+        str = """
+        const a =
+            arg1 +
+            arg2 +
+            arg3"""
+        @test fmt(str_, 4, 18) == str
+
+        str_ = "const a = arg1 == arg2 == arg3"
+        str = """
+        const a =
+            arg1 ==
+            arg2 ==
+            arg3"""
+        @test fmt(str_, 4, 19) == str
 
         # https://github.com/domluna/JuliaFormatter.jl/issues/60
         str_ = """


### PR DESCRIPTION
- `=>` and `->` nest the same as `=`
- comparison `a == b == c` and chainopcalls `a + b + c` are only unnested if the entire expression can be
- Removes the restriction that disallowed a binary op to nest if one of the argument was an invisbracket
- force nests in situation where one of the arguments is inherently multiline, fixes #139 
- nesting rules for x_Str and x_Cmd follow other string types