### PR TITLE
More options related to whitespace

### DIFF
--- a/bin/format.jl
+++ b/bin/format.jl
@@ -1,5 +1,25 @@
 #!/usr/bin/env julia
 
+import Pkg
+
+if isfile("Project.toml")
+    # Okay, we're in $GITHUB_WORKSPACE, and we have a Julia package.
+    project = read("Project.toml", String)
+    if occursin("uuid = \"98e50ef6-434e-11e9-1051-2b60c6c9e899\"", project)
+        # This package is JuliaFormatter itself. Let's use the copy stored here
+        # instead of the last taged version
+        Pkg.add(Pkg.PackageSpec(path = pwd()))
+    else
+        # This is a package that's not JuliaFormatter. Just use the last tagged
+        # version of JuliaFormatter.jl.
+        Pkg.add("JuliaFormatter")
+    end
+else
+    # This doesn't look like a standard Julia package, but it might be a script.
+    # In any case, it isn't JuliaFormatter.jl.
+    Pkg.add("JuliaFormatter")
+end
+
 using JuliaFormatter
 
 help = """
@@ -7,8 +27,8 @@ JuliaFormatter formats Julia (.jl) programs. The formatter is width-sensitive.
 
 Without an explicit file or path, this help message is written to stdout.
 Given a file, it operates on that file; given a directory, it operates on
-all .jl files in that directory, recursively (Files starting with a nofmt comment are ignored).
-By default, JuliaFormatter overwrites files with the reformatted source.
+all .jl files in that directory, recursively.  By default, JuliaFormatter overwrites
+files with the reformatted source.
 
 Usage:
 
@@ -18,20 +38,35 @@ Flags:
 
     -i, --indent
         The number of spaces used for an indentation.
+
     -m, --margin
         The maximum number of characters of code on a single line.  Lines over the
         limit will be wrapped if possible. There are cases where lines cannot be wrapped
         and they will still end up wider than the requested margin.
+
     -v, --verbose
         Print the name of the files being formatted with relevant details.
+
     -h, --help
         Print this message.
+
     -o, --overwrite
         Writes the formatted source to a new file where the original
         filename is suffixed with _fmt, i.e. `filename_fmt.jl`.
+
     --always_for_in
         Always replaces `=` with `in` for `for` loops.
-        For example, `for i = 1:10` will be transformed to `for i in 1:10`.
+        Example: `for i = 1:10` will be transformed to `for i in 1:10`.
+
+    --whitespace_typedefs
+        Add whitespace in type definitions.
+        Example: `Union{A <: B, C}` to `Union{A<:B,C}`.
+
+    --whitespace_ops_in_indices`
+        Add whitespace to binary ops in indices.
+        Example: `arr[a + b]` to `arr[a+b]`.
+        Additionally, if there's a colon `:` involved, parenthesis will be added to the LHS and RHS.
+        Example: `arr[(i1 + i2):(i3 + i4)]` instead of `arr[i1+i2:i3+i4]`.
 """
 
 function parse_opts!(args::Vector{String})
@@ -55,10 +90,20 @@ function parse_opts!(args::Vector{String})
             opt = :overwrite
         elseif arg == "--always_for_in"
             opt = :always_for_in
+        elseif arg == "--whitespace_typedefs"
+            opt = :whitespace_typedefs
+        elseif arg == "--whitespace_ops_in_indices"
+            opt = :whitespace_ops_in_indices
         else
             error("invalid option $arg")
         end
-        if opt in (:verbose, :help, :always_for_in)
+        if opt in (
+            :verbose,
+            :help,
+            :always_for_in,
+            :whitespace_typedefs,
+            :whitespace_ops_in_indices,
+        )
             opts[opt] = true
             deleteat!(args, i)
         elseif opt == :overwrite

--- a/bin/format.jl
+++ b/bin/format.jl
@@ -1,25 +1,4 @@
 #!/usr/bin/env julia
-
-import Pkg
-
-if isfile("Project.toml")
-    # Okay, we're in $GITHUB_WORKSPACE, and we have a Julia package.
-    project = read("Project.toml", String)
-    if occursin("uuid = \"98e50ef6-434e-11e9-1051-2b60c6c9e899\"", project)
-        # This package is JuliaFormatter itself. Let's use the copy stored here
-        # instead of the last taged version
-        Pkg.add(Pkg.PackageSpec(path = pwd()))
-    else
-        # This is a package that's not JuliaFormatter. Just use the last tagged
-        # version of JuliaFormatter.jl.
-        Pkg.add("JuliaFormatter")
-    end
-else
-    # This doesn't look like a standard Julia package, but it might be a script.
-    # In any case, it isn't JuliaFormatter.jl.
-    Pkg.add("JuliaFormatter")
-end
-
 using JuliaFormatter
 
 help = """

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,12 +2,21 @@
 
 [![Build Status](https://travis-ci.org/domluna/JuliaFormatter.jl.svg?branch=master)](https://travis-ci.org/domluna/JuliaFormatter.jl)
 
-Width-sensitive formatter for Julia code. Inspired by gofmt, refmt, and black built with [`CSTParser`](https://github.com/ZacLN/CSTParser.jl).
+Width-sensitive formatter for Julia code. Inspired by gofmt, refmt, and black. Built with [`CSTParser`](https://github.com/ZacLN/CSTParser.jl).
 
 ## Installation
 
 ```julia
 ]add JuliaFormatter
+```
+
+## Quick Start
+
+```julia
+julia> using JuliaFormatter
+
+# Recursively formats all Julia files in the current directory
+julia> format(".")
 ```
 
 ## Usage
@@ -20,38 +29,59 @@ format_text(
     indent = 4,
     margin = 92,
     always_for_in = false,
+    whitespace_typedefs::Bool = false,
+    whitespace_ops_in_indices::Bool = false,
 )
 
 format_file(
     file::AbstractString;
-    indent = 4,
-    margin = 92,
     overwrite = true,
     verbose = false,
+    indent = 4,
+    margin = 92,
     always_for_in = false,
+    whitespace_typedefs::Bool = false,
+    whitespace_ops_in_indices::Bool = false,
 )
 
 format(
     paths...;
-    indent = 4,
-    margin = 92,
     overwrite = true,
     verbose = false,
+    indent = 4,
+    margin = 92,
     always_for_in = false,
+    whitespace_typedefs::Bool = false,
+    whitespace_ops_in_indices::Bool = false,
 )
 ```
 
 The `text` argument to `format_text` is a string containing the code to be formatted; the formatted code is retuned as a new string. The `file` argument to `format_file` is the path of a file to be formatted. The `format` function is either called with a singe string to format if it is a `.jl` file or to recuse into looking for `.jl` files if it is a directory. It can also be called with a collection of such paths to iterate over.
 
-*Options:*
+### File Options
 
-* `indent` - The number of spaces used for an indentation.
-* `margin` - The maximum number of characters of code on a single line. Lines over
-the limit will be wrapped if possible. There are cases where lines cannot be wrapped
-and they will still end up wider than the requested margin.
-* `overwrite` - If the file should be overwritten by the formatted output. If set to false, the formatted version of file named `foo.jl` will be written to `foo_fmt.jl`.
-* `verbose` - Whether to print the name of the file being formatted along with relevant details to `stdout`.
-* `always_for_in` - Always use `in` keyword for `for` loops. This defaults to `false`.
+If `overwrite` is `true` the file will be reformatted in place, overwriting
+the existing file; if it is `false`, the formatted version of `foo.jl` will
+be written to `foo_fmt.jl` instead.
 
-There is also a command-line tool `bin/format.jl` which can be invoked with `-i`/`--indent` and `-m`/`--margin` and with paths which will be passed to `format`.
+If `verbose` is `true` details related to formatting the file will be printed
+to `stdout`.
 
+### Formatting Options
+
+`indent` - the number of spaces used for an indentation.
+
+`margin` - the maximum length of a line. Code exceeding this margin will be formatted
+across multiple lines.
+
+If `always_for_in` is true `=` is always replaced with `in` if part of a
+`for` loop condition.  For example, `for i = 1:10` will be transformed
+to `for i in 1:10`.
+
+If `whitespace_typedefs` is true, whitespace is added for type definitions.
+Make this `true` if you prefer `Union{A <: B, C}` to `Union{A<:B,C}`.
+
+If `whitespace_ops_in_indices` is true, whitespace is added for binary operations
+in indices. Make this `true` if you prefer `arr[a + b]` to `arr[a+b]`. Additionally,
+if there's a colon `:` involved, parenthesis will be added to the LHS and RHS.
+Example: `arr[(i1 + i2):(i3 + i4)]` instead of `arr[i1+i2:i3+i4]`.

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -198,17 +198,31 @@ include("print.jl")
         indent::Int = 4,
         margin::Int = 92,
         always_for_in::Bool = false,
-    ) :: String
+        whitespace_typedefs::Bool = false,
+        whitespace_ops_in_indices::Bool = false,
+    )::String
 
 Formats a Julia source passed in as a string, returning the formatted
-code as another string. The formatting options are:
+code as another string.
 
-- `indent` which defaults to 4 spaces
-- `margin` which defaults to 92 columns
+### Formatting Options
+
+`indent` - the number of spaces used for an indentation.
+
+`margin` - the maximum length of a line. Code exceeding this margin will be formatted
+across multiple lines.
 
 If `always_for_in` is true `=` is always replaced with `in` if part of a
 `for` loop condition.  For example, `for i = 1:10` will be transformed
 to `for i in 1:10`.
+
+If `whitespace_typedefs` is true, whitespace is added for type definitions.
+Make this `true` if you prefer `Union{A <: B, C}` to `Union{A<:B,C}`.
+
+If `whitespace_ops_in_indices` is true, whitespace is added for binary operations
+in indices. Make this `true` if you prefer `arr[a + b]` to `arr[a+b]`. Additionally,
+if there's a colon `:` involved, parenthesis will be added to the LHS and RHS.
+Example: `arr[(i1 + i2):(i3 + i4)]` instead of `arr[i1+i2:i3+i4]`.
 """
 function format_text(
     text::AbstractString;
@@ -263,19 +277,18 @@ end
 """
     format_file(
         filename::AbstractString;
-        indent::Integer = 4,
-        margin::Integer = 92,
         overwrite::Bool = true,
         verbose::Bool = false,
+        indent::Integer = 4,
+        margin::Integer = 92,
         always_for_in::Bool = false,
+        whitespace_typedefs::Bool = false,
+        whitespace_ops_in_indices::Bool = false,
     )
 
 Formats the contents of `filename` assuming it's a Julia source file.
 
-The formatting options are:
-
-- `indent` which defaults to 4 spaces
-- `margin` which defaults to 92 columns
+### File Options
 
 If `overwrite` is `true` the file will be reformatted in place, overwriting
 the existing file; if it is `false`, the formatted version of `foo.jl` will
@@ -284,25 +297,49 @@ be written to `foo_fmt.jl` instead.
 If `verbose` is `true` details related to formatting the file will be printed
 to `stdout`.
 
+### Formatting Options
+
+`indent` - the number of spaces used for an indentation.
+
+`margin` - the maximum length of a line. Code exceeding this margin will be formatted
+across multiple lines.
+
 If `always_for_in` is true `=` is always replaced with `in` if part of a
 `for` loop condition.  For example, `for i = 1:10` will be transformed
 to `for i in 1:10`.
+
+If `whitespace_typedefs` is true, whitespace is added for type definitions.
+Make this `true` if you prefer `Union{A <: B, C}` to `Union{A<:B,C}`.
+
+If `whitespace_ops_in_indices` is true, whitespace is added for binary operations
+in indices. Make this `true` if you prefer `arr[a + b]` to `arr[a+b]`. Additionally,
+if there's a colon `:` involved, parenthesis will be added to the LHS and RHS.
+Example: `arr[(i1 + i2):(i3 + i4)]` instead of `arr[i1+i2:i3+i4]`.
 """
 function format_file(
     filename::AbstractString;
-    indent::Integer = 4,
-    margin::Integer = 92,
     overwrite::Bool = true,
     verbose::Bool = false,
+    indent::Integer = 4,
+    margin::Integer = 92,
     always_for_in::Bool = false,
+    whitespace_typedefs::Bool = false,
+    whitespace_ops_in_indices::Bool = false,
 )
     path, ext = splitext(filename)
     if ext != ".jl"
         error("$filename must be a Julia (.jl) source file")
     end
-    verbose && println("Formatting $filename with indent = $indent, margin = $margin")
+    verbose && println("Formatting $filename")
     str = String(read(filename))
-    str = format_text(str, indent = indent, margin = margin, always_for_in = always_for_in)
+    str = format_text(
+        str,
+        indent = indent,
+        margin = margin,
+        always_for_in = always_for_in,
+        whitespace_typedefs = whitespace_typedefs,
+        whitespace_ops_in_indices = whitespace_ops_in_indices,
+    )
     str = replace(str, r"\n*$" => "\n")
     overwrite ? write(filename, str) : write(path * "_fmt" * ext, str)
     nothing


### PR DESCRIPTION
1. Add whitespace in type definitions

```julia
Foo{A, B} instead of Foo{A,B}

or 

Foo{A <: B, C} instead of Foo{A<:B,C}
```

2. Add whitespace for binops in indices and ranges

```julia
arr[a + b] instead of arr[a+b]

arr[(a + b):(c + d)] instead of arr[a+b:c+d]
```

Notice the added parens :), otherwise this wouldn't look as good.

- [x] update docs
- [x] update https://github.com/julia-actions/julia-format