### PR TITLE
Code Cleanup + More Docs

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -5,9 +5,9 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[CSTParser]]
 deps = ["Tokenize"]
-git-tree-sha1 = "39ba1205b6ddd4c7fa4d0ba6f2f98774a9b92d2c"
+git-tree-sha1 = "3a483b911e1eacc9b897cd45229ef5dc3a49a7f2"
 uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
-version = "1.1.0"
+version = "1.1.1"
 
 [[Distributed]]
 deps = ["Random", "Serialization", "Sockets"]

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ There is also a command-line tool `bin/format.jl` which can be invoked with `-i`
 
 ### Pass 1: Prettify
 
-The CST is "prettified", creating a `PTree`. The printing output of a `PTree` is a canonical representation of the code removing unnecessary whitespace and joining or separating lines of code; expressions will be attempted to be placed on a single line.
+The CST is "prettified", creating a `FST` (Formatted Syntax Tree). The printing output of a `FST` is a canonical representation of the code removing unnecessary whitespace and joining or separating lines of code; expressions will be attempted to be placed on a single line.
 
 Example:
 
@@ -162,7 +162,7 @@ S <: Union{
 }
 ```
 
-If a comment is detected inside the `PTree` it nesting will be forced. For example:
+If a comment is detected inside the `FST` it nesting will be forced. For example:
 
 ```julia
 var = foo(
@@ -183,7 +183,7 @@ var = foo(
 
 ### Part 3: Printing
 
-Finally, the `PTree` is printed to an `IOBuffer`. Prior to returning the formatted text a final validity
+Finally, the `FST` is printed to an `IOBuffer`. Prior to returning the formatted text a final validity
 check is performed.
 
 ## Skipping Formatting

--- a/README.md
+++ b/README.md
@@ -4,11 +4,24 @@
 [![](https://img.shields.io/badge/docs-dev-blue.svg)](https://domluna.github.io/JuliaFormatter.jl/dev)
 [![Build Status](https://travis-ci.org/domluna/JuliaFormatter.jl.svg?branch=master)](https://travis-ci.org/domluna/JuliaFormatter.jl)
 
-Width-sensitive formatter for Julia code. Inspired by gofmt and refmt.
+Width-sensitive formatter for Julia code. Inspired by gofmt, refmt, and black.
+
+## Installation
 
 ```julia
 ]add JuliaFormatter
 ```
+
+## Quick Start
+
+```julia
+julia> using JuliaFormatter
+
+# Recursively formats all Julia files in the current directory
+julia> format(".")
+```
+
+## Usage
 
 `JuliaFormatter` exports `format_text`, `format_file` and `format`:
 
@@ -18,284 +31,59 @@ format_text(
     indent = 4,
     margin = 92,
     always_for_in = false,
+    whitespace_typedefs::Bool = false,
+    whitespace_ops_in_indices::Bool = false,
 )
 
 format_file(
     file::AbstractString;
-    indent = 4,
-    margin = 92,
     overwrite = true,
     verbose = false,
+    indent = 4,
+    margin = 92,
     always_for_in = false,
+    whitespace_typedefs::Bool = false,
+    whitespace_ops_in_indices::Bool = false,
 )
 
 format(
     paths...;
-    indent = 4,
-    margin = 92,
     overwrite = true,
     verbose = false,
+    indent = 4,
+    margin = 92,
     always_for_in = false,
+    whitespace_typedefs::Bool = false,
+    whitespace_ops_in_indices::Bool = false,
 )
 ```
 
 The `text` argument to `format_text` is a string containing the code to be formatted; the formatted code is retuned as a new string. The `file` argument to `format_file` is the path of a file to be formatted. The `format` function is either called with a singe string to format if it is a `.jl` file or to recuse into looking for `.jl` files if it is a directory. It can also be called with a collection of such paths to iterate over.
 
-*Options:*
+### File Options
 
-* `indent` - The number of spaces used for an indentation.
-* `margin` - The maximum number of characters of code on a single line. Lines over
-the limit will be wrapped if possible. There are cases where lines cannot be wrapped
-and they will still end up wider than the requested margin.
-* `overwrite` - If the file should be overwritten by the formatted output. If set to false, the formatted version of file named `foo.jl` will be written to `foo_fmt.jl`.
-* `verbose` - Whether to print the name of the file being formatted along with relevant details to `stdout`.
-* `always_for_in` - Always use `in` keyword for `for` loops. This defaults to `false`.
+If `overwrite` is `true` the file will be reformatted in place, overwriting
+the existing file; if it is `false`, the formatted version of `foo.jl` will
+be written to `foo_fmt.jl` instead.
 
-There is also a command-line tool `bin/format.jl` which can be invoked with `-i`/`--indent` and `-m`/`--margin` and with paths which will be passed to `format`.
+If `verbose` is `true` details related to formatting the file will be printed
+to `stdout`.
 
+### Formatting Options
 
-## How It Works
+`indent` - the number of spaces used for an indentation.
 
-`JuliaFormatter` parses a `.jl` source file into a Concrete Syntax Tree (CST) using [`CSTParser`](https://github.com/ZacLN/CSTParser.jl).
+`margin` - the maximum length of a line. Code exceeding this margin will be formatted
+across multiple lines.
 
-### Pass 1: Prettify
+If `always_for_in` is true `=` is always replaced with `in` if part of a
+`for` loop condition.  For example, `for i = 1:10` will be transformed
+to `for i in 1:10`.
 
-The CST is "prettified", creating a `FST` (Formatted Syntax Tree). The printing output of a `FST` is a canonical representation of the code removing unnecessary whitespace and joining or separating lines of code; expressions will be attempted to be placed on a single line.
+If `whitespace_typedefs` is true, whitespace is added for type definitions.
+Make this `true` if you prefer `Union{A <: B, C}` to `Union{A<:B,C}`.
 
-Example:
-
-```julia
-function  foo
-end
-
-->
-
-function foo end
-```
-
-### Pass 2: Nesting
-
-In the nesting phase lines going over the print width are split into multiple lines such that they fit within
-the allowed width. All expressions are nested front to back with the exception of binary operations and conditionals.
-
-Examples:
-
-
-```julia
-arg1 + arg2
-
-->
-
-arg1 + 
-arg2
-```
-
-```julia
-foo() = body
-
-->
-
-# The indentation of the body is based on `indent_size`
-foo() =
-    body
-```
-
-**Conditionals**
-
-```julia
-cond ? e1 : e2
-
-->
-
-cond ? e1 :
-e2
-
-->
-
-cond ? 
-e1 :
-e2
-```
-
-**Calls** (also applies to {}, (), [], etc)
-
-```julia
-f(arg1, arg2, arg3)
-
-->
-
-f(
-  arg1,
-  arg2,
-  arg3,
-)
-```
-
-```julia
-function longfunctionname_that_is_long(lots, of, args, even, more, args)
-    body
-end
-
-->
-
-function longfunctionname_that_is_long(
-    lots, 
-    of, 
-    args,
-    even, 
-    more, 
-    args,
-)
-    body
-end
-```
-
-```julia
-S <: Union{Type1,Type2,Type3}
-
-->
-
-S <: Union{
-   Type1,
-   Type2,
-   Type3,
-}
-```
-
-If a comment is detected inside the `FST` it nesting will be forced. For example:
-
-```julia
-var = foo(
-    a, b, # comment
-    c,
-)
-```
-
-formatted result will be (regardless of the margin)
-
-```julia
-var = foo(
-    a,
-    b, # comment
-    c,
-)
-```
-
-### Part 3: Printing
-
-Finally, the `FST` is printed to an `IOBuffer`. Prior to returning the formatted text a final validity
-check is performed.
-
-## Skipping Formatting
-
-By default formatting is always on but can be toggled with the following comments:
-
-```julia
-#! format: off
-# turns off formatting from this point onwards
-...
-
-#! format: on
-# turns formatting back on from this point onwards
-```
-
-These can be used throughout a file, or, for an entire file not be formatted add "format: off" at the top of the file:
-
-```julia
-#! format: off
-#
-# It doesn't actually matter if it's on
-# the first line of the line but anything
-# onwards will NOT be formatted.
-
-module Foo
-...
-end
-```
-
-Note the formatter expects `#! format: on` and `#! format: off` to be on its own line and the whitespace to be an exact match.
-
-## Syntax Tree Transformations
-
-### `for in` vs. `for =`
-
-By default if the RHS is a range, i.e. `1:10` then `for in` is converted to `for =`. Otherwise `for =` is converted to `for in`. See [this issue](https://github.com/domluna/JuliaFormatter.jl/issues/34) for the rationale and further explanation.
-
-Alternative to the above - setting `always_for_in` to `true`, i.e. `format_text(..., always_for_in = true)` will always convert `=` to `in` even if the RHS is a range.
-
-### Trailing Commas
-
-If an iterable expression is nested a trailing comma is added to the last argument. The trailing comma is removed if the expressions is unnested:
-
-
-```julia
-f(a, b, c)
-
-->
-
-f(
-  a,
-  b,
-  c,
-)
-```
-
-See [this issue](https://github.com/domluna/JuliaFormatter.jl/issues/44) for more details.
-
-
-
-### Trailing Semicolons
-
-If a matrix expression is nested the semicolons are removed.
-
-```julia
-[1 0; 0 1]
-
-->
-
-[
- 1 0
- 0 1
-]
-```
-
-See [this issue](https://github.com/domluna/JuliaFormatter.jl/issues/77) for more details.
-
-### Leading and trailing 0s for float literals
-
-If a float literal is missing a *trailing* 0 it is added:
-
-```julia
-a = 1.
-
-->
-
-a = 1.0
-```
-
-If a float literal is missing a *leading* 0 it is added:
-
-```julia
-a = .1
-
-->
-
-a = 0.1
-```
-
-See [this issue](https://github.com/domluna/JuliaFormatter.jl/issues/66) for more details.
-
-### Surround `where` arguments with curly brackets
-
-If the arguments of a `where` call are not surrounded by curly brackets, they are added:
-
-
-```julia
-foo(x::T) where T = ...
-
-->
-
-foo(x::T) where {T} = ...
-```
-
-See [this issue](https://github.com/domluna/JuliaFormatter.jl/issues/53) for more details.
+If `whitespace_ops_in_indices` is true, whitespace is added for binary operations
+in indices. Make this `true` if you prefer `arr[a + b]` to `arr[a+b]`. Additionally,
+if there's a colon `:` involved, parenthesis will be added to the LHS and RHS.
+Example: `arr[(i1 + i2):(i3 + i4)]` instead of `arr[i1+i2:i3+i4]`.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,6 +6,7 @@ makedocs(
     modules = [JuliaFormatter],
     pages = [
         "Introduction" => "index.md",
+        "How It Works" => "how_it_works.md",
         "Code Style" => "style.md",
         "Syntax Transforms" => "transforms.md",
     ],

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,6 +8,7 @@ makedocs(
         "Introduction" => "index.md",
         "How It Works" => "how_it_works.md",
         "Code Style" => "style.md",
+        "Skipping Formatting" => "skipping_formatting.md",
         "Syntax Transforms" => "transforms.md",
     ],
 )

--- a/docs/src/how_it_works.md
+++ b/docs/src/how_it_works.md
@@ -1,0 +1,117 @@
+# How It Works
+
+The formatter takes a `.jl` file as input and produce a _idealized_, formatted `.jl`
+as output. Some formatters mutate the state of the current file, `JuliaFormatter` takes a different
+approach - first generating a canonical output, and then mutating that canonical output; adhering
+to the indent and margin constraints.
+
+## Generating an `FST`
+
+The source code is parsed with `CSTParser.jl` which returns a CST (Concrete Syntax Tree). A CST
+is a one-to-one mapping of the language to a tree form. In most cases a more compact AST (Abstract Syntax Tree)
+representation is desired. However, since formatting manipulate the source text itself, the richer representation
+of a CST is incredibly useful.
+
+Once the CST is created it's then used to generate a `FST` (Formatted Syntax Tree). 
+
+> Note: this is not an actual term, just something I made up. Essentially it's a CST with additional formatting specific metadata.
+
+The important part of an FST is any `.jl` file that is syntactically the same (whitespace is irrelevant) produce an identical
+`FST`.
+
+For example:
+
+
+```julia
+# p1.jl
+a = 
+       foo(a,                     b,           
+       c,d)
+```
+
+and
+
+```julia
+# p2.jl
+a =                      foo(a,
+b,
+c,d)
+```
+
+will produce the **same FST**, which printed would look like:
+
+
+```julia
+# fst output
+a = foo(a, b, c, d)
+```
+
+So what does a typical `FST` look like? 
+
+Code is properly indented. Uncessary whitespace is removed. Comments and newlines are untouched.
+
+If the expression can be put on a single line it will be. It doesn't matter 
+it's a function call which 120 arguments, making it 1000 characters long. 
+During this initial stage it will be put on a single line.
+
+If the expression has a structure to it, such as a `try`, `if`, or 'struct'
+definition. It will be spread across multiple lines appropriately:
+
+```julia
+
+# original source
+try a1;a2 catch e b1;b2 finally c1;c2 end
+
+-> 
+
+# printed FST
+try
+   a1
+   a2
+catch e
+   b1
+   b2
+finally
+   c1
+   c2
+end
+```
+
+With this `FST` representation it's much easier to determine when and how
+lines should be broken.
+
+
+## Nesting - breaking lines
+
+During the nesting stage and original `FST` is mutated to adhere to the margin specification.
+
+Throughout the previous stage, while the `FST` was being generated, `PLACEHOLDER` nodes were
+being inserted at various points. These can be converted to `NEWLINE` nodes during nesting, which
+is how lines are broken.
+
+Assume we had a function call which went over the margin.
+
+
+```julia
+begin
+    foo = funccall(argument1, argument2, ..., argument120) # way over margin limit !!!
+end
+```
+
+It would be nested to
+
+```julia
+begin
+    foo = funccall(
+        argument1,
+        argument2,
+        ...,
+        argument120
+    ) # way over margin limit !!!
+end
+```
+
+> You can read how code is nested in the style section.
+
+Once the `FST` has been nested it's then printed out to a file and voila! You have a formatted
+version of your code!

--- a/docs/src/skipping_formatting.md
+++ b/docs/src/skipping_formatting.md
@@ -1,0 +1,28 @@
+# Skipping Formatting
+
+By default formatting is always on but can be toggled with the following comments:
+
+```julia
+#! format: off
+# Turns off formatting from this point onwards
+...
+
+#! format: on
+# Turns formatting back on from this point onwards
+```
+
+These can be used throughout a file, or, for an entire file not be formatted add "format: off" at the top of the file:
+
+```julia
+#! format: off
+#
+# It doesn't actually matter if it's on
+# the first line of the line but anything
+# onwards will NOT be formatted.
+
+module Foo
+...
+end
+```
+
+Note the formatter expects `#! format: on` and `#! format: off` to be on its own line and the whitespace to be an exact match.

--- a/docs/src/style.md
+++ b/docs/src/style.md
@@ -10,7 +10,7 @@
 
 Normalizes the `.jl` file into a canonical format. All unnecessary whitespace is removed, code is properly indented, and everything which can fit on a single line, does.
 
-This stage creates a `PTree`.
+This stage creates an initial `FST` (Formatted Syntax Tree).
 
 **(all examples assume indentation of 4 spaces)**
 
@@ -102,7 +102,7 @@ list[a+b]
 
 Lines going over the maximum margin are split into multiple lines such that they fit inside the margin.
 
-This stage mutates the `PTree` generated from *prettification*.
+This stage mutates the `FST` generated from *prettification*.
 
 Most expressions are nested left to right with the exception of binary operations and conditionals which are nested right to left.
 
@@ -214,4 +214,4 @@ var = foo(
 
 ## Print
 
-This stage prints the mutated `PTree`.
+This stage prints the mutated `FST`.

--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -8,18 +8,18 @@ Alternative to the above - setting `always_for_in` to `true`, i.e. `format_text(
 
 ## Trailing Commas
 
-If an iterable expression is nested a trailing comma is added to the last argument. The trailing comma is removed if the expressions is unnested:
+If the node is _iterable_, for example a function call or list and is nested, a trailing comma is added to the last argument. The trailing comma is removed if unnested:
 
 
 ```julia
-f(a, b, c)
+func(a, b, c)
 
 ->
 
-f(
-  a,
-  b,
-  c,
+func(
+    a,
+    b,
+    c,
 )
 ```
 
@@ -27,16 +27,16 @@ See [this issue](https://github.com/domluna/JuliaFormatter.jl/issues/44) for mor
 
 ## Trailing Semicolons
 
-If a matrix expression is nested the semicolons are removed.
+If a matrix node is nested the semicolons are removed.
 
 ```julia
-[1 0; 0 1]
+A = [1 0; 0 1]
 
 ->
 
-[
- 1 0
- 0 1
+A = [
+    1 0
+    0 1
 ]
 ```
 

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -5,10 +5,10 @@ using Tokenize
 
 export format, format_text, format_file, format_dir
 
-is_str_or_cmd(x::Tokens.Kind) =
-    x in (Tokens.CMD, Tokens.TRIPLE_CMD, Tokens.STRING, Tokens.TRIPLE_STRING)
-is_str_or_cmd(x::CSTParser.Head) =
-    x in (CSTParser.StringH, CSTParser.x_Str, CSTParser.x_Cmd)
+is_str_or_cmd(t::Tokens.Kind) =
+    t in (Tokens.CMD, Tokens.TRIPLE_CMD, Tokens.STRING, Tokens.TRIPLE_STRING)
+is_str_or_cmd(typ::CSTParser.Head) =
+    typ in (CSTParser.StringH, CSTParser.x_Str, CSTParser.x_Cmd)
 
 # on Windows lines can end in "\r\n"
 normalize_line_ending(s::AbstractString) = replace(s, "\r\n" => "\n")

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -114,62 +114,66 @@ function nest!(fst::FST, s::State)
     if fst.typ === CSTParser.Import
         n_import!(fst, s)
     elseif fst.typ === CSTParser.Export
-        n_import!(fst, s)
+        n_export!(fst, s)
     elseif fst.typ === CSTParser.Using
-        n_import!(fst, s)
+        n_using!(fst, s)
     elseif fst.typ === CSTParser.WhereOpCall
-        n_wherecall!(fst, s)
+        n_whereopcall!(fst, s)
     elseif fst.typ === CSTParser.ConditionalOpCall
-        n_condcall!(fst, s)
+        n_conditionalopcall!(fst, s)
     elseif fst.typ === CSTParser.BinaryOpCall
-        n_binarycall!(fst, s)
+        n_binaryopcall!(fst, s)
     elseif fst.typ === CSTParser.Curly
-        n_call!(fst, s)
+        n_curly!(fst, s)
     elseif fst.typ === CSTParser.Call
         n_call!(fst, s)
     elseif fst.typ === CSTParser.MacroCall
-        n_call!(fst, s)
+        n_macrocall!(fst, s)
     elseif fst.typ === CSTParser.Ref
-        n_call!(fst, s)
+        n_ref!(fst, s)
     elseif fst.typ === CSTParser.TypedVcat
-        n_call!(fst, s)
+        n_typedvcat!(fst, s)
     elseif fst.typ === CSTParser.TupleH
-        n_tuple!(fst, s)
+        n_tupleh!(fst, s)
     elseif fst.typ === CSTParser.Vect
-        n_tuple!(fst, s)
+        n_vect!(fst, s)
     elseif fst.typ === CSTParser.Vcat
-        n_tuple!(fst, s)
+        n_vcat!(fst, s)
     elseif fst.typ === CSTParser.Parameters
-        n_tuple!(fst, s)
+        n_parameters!(fst, s)
     elseif fst.typ === CSTParser.Braces
-        n_tuple!(fst, s)
+        n_braces!(fst, s)
     elseif fst.typ === CSTParser.InvisBrackets
-        n_tuple!(fst, s)
+        n_invisbrackets!(fst, s)
     elseif fst.typ === CSTParser.Comprehension
-        n_tuple!(fst, s)
+        n_comphrehension!(fst, s)
     elseif fst.typ === CSTParser.Do
         n_do!(fst, s)
     elseif fst.typ === CSTParser.Generator
-        n_gen!(fst, s)
+        n_generator!(fst, s)
     elseif fst.typ === CSTParser.Filter
-        n_gen!(fst, s)
+        n_filter!(fst, s)
     elseif fst.typ === CSTParser.Block
         n_block!(fst, s)
     elseif fst.typ === CSTParser.ChainOpCall
-        n_block!(fst, s)
+        n_chainopcall!(fst, s)
     elseif fst.typ === CSTParser.Comparison
-        n_block!(fst, s)
+        n_comparison!(fst, s)
     elseif fst.typ === CSTParser.For
         n_for!(fst, s)
     elseif fst.typ === CSTParser.Let
-        n_for!(fst, s)
+        n_let!(fst, s)
     elseif fst.typ === CSTParser.UnaryOpCall && fst[2].typ === CSTParser.OPERATOR
-        fst[1].extra_margin = fst.extra_margin + length(fst[2])
-        nest!(fst[1], s)
-        nest!(fst[2], s)
+        n_unaryopcall!(fst, s)
     else
         nest!(fst.nodes, s, fst.indent, extra_margin = fst.extra_margin)
     end
+end
+
+function n_unaryopcall!(fst::FST, s::State)
+    fst[1].extra_margin = fst.extra_margin + length(fst[2])
+    nest!(fst[1], s)
+    nest!(fst[2], s)
 end
 
 function n_do!(fst::FST, s::State)
@@ -214,8 +218,11 @@ function n_import!(fst::FST, s::State)
         nest!(fst.nodes, s, fst.indent, extra_margin = fst.extra_margin)
     end
 end
+n_export!(fst::FST, s::State) = n_import!(fst, s)
+n_using!(fst::FST, s::State) = n_import!(fst, s)
+n_importall!(fst::FST, s::State) = n_import!(fst, s)
 
-function n_tuple!(fst::FST, s::State)
+function n_tupleh!(fst::FST, s::State)
     line_margin = s.line_offset + length(fst) + fst.extra_margin
     idx = findlast(n -> n.typ === PLACEHOLDER, fst.nodes)
     # @info "ENTERING" idx fst.typ s.line_offset length(fst) fst.extra_margin
@@ -264,6 +271,12 @@ function n_tuple!(fst::FST, s::State)
         nest!(fst.nodes, s, fst.indent, extra_margin = extra_margin)
     end
 end
+n_vect!(fst::FST, s::State) = n_tupleh!(fst, s)
+n_vcat!(fst::FST, s::State) = n_tupleh!(fst, s)
+n_braces!(fst::FST, s::State) = n_tupleh!(fst, s)
+n_parameters!(fst::FST, s::State) = n_tupleh!(fst, s)
+n_invisbrackets!(fst::FST, s::State) = n_tupleh!(fst, s)
+n_comphrehension!(fst::FST, s::State) = n_tupleh!(fst, s)
 
 
 function n_call!(fst::FST, s::State)
@@ -310,9 +323,12 @@ function n_call!(fst::FST, s::State)
         nest!(fst.nodes, s, fst.indent, extra_margin = extra_margin)
     end
 end
+n_curly!(fst::FST, s::State) = n_call!(fst, s)
+n_macrocall!(fst::FST, s::State) = n_call!(fst, s)
+n_ref!(fst::FST, s::State) = n_call!(fst, s)
+n_typedvcat!(fst::FST, s::State) = n_call!(fst, s)
 
-# "A where B"
-function n_wherecall!(fst::FST, s::State)
+function n_whereopcall!(fst::FST, s::State)
     line_margin = s.line_offset + length(fst) + fst.extra_margin
     # @info "" s.line_offset fst.typ line_margin fst.extra_margin length(fst) fst.force_nest line_margin > s.margin
     if line_margin > s.margin || fst.force_nest
@@ -371,7 +387,7 @@ function n_wherecall!(fst::FST, s::State)
     end
 end
 
-function n_condcall!(fst::FST, s::State)
+function n_conditionalopcall!(fst::FST, s::State)
     line_margin = s.line_offset + length(fst) + fst.extra_margin
     # @info "ENTERING" fst.typ s.line_offset line_margin fst.force_nest
     if line_margin > s.margin || fst.force_nest
@@ -441,7 +457,7 @@ end
 #
 # arg1 op
 # arg2
-function n_binarycall!(fst::FST, s::State)
+function n_binaryopcall!(fst::FST, s::State)
     # If there's no placeholder the binary call is not nestable
     idxs = findall(n -> n.typ === PLACEHOLDER, fst.nodes)
     line_margin = s.line_offset + length(fst) + fst.extra_margin
@@ -592,6 +608,7 @@ function n_for!(fst::FST, s::State)
         res == (0, "") && deleteat!(fst.nodes, idx - 1)
     end
 end
+n_let!(fst::FST, s::State) = n_for!(fst, s)
 
 function n_block!(fst::FST, s::State; custom_indent = 0)
     line_margin = s.line_offset + length(fst) + fst.extra_margin
@@ -630,5 +647,7 @@ function n_block!(fst::FST, s::State; custom_indent = 0)
         nest!(fst.nodes, s, fst.indent, extra_margin = fst.extra_margin)
     end
 end
-
-n_gen!(fst::FST, s::State) = n_block!(fst, s, custom_indent = fst.indent)
+n_generator!(fst::FST, s::State) = n_block!(fst, s, custom_indent = fst.indent)
+n_filter!(fst::FST, s::State) = n_block!(fst, s, custom_indent = fst.indent)
+n_comparison!(fst::FST, s::State) = n_block!(fst, s)
+n_chainopcall!(fst::FST, s::State) = n_block!(fst, s)

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -332,11 +332,11 @@ function pretty(cst::CSTParser.EXPR, s::State)
     elseif cst.typ === CSTParser.ModuleH
         return p_module(cst, s)
     elseif cst.typ === CSTParser.BareModule
-        return p_module(cst, s)
+        return p_baremodule(cst, s)
     elseif cst.typ === CSTParser.FunctionDef
-        return p_function(cst, s)
+        return p_functiondef(cst, s)
     elseif cst.typ === CSTParser.Macro
-        return p_function(cst, s)
+        return p_macro(cst, s)
     elseif cst.typ === CSTParser.Primitive
         return p_primitive(cst, s)
     elseif cst.typ === CSTParser.Struct
@@ -348,9 +348,9 @@ function pretty(cst::CSTParser.EXPR, s::State)
     elseif cst.typ === CSTParser.Primitive
         return p_primitive(cst, s)
     elseif cst.typ === CSTParser.For
-        return p_loop(cst, s)
+        return p_for(cst, s)
     elseif cst.typ === CSTParser.While
-        return p_loop(cst, s)
+        return p_while(cst, s)
     elseif cst.typ === CSTParser.Do
         return p_do(cst, s)
     elseif cst.typ === CSTParser.If
@@ -367,10 +367,12 @@ function pretty(cst::CSTParser.EXPR, s::State)
         return p_let(cst, s)
     elseif cst.typ === CSTParser.Vect
         return p_vect(cst, s)
+    elseif cst.typ === CSTParser.Comprehension
+        return p_comprehension(cst, s)
     elseif cst.typ === CSTParser.Braces
         return p_braces(cst, s)
     elseif cst.typ === CSTParser.TupleH
-        return p_tuple(cst, s)
+        return p_tupleh(cst, s)
     elseif cst.typ === CSTParser.InvisBrackets
         return p_invisbrackets(cst, s)
     elseif cst.typ === CSTParser.Curly
@@ -380,55 +382,53 @@ function pretty(cst::CSTParser.EXPR, s::State)
     elseif cst.typ === CSTParser.MacroCall
         return p_macrocall(cst, s)
     elseif cst.typ === CSTParser.WhereOpCall
-        return p_wherecall(cst, s)
+        return p_whereopcall(cst, s)
     elseif cst.typ === CSTParser.ConditionalOpCall
-        return p_condcall(cst, s)
+        return p_conditionalopcall(cst, s)
     elseif cst.typ === CSTParser.BinaryOpCall
-        return p_binarycall(cst, s)
+        return p_binaryopcall(cst, s)
     elseif cst.typ === CSTParser.UnaryOpCall
-        return p_unarycall(cst, s)
+        return p_unaryopcall(cst, s)
     elseif cst.typ === CSTParser.ChainOpCall
-        return p_chaincall(cst, s)
+        return p_chainopcall(cst, s)
     elseif cst.typ === CSTParser.ColonOpCall
-        return p_coloncall(cst, s)
+        return p_colonopcall(cst, s)
     elseif cst.typ === CSTParser.Comparison
-        return p_chaincall(cst, s)
+        return p_comparison(cst, s)
     elseif cst.typ === CSTParser.Kw
         return p_kw(cst, s)
     elseif cst.typ === CSTParser.Parameters
-        return p_params(cst, s)
+        return p_parameters(cst, s)
     elseif cst.typ === CSTParser.Local
-        return p_vardef(cst, s)
+        return p_local(cst, s)
     elseif cst.typ === CSTParser.Global
-        return p_vardef(cst, s)
+        return p_global(cst, s)
     elseif cst.typ === CSTParser.Const
-        return p_vardef(cst, s)
+        return p_const(cst, s)
     elseif cst.typ === CSTParser.Return
-        return p_vardef(cst, s)
+        return p_return(cst, s)
     elseif cst.typ === CSTParser.Import
         return p_import(cst, s)
     elseif cst.typ === CSTParser.Export
-        return p_import(cst, s)
+        return p_export(cst, s)
     elseif cst.typ === CSTParser.Using
-        return p_import(cst, s)
+        return p_using(cst, s)
     elseif cst.typ === CSTParser.Row
         return p_row(cst, s)
     elseif cst.typ === CSTParser.Vcat
         return p_vcat(cst, s)
     elseif cst.typ === CSTParser.TypedVcat
-        return p_vcat(cst, s)
+        return p_typedvcat(cst, s)
     elseif cst.typ === CSTParser.Hcat
         return p_hcat(cst, s)
     elseif cst.typ === CSTParser.TypedHcat
-        return p_hcat(cst, s)
+        return p_typedhcat(cst, s)
     elseif cst.typ === CSTParser.Ref
         return p_ref(cst, s)
-    elseif cst.typ === CSTParser.Comprehension
-        return p_vect(cst, s)
     elseif cst.typ === CSTParser.Generator
-        return p_gen(cst, s)
+        return p_generator(cst, s)
     elseif cst.typ === CSTParser.Filter
-        return p_gen(cst, s)
+        return p_filter(cst, s)
     end
 
     t = FST(cst, nspaces(s))
@@ -743,7 +743,6 @@ function p_block(
             end
         end
     end
-    # @info "" t.typ length(t)
     t
 end
 
@@ -776,7 +775,7 @@ function p_primitive(cst::CSTParser.EXPR, s::State)
 end
 
 # FunctionDef/Macro
-function p_function(cst::CSTParser.EXPR, s::State)
+function p_functiondef(cst::CSTParser.EXPR, s::State)
     t = FST(cst, nspaces(s))
     add_node!(t, pretty(cst[1], s), s)
     add_node!(t, Whitespace(1), s)
@@ -804,6 +803,7 @@ function p_function(cst::CSTParser.EXPR, s::State)
     end
     t
 end
+p_macro(cst::CSTParser.EXPR, s::State) = p_functiondef(cst, s)
 
 # Struct
 function p_struct(cst::CSTParser.EXPR, s::State)
@@ -868,9 +868,10 @@ function p_module(cst::CSTParser.EXPR, s::State)
     end
     t
 end
+p_baremodule(cst::CSTParser.EXPR, s::State) = p_module(cst, s)
 
 # Const/Local/Global/Return
-function p_vardef(cst::CSTParser.EXPR, s::State)
+function p_const(cst::CSTParser.EXPR, s::State)
     t = FST(cst, nspaces(s))
     add_node!(t, pretty(cst[1], s), s)
     if cst[2].fullspan != 0
@@ -881,6 +882,9 @@ function p_vardef(cst::CSTParser.EXPR, s::State)
     end
     t
 end
+p_local(cst::CSTParser.EXPR, s::State) = p_const(cst, s)
+p_global(cst::CSTParser.EXPR, s::State) = p_const(cst, s)
+p_return(cst::CSTParser.EXPR, s::State) = p_const(cst, s)
 
 # TopLevel
 function p_toplevel(cst::CSTParser.EXPR, s::State)
@@ -1034,7 +1038,7 @@ function eq_to_in_normalization!(cst::CSTParser.EXPR, always_for_in::Bool)
 end
 
 # For/While
-function p_loop(cst::CSTParser.EXPR, s::State)
+function p_for(cst::CSTParser.EXPR, s::State)
     t = FST(cst, nspaces(s))
     add_node!(t, pretty(cst[1], s), s)
     add_node!(t, Whitespace(1), s)
@@ -1064,6 +1068,7 @@ function p_loop(cst::CSTParser.EXPR, s::State)
     add_node!(t, pretty(cst[4], s), s)
     t
 end
+p_while(cst::CSTParser.EXPR, s::State) = p_for(cst, s)
 
 # Do
 function p_do(cst::CSTParser.EXPR, s::State)
@@ -1197,7 +1202,7 @@ function p_if(cst::CSTParser.EXPR, s::State)
 end
 
 # ChainOpCall/Comparison
-function p_chaincall(cst::CSTParser.EXPR, s::State; nonest = false, nospace = false)
+function p_chainopcall(cst::CSTParser.EXPR, s::State; nonest = false, nospace = false)
     t = FST(cst, nspaces(s))
     nws = nospace ? 0 : 1
     for (i, a) in enumerate(cst)
@@ -1218,18 +1223,19 @@ function p_chaincall(cst::CSTParser.EXPR, s::State; nonest = false, nospace = fa
     end
     t
 end
+p_comparison(cst::CSTParser.EXPR, s::State; nonest = false, nospace = false) = p_chainopcall(cst, s, nonest=nonest, nospace=nospace)
 
 # ColonOpCall
-function p_coloncall(cst::CSTParser.EXPR, s::State)
+function p_colonopcall(cst::CSTParser.EXPR, s::State)
     t = FST(cst, nspaces(s))
     nospace = !s.opts.whitespace_ops_in_indices
     for a in cst
         if a.typ === CSTParser.BinaryOpCall
-            n = p_binarycall(a, s, nonest = true, nospace = nospace)
+            n = p_binaryopcall(a, s, nonest = true, nospace = nospace)
         elseif a.typ === CSTParser.InvisBrackets
             n = p_invisbrackets(a, s, nonest = true, nospace = nospace)
         elseif a.typ === CSTParser.ChainOpCall || a.typ === CSTParser.Comparison
-            n = p_chaincall(a, s, nonest = true, nospace = nospace)
+            n = p_chainopcall(a, s, nonest = true, nospace = nospace)
         else
             n = pretty(a, s)
         end
@@ -1298,7 +1304,7 @@ function nest_arg2(cst::CSTParser.EXPR)
 end
 
 # BinaryOpCall
-function p_binarycall(cst::CSTParser.EXPR, s::State; nonest = false, nospace = false)
+function p_binaryopcall(cst::CSTParser.EXPR, s::State; nonest = false, nospace = false)
     t = FST(cst, nspaces(s))
     op = cst[2]
     nonest = nonest || op.kind === Tokens.COLON
@@ -1311,11 +1317,11 @@ function p_binarycall(cst::CSTParser.EXPR, s::State; nonest = false, nospace = f
     nospace_args = s.opts.whitespace_ops_in_indices ? false : nospace
 
     if cst[1].typ === CSTParser.BinaryOpCall
-        n = p_binarycall(cst[1], s, nonest = nonest, nospace = nospace_args)
+        n = p_binaryopcall(cst[1], s, nonest = nonest, nospace = nospace_args)
     elseif cst[1].typ === CSTParser.InvisBrackets
         n = p_invisbrackets(cst[1], s, nonest = nonest, nospace = nospace_args)
     elseif cst[1].typ === CSTParser.ChainOpCall || cst[1].typ === CSTParser.Comparison
-        n = p_chaincall(cst[1], s, nonest = nonest, nospace = nospace_args)
+        n = p_chainopcall(cst[1], s, nonest = nonest, nospace = nospace_args)
     else
         n = pretty(cst[1], s)
     end
@@ -1357,11 +1363,11 @@ function p_binarycall(cst::CSTParser.EXPR, s::State; nonest = false, nospace = f
     end
 
     if cst[3].typ === CSTParser.BinaryOpCall
-        n = p_binarycall(cst[3], s, nonest = nonest, nospace = nospace_args)
+        n = p_binaryopcall(cst[3], s, nonest = nonest, nospace = nospace_args)
     elseif cst[3].typ === CSTParser.InvisBrackets
         n = p_invisbrackets(cst[3], s, nonest = nonest, nospace = nospace_args)
     elseif cst[3].typ === CSTParser.ChainOpCall || cst[3].typ === CSTParser.Comparison
-        n = p_chaincall(cst[3], s, nonest = nonest, nospace = nospace_args)
+        n = p_chainopcall(cst[3], s, nonest = nonest, nospace = nospace_args)
     else
         n = pretty(cst[3], s)
     end
@@ -1387,7 +1393,7 @@ end
 
 # WhereOpCall
 # A where B
-function p_wherecall(cst::CSTParser.EXPR, s::State)
+function p_whereopcall(cst::CSTParser.EXPR, s::State)
     t = FST(cst, nspaces(s))
     add_node!(t, pretty(cst[1], s), s)
 
@@ -1431,7 +1437,7 @@ function p_wherecall(cst::CSTParser.EXPR, s::State)
         elseif a.typ === CSTParser.BinaryOpCall
             add_node!(
                 t,
-                p_binarycall(a, s, nospace = !s.opts.whitespace_typedefs),
+                p_binaryopcall(a, s, nospace = !s.opts.whitespace_typedefs),
                 s,
                 join_lines = true,
             )
@@ -1449,7 +1455,7 @@ function p_wherecall(cst::CSTParser.EXPR, s::State)
 end
 
 # Conditional
-function p_condcall(cst::CSTParser.EXPR, s::State)
+function p_conditionalopcall(cst::CSTParser.EXPR, s::State)
     t = FST(cst, nspaces(s))
     add_node!(t, pretty(cst[1], s), s)
     add_node!(t, Whitespace(1), s)
@@ -1466,7 +1472,7 @@ function p_condcall(cst::CSTParser.EXPR, s::State)
 end
 
 # UnaryOpCall
-function p_unarycall(cst::CSTParser.EXPR, s::State; nospace = true)
+function p_unaryopcall(cst::CSTParser.EXPR, s::State; nospace = true)
     t = FST(cst, nspaces(s))
     add_node!(t, pretty(cst[1], s), s)
     !nospace && add_node!(t, Whitespace(1), s)
@@ -1541,7 +1547,7 @@ function p_invisbrackets(cst::CSTParser.EXPR, s::State; nonest = false, nospace 
         elseif a.typ === CSTParser.BinaryOpCall
             add_node!(
                 t,
-                p_binarycall(a, s, nonest = nonest, nospace = nospace),
+                p_binaryopcall(a, s, nonest = nonest, nospace = nospace),
                 s,
                 join_lines = true,
             )
@@ -1568,7 +1574,7 @@ function p_invisbrackets(cst::CSTParser.EXPR, s::State; nonest = false, nospace 
 end
 
 # TupleH
-function p_tuple(cst::CSTParser.EXPR, s::State)
+function p_tupleh(cst::CSTParser.EXPR, s::State)
     t = FST(cst, nspaces(s))
 
     args = get_args(cst)
@@ -1640,10 +1646,11 @@ function p_vect(cst::CSTParser.EXPR, s::State)
     end
     t
 end
+p_comprehension(cst::CSTParser.EXPR, s::State) = p_vect(cst, s)
 
 
 # Parameters
-function p_params(cst::CSTParser.EXPR, s::State)
+function p_parameters(cst::CSTParser.EXPR, s::State)
     t = FST(cst, nspaces(s))
     for (i, a) in enumerate(cst)
         n = pretty(a, s)
@@ -1675,6 +1682,9 @@ function p_import(cst::CSTParser.EXPR, s::State)
     end
     t
 end
+p_export(cst::CSTParser.EXPR, s::State) = p_import(cst, s)
+p_using(cst::CSTParser.EXPR, s::State) = p_import(cst, s)
+p_importall(cst::CSTParser.EXPR, s::State) = p_import(cst, s)
 
 # Ref
 function p_ref(cst::CSTParser.EXPR, s::State)
@@ -1695,7 +1705,7 @@ function p_ref(cst::CSTParser.EXPR, s::State)
         elseif a.typ === CSTParser.BinaryOpCall
             add_node!(
                 t,
-                p_binarycall(a, s, nonest = true, nospace = nospace),
+                p_binaryopcall(a, s, nonest = true, nospace = nospace),
                 s,
                 join_lines = true,
             )
@@ -1747,6 +1757,7 @@ function p_vcat(cst::CSTParser.EXPR, s::State)
     end
     t
 end
+p_typedvcat(cst::CSTParser.EXPR, s::State) = p_vcat(cst, s)
 
 # Hcat/TypedHcat
 function p_hcat(cst::CSTParser.EXPR, s::State)
@@ -1762,6 +1773,7 @@ function p_hcat(cst::CSTParser.EXPR, s::State)
     end
     t
 end
+p_typedhcat(cst::CSTParser.EXPR, s::State) = p_hcat(cst, s)
 
 # Row
 function p_row(cst::CSTParser.EXPR, s::State)
@@ -1779,7 +1791,7 @@ function p_row(cst::CSTParser.EXPR, s::State)
             add_node!(t, pretty(a, s), s, join_lines = true)
             add_node!(t, Whitespace(nospace ? 0 : 1), s)
         elseif in_braces && a.typ === CSTParser.UnaryOpCall
-            add_node!(t, p_unarycall(a, s, nospace = nospace), s, join_lines = true)
+            add_node!(t, p_unaryopcall(a, s, nospace = nospace), s, join_lines = true)
             i < length(cst) && add_node!(t, Whitespace(1), s)
         else
             add_node!(t, pretty(a, s), s, join_lines = true)
@@ -1790,7 +1802,7 @@ function p_row(cst::CSTParser.EXPR, s::State)
 end
 
 # Generator/Filter
-function p_gen(cst::CSTParser.EXPR, s::State)
+function p_generator(cst::CSTParser.EXPR, s::State)
     t = FST(cst, nspaces(s))
     for (i, a) in enumerate(cst)
         if a.typ === CSTParser.KEYWORD
@@ -1817,7 +1829,7 @@ function p_gen(cst::CSTParser.EXPR, s::State)
                 end
             end
         elseif a.typ === CSTParser.BinaryOpCall
-            add_node!(t, p_binarycall(a, s, nonest = true), s, join_lines = true)
+            add_node!(t, p_binaryopcall(a, s, nonest = true), s, join_lines = true)
         elseif CSTParser.is_comma(a) && i < length(cst) && !is_punc(cst[i+1])
             add_node!(t, pretty(a, s), s, join_lines = true)
             add_node!(t, Whitespace(1), s)
@@ -1827,3 +1839,4 @@ function p_gen(cst::CSTParser.EXPR, s::State)
     end
     t
 end
+p_filter(cst::CSTParser.EXPR, s::State) = p_generator(cst, s)

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -305,12 +305,14 @@ function length_to(fst::FST, ntyps::Vector; start::Int = 1)
 end
 
 is_closer(fst::FST) =
-    fst.typ === CSTParser.PUNCTUATION && (fst.val == "}" || fst.val == ")" || fst.val == "]")
+    fst.typ === CSTParser.PUNCTUATION &&
+    (fst.val == "}" || fst.val == ")" || fst.val == "]")
 is_closer(cst::CSTParser.EXPR) =
     cst.kind === Tokens.RBRACE || cst.kind === Tokens.RPAREN || cst.kind === Tokens.RSQUARE
 
 is_opener(fst::FST) =
-    fst.typ === CSTParser.PUNCTUATION && (fst.val == "{" || fst.val == "(" || fst.val == "[")
+    fst.typ === CSTParser.PUNCTUATION &&
+    (fst.val == "{" || fst.val == "(" || fst.val == "[")
 is_opener(cst::CSTParser.EXPR) =
     cst.kind === Tokens.LBRACE || cst.kind === Tokens.LPAREN || cst.kind === Tokens.LSQUARE
 

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -46,8 +46,7 @@ Newline(; length = 0, force_nest = false) =
     FST(NEWLINE, -1, -1, 0, length, "\n", nothing, nothing, force_nest, 0)
 Semicolon() = FST(SEMICOLON, -1, -1, 0, 1, ";", nothing, nothing, false, 0)
 TrailingComma() = FST(TRAILINGCOMMA, -1, -1, 0, 0, "", nothing, nothing, false, 0)
-TrailingSemicolon() =
-    FST(TRAILINGSEMICOLON, -1, -1, 0, 1, ";", nothing, nothing, false, 0)
+TrailingSemicolon() = FST(TRAILINGSEMICOLON, -1, -1, 0, 1, ";", nothing, nothing, false, 0)
 Whitespace(n) = FST(WHITESPACE, -1, -1, 0, n, " "^n, nothing, nothing, false, 0)
 Placeholder(n) = FST(PLACEHOLDER, -1, -1, 0, n, " "^n, nothing, nothing, false, 0)
 Notcode(startline, endline) =
@@ -102,8 +101,8 @@ end
 # TODO: Remove once this is fixed in CSTParser.
 # https://github.com/julia-vscode/CSTParser.jl/issues/108
 function get_args(cst::CSTParser.EXPR)
-    if cst.typ === CSTParser.MacroCall ||
-       cst.typ === CSTParser.TypedVcat || cst.typ === CSTParser.Ref || cst.typ === CSTParser.Curly
+    if cst.typ === CSTParser.MacroCall || cst.typ === CSTParser.TypedVcat ||
+       cst.typ === CSTParser.Ref || cst.typ === CSTParser.Curly
         return get_args(cst.args[2:end])
     elseif cst.typ === CSTParser.Parameters || cst.typ === CSTParser.Braces ||
            cst.typ === CSTParser.Vcat || cst.typ === CSTParser.TupleH ||
@@ -696,7 +695,13 @@ end
 
 # Block
 # length Block is the length of the longest expr
-function p_block(cst::CSTParser.EXPR, s::State; ignore_single_line = false, from_quote = false, join_body = false)
+function p_block(
+    cst::CSTParser.EXPR,
+    s::State;
+    ignore_single_line = false,
+    from_quote = false,
+    join_body = false,
+)
     t = FST(cst, nspaces(s))
     single_line = ignore_single_line ? false :
         cursor_loc(s)[1] == cursor_loc(s, s.offset + cst.span - 1)[1]

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -281,7 +281,7 @@ end
 function is_prev_newline(fst::FST)
     if fst.typ === NEWLINE
         return true
-    elseif is_leaf(x) || length(fst.nodes) == 0
+    elseif is_leaf(fst) || length(fst.nodes) == 0
         return false
     end
     is_prev_newline(fst[end])
@@ -294,7 +294,7 @@ Returns the length to any node type in `ntyps` based off the `start` index.
 """
 function length_to(fst::FST, ntyps::Vector; start::Int = 1)
     fst.typ in ntyps && return 0, true
-    is_leaf(x) && return length(x), false
+    is_leaf(fst) && return length(fst), false
     len = 0
     for i = start:length(fst.nodes)
         l, found = length_to(fst.nodes[i], ntyps)

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -1223,7 +1223,8 @@ function p_chainopcall(cst::CSTParser.EXPR, s::State; nonest = false, nospace = 
     end
     t
 end
-p_comparison(cst::CSTParser.EXPR, s::State; nonest = false, nospace = false) = p_chainopcall(cst, s, nonest=nonest, nospace=nospace)
+p_comparison(cst::CSTParser.EXPR, s::State; nonest = false, nospace = false) =
+    p_chainopcall(cst, s, nonest = nonest, nospace = nospace)
 
 # ColonOpCall
 function p_colonopcall(cst::CSTParser.EXPR, s::State)

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -278,13 +278,13 @@ function add_node!(t::FST, n::FST, s::State; join_lines = false, max_padding = -
     nothing
 end
 
-function is_prev_newline(x::FST)
-    if x.typ === NEWLINE
+function is_prev_newline(fst::FST)
+    if fst.typ === NEWLINE
         return true
-    elseif is_leaf(x) || length(x.nodes) == 0
+    elseif is_leaf(x) || length(fst.nodes) == 0
         return false
     end
-    is_prev_newline(x.nodes[end])
+    is_prev_newline(fst[end])
 end
 
 """
@@ -292,27 +292,27 @@ end
 
 Returns the length to any node type in `ntyps` based off the `start` index.
 """
-function length_to(x::FST, ntyps::Vector; start::Int = 1)
-    x.typ in ntyps && return 0, true
+function length_to(fst::FST, ntyps::Vector; start::Int = 1)
+    fst.typ in ntyps && return 0, true
     is_leaf(x) && return length(x), false
     len = 0
-    for i = start:length(x.nodes)
-        l, found = length_to(x.nodes[i], ntyps)
+    for i = start:length(fst.nodes)
+        l, found = length_to(fst.nodes[i], ntyps)
         len += l
         found && return len, found
     end
     return len, false
 end
 
-is_closer(x::FST) =
-    x.typ === CSTParser.PUNCTUATION && (x.val == "}" || x.val == ")" || x.val == "]")
-is_closer(x::CSTParser.EXPR) =
-    x.kind === Tokens.RBRACE || x.kind === Tokens.RPAREN || x.kind === Tokens.RSQUARE
+is_closer(fst::FST) =
+    fst.typ === CSTParser.PUNCTUATION && (fst.val == "}" || fst.val == ")" || fst.val == "]")
+is_closer(cst::CSTParser.EXPR) =
+    cst.kind === Tokens.RBRACE || cst.kind === Tokens.RPAREN || cst.kind === Tokens.RSQUARE
 
-is_opener(x::FST) =
-    x.typ === CSTParser.PUNCTUATION && (x.val == "{" || x.val == "(" || x.val == "[")
-is_opener(x::CSTParser.EXPR) =
-    x.kind === Tokens.LBRACE || x.kind === Tokens.LPAREN || x.kind === Tokens.LSQUARE
+is_opener(fst::FST) =
+    fst.typ === CSTParser.PUNCTUATION && (fst.val == "{" || fst.val == "(" || fst.val == "[")
+is_opener(cst::CSTParser.EXPR) =
+    cst.kind === Tokens.LBRACE || cst.kind === Tokens.LPAREN || cst.kind === Tokens.LSQUARE
 
 function pretty(cst::CSTParser.EXPR, s::State)
     if cst.typ === CSTParser.IDENTIFIER
@@ -564,7 +564,7 @@ function p_literal(cst::CSTParser.EXPR, s::State)
         end
     end
 
-    # @debug "" lines x.val loc loc[2] sidx
+    # @debug "" lines cst.val loc loc[2] sidx
 
     t = FST(CSTParser.StringH, -1, -1, loc[2] - 1, 0, nothing, FST[], Ref(cst), false, 0)
     for (i, l) in enumerate(lines)
@@ -610,7 +610,7 @@ function p_stringh(cst::CSTParser.EXPR, s::State)
         end
     end
 
-    # @debug "" lines x.val loc loc[2] sidx
+    # @debug "" lines cst.val loc loc[2] sidx
 
     t = FST(cst, loc[2] - 1)
     for (i, l) in enumerate(lines)

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -25,15 +25,15 @@ mutable struct PTree
     extra_margin::Int
 end
 
-PTree(x::CSTParser.EXPR, indent::Integer) =
-    PTree(x.typ, -1, -1, indent, 0, nothing, PTree[], Ref(x), false, 0)
+PTree(cst::CSTParser.EXPR, indent::Integer) =
+    PTree(cst.typ, -1, -1, indent, 0, nothing, PTree[], Ref(cst), false, 0)
 
-function PTree(x::CSTParser.EXPR, startline::Integer, endline::Integer, val::AbstractString)
-    PTree(x.typ, startline, endline, 0, length(val), val, nothing, Ref(x), false, 0)
+function PTree(cst::CSTParser.EXPR, startline::Integer, endline::Integer, val::AbstractString)
+    PTree(cst.typ, startline, endline, 0, length(val), val, nothing, Ref(cst), false, 0)
 end
 
-function PTree(x::CSTParser.Head, startline::Integer, endline::Integer, val::AbstractString)
-    PTree(x, startline, endline, 0, length(val), val, nothing, nothing, false, 0)
+function PTree(cst::CSTParser.Head, startline::Integer, endline::Integer, val::AbstractString)
+    PTree(cst, startline, endline, 0, length(val), val, nothing, nothing, false, 0)
 end
 
 function Base.setindex!(pt::PTree, node::PTree, ind::Int)
@@ -103,16 +103,16 @@ end
 
 # TODO: Remove once this is fixed in CSTParser.
 # https://github.com/julia-vscode/CSTParser.jl/issues/108
-function get_args(x::CSTParser.EXPR)
-    if x.typ === CSTParser.MacroCall ||
-       x.typ === CSTParser.TypedVcat || x.typ === CSTParser.Ref || x.typ === CSTParser.Curly
-        return get_args(x.args[2:end])
-    elseif x.typ === CSTParser.Parameters || x.typ === CSTParser.Braces ||
-           x.typ === CSTParser.Vcat || x.typ === CSTParser.TupleH ||
-           x.typ === CSTParser.Vect || x.typ === CSTParser.InvisBrackets
-        return get_args(x.args)
+function get_args(cst::CSTParser.EXPR)
+    if cst.typ === CSTParser.MacroCall ||
+       cst.typ === CSTParser.TypedVcat || cst.typ === CSTParser.Ref || cst.typ === CSTParser.Curly
+        return get_args(cst.args[2:end])
+    elseif cst.typ === CSTParser.Parameters || cst.typ === CSTParser.Braces ||
+           cst.typ === CSTParser.Vcat || cst.typ === CSTParser.TupleH ||
+           cst.typ === CSTParser.Vect || cst.typ === CSTParser.InvisBrackets
+        return get_args(cst.args)
     end
-    CSTParser.get_args(x)
+    CSTParser.get_args(cst)
 end
 
 function get_args(args::Vector{CSTParser.EXPR})
@@ -121,7 +121,7 @@ function get_args(args::Vector{CSTParser.EXPR})
         CSTParser.ispunctuation(arg) && continue
         if CSTParser.typof(arg) === CSTParser.Parameters
             for j = 1:length(arg.args)
-                parg = arg.args[j]
+                parg = arg[j]
                 CSTParser.ispunctuation(parg) && continue
                 push!(args0, parg)
             end
@@ -317,126 +317,126 @@ is_opener(x::PTree) =
 is_opener(x::CSTParser.EXPR) =
     x.kind === Tokens.LBRACE || x.kind === Tokens.LPAREN || x.kind === Tokens.LSQUARE
 
-function pretty(x::CSTParser.EXPR, s::State)
-    if x.typ === CSTParser.IDENTIFIER
-        return p_identifier(x, s)
-    elseif x.typ === CSTParser.OPERATOR
-        return p_operator(x, s)
-    elseif x.typ === CSTParser.PUNCTUATION
-        return p_punctuation(x, s)
-    elseif x.typ === CSTParser.KEYWORD
-        return p_keyword(x, s)
-    elseif x.typ === CSTParser.LITERAL
-        return p_literal(x, s)
-    elseif x.typ === CSTParser.StringH
-        return p_stringh(x, s)
-    elseif x.typ === CSTParser.Block
-        return p_block(x, s)
-    elseif x.typ === CSTParser.ModuleH
-        return p_module(x, s)
-    elseif x.typ === CSTParser.BareModule
-        return p_module(x, s)
-    elseif x.typ === CSTParser.FunctionDef
-        return p_function(x, s)
-    elseif x.typ === CSTParser.Macro
-        return p_function(x, s)
-    elseif x.typ === CSTParser.Primitive
-        return p_primitive(x, s)
-    elseif x.typ === CSTParser.Struct
-        return p_struct(x, s)
-    elseif x.typ === CSTParser.Mutable
-        return p_mutable(x, s)
-    elseif x.typ === CSTParser.Abstract
-        return p_abstract(x, s)
-    elseif x.typ === CSTParser.Primitive
-        return p_primitive(x, s)
-    elseif x.typ === CSTParser.For
-        return p_loop(x, s)
-    elseif x.typ === CSTParser.While
-        return p_loop(x, s)
-    elseif x.typ === CSTParser.Do
-        return p_do(x, s)
-    elseif x.typ === CSTParser.If
-        return p_if(x, s)
-    elseif x.typ === CSTParser.Try
-        return p_try(x, s)
-    elseif x.typ === CSTParser.TopLevel
-        return p_toplevel(x, s)
-    elseif x.typ === CSTParser.Begin
-        return p_begin(x, s)
-    elseif x.typ === CSTParser.Quote
-        return p_quote(x, s)
-    elseif x.typ === CSTParser.Let
-        return p_let(x, s)
-    elseif x.typ === CSTParser.Vect
-        return p_vect(x, s)
-    elseif x.typ === CSTParser.Braces
-        return p_braces(x, s)
-    elseif x.typ === CSTParser.TupleH
-        return p_tuple(x, s)
-    elseif x.typ === CSTParser.InvisBrackets
-        return p_invisbrackets(x, s)
-    elseif x.typ === CSTParser.Curly
-        return p_curly(x, s)
-    elseif x.typ === CSTParser.Call
-        return p_call(x, s)
-    elseif x.typ === CSTParser.MacroCall
-        return p_macrocall(x, s)
-    elseif x.typ === CSTParser.WhereOpCall
-        return p_wherecall(x, s)
-    elseif x.typ === CSTParser.ConditionalOpCall
-        return p_condcall(x, s)
-    elseif x.typ === CSTParser.BinaryOpCall
-        return p_binarycall(x, s)
-    elseif x.typ === CSTParser.UnaryOpCall
-        return p_unarycall(x, s)
-    elseif x.typ === CSTParser.ChainOpCall
-        return p_chaincall(x, s)
-    elseif x.typ === CSTParser.ColonOpCall
-        return p_coloncall(x, s)
-    elseif x.typ === CSTParser.Comparison
-        return p_chaincall(x, s)
-    elseif x.typ === CSTParser.Kw
-        return p_kw(x, s)
-    elseif x.typ === CSTParser.Parameters
-        return p_params(x, s)
-    elseif x.typ === CSTParser.Local
-        return p_vardef(x, s)
-    elseif x.typ === CSTParser.Global
-        return p_vardef(x, s)
-    elseif x.typ === CSTParser.Const
-        return p_vardef(x, s)
-    elseif x.typ === CSTParser.Return
-        return p_vardef(x, s)
-    elseif x.typ === CSTParser.Import
-        return p_import(x, s)
-    elseif x.typ === CSTParser.Export
-        return p_import(x, s)
-    elseif x.typ === CSTParser.Using
-        return p_import(x, s)
-    elseif x.typ === CSTParser.Row
-        return p_row(x, s)
-    elseif x.typ === CSTParser.Vcat
-        return p_vcat(x, s)
-    elseif x.typ === CSTParser.TypedVcat
-        return p_vcat(x, s)
-    elseif x.typ === CSTParser.Hcat
-        return p_hcat(x, s)
-    elseif x.typ === CSTParser.TypedHcat
-        return p_hcat(x, s)
-    elseif x.typ === CSTParser.Ref
-        return p_ref(x, s)
-    elseif x.typ === CSTParser.Comprehension
-        return p_vect(x, s)
-    elseif x.typ === CSTParser.Generator
-        return p_gen(x, s)
-    elseif x.typ === CSTParser.Filter
-        return p_gen(x, s)
+function pretty(cst::CSTParser.EXPR, s::State)
+    if cst.typ === CSTParser.IDENTIFIER
+        return p_identifier(cst, s)
+    elseif cst.typ === CSTParser.OPERATOR
+        return p_operator(cst, s)
+    elseif cst.typ === CSTParser.PUNCTUATION
+        return p_punctuation(cst, s)
+    elseif cst.typ === CSTParser.KEYWORD
+        return p_keyword(cst, s)
+    elseif cst.typ === CSTParser.LITERAL
+        return p_literal(cst, s)
+    elseif cst.typ === CSTParser.StringH
+        return p_stringh(cst, s)
+    elseif cst.typ === CSTParser.Block
+        return p_block(cst, s)
+    elseif cst.typ === CSTParser.ModuleH
+        return p_module(cst, s)
+    elseif cst.typ === CSTParser.BareModule
+        return p_module(cst, s)
+    elseif cst.typ === CSTParser.FunctionDef
+        return p_function(cst, s)
+    elseif cst.typ === CSTParser.Macro
+        return p_function(cst, s)
+    elseif cst.typ === CSTParser.Primitive
+        return p_primitive(cst, s)
+    elseif cst.typ === CSTParser.Struct
+        return p_struct(cst, s)
+    elseif cst.typ === CSTParser.Mutable
+        return p_mutable(cst, s)
+    elseif cst.typ === CSTParser.Abstract
+        return p_abstract(cst, s)
+    elseif cst.typ === CSTParser.Primitive
+        return p_primitive(cst, s)
+    elseif cst.typ === CSTParser.For
+        return p_loop(cst, s)
+    elseif cst.typ === CSTParser.While
+        return p_loop(cst, s)
+    elseif cst.typ === CSTParser.Do
+        return p_do(cst, s)
+    elseif cst.typ === CSTParser.If
+        return p_if(cst, s)
+    elseif cst.typ === CSTParser.Try
+        return p_try(cst, s)
+    elseif cst.typ === CSTParser.TopLevel
+        return p_toplevel(cst, s)
+    elseif cst.typ === CSTParser.Begin
+        return p_begin(cst, s)
+    elseif cst.typ === CSTParser.Quote
+        return p_quote(cst, s)
+    elseif cst.typ === CSTParser.Let
+        return p_let(cst, s)
+    elseif cst.typ === CSTParser.Vect
+        return p_vect(cst, s)
+    elseif cst.typ === CSTParser.Braces
+        return p_braces(cst, s)
+    elseif cst.typ === CSTParser.TupleH
+        return p_tuple(cst, s)
+    elseif cst.typ === CSTParser.InvisBrackets
+        return p_invisbrackets(cst, s)
+    elseif cst.typ === CSTParser.Curly
+        return p_curly(cst, s)
+    elseif cst.typ === CSTParser.Call
+        return p_call(cst, s)
+    elseif cst.typ === CSTParser.MacroCall
+        return p_macrocall(cst, s)
+    elseif cst.typ === CSTParser.WhereOpCall
+        return p_wherecall(cst, s)
+    elseif cst.typ === CSTParser.ConditionalOpCall
+        return p_condcall(cst, s)
+    elseif cst.typ === CSTParser.BinaryOpCall
+        return p_binarycall(cst, s)
+    elseif cst.typ === CSTParser.UnaryOpCall
+        return p_unarycall(cst, s)
+    elseif cst.typ === CSTParser.ChainOpCall
+        return p_chaincall(cst, s)
+    elseif cst.typ === CSTParser.ColonOpCall
+        return p_coloncall(cst, s)
+    elseif cst.typ === CSTParser.Comparison
+        return p_chaincall(cst, s)
+    elseif cst.typ === CSTParser.Kw
+        return p_kw(cst, s)
+    elseif cst.typ === CSTParser.Parameters
+        return p_params(cst, s)
+    elseif cst.typ === CSTParser.Local
+        return p_vardef(cst, s)
+    elseif cst.typ === CSTParser.Global
+        return p_vardef(cst, s)
+    elseif cst.typ === CSTParser.Const
+        return p_vardef(cst, s)
+    elseif cst.typ === CSTParser.Return
+        return p_vardef(cst, s)
+    elseif cst.typ === CSTParser.Import
+        return p_import(cst, s)
+    elseif cst.typ === CSTParser.Export
+        return p_import(cst, s)
+    elseif cst.typ === CSTParser.Using
+        return p_import(cst, s)
+    elseif cst.typ === CSTParser.Row
+        return p_row(cst, s)
+    elseif cst.typ === CSTParser.Vcat
+        return p_vcat(cst, s)
+    elseif cst.typ === CSTParser.TypedVcat
+        return p_vcat(cst, s)
+    elseif cst.typ === CSTParser.Hcat
+        return p_hcat(cst, s)
+    elseif cst.typ === CSTParser.TypedHcat
+        return p_hcat(cst, s)
+    elseif cst.typ === CSTParser.Ref
+        return p_ref(cst, s)
+    elseif cst.typ === CSTParser.Comprehension
+        return p_vect(cst, s)
+    elseif cst.typ === CSTParser.Generator
+        return p_gen(cst, s)
+    elseif cst.typ === CSTParser.Filter
+        return p_gen(cst, s)
     end
 
-    t = PTree(x, nspaces(s))
-    is_fileh = x.typ === CSTParser.FileH
-    for a in x
+    t = PTree(cst, nspaces(s))
+    is_fileh = cst.typ === CSTParser.FileH
+    for a in cst
         if a.kind === Tokens.NOTHING
             s.offset += a.fullspan
             continue
@@ -453,84 +453,84 @@ function pretty(x::CSTParser.EXPR, s::State)
     t
 end
 
-function p_identifier(x, s)
+function p_identifier(cst::CSTParser.EXPR, s::State)
     loc = cursor_loc(s)
-    s.offset += x.fullspan
-    PTree(x, loc[1], loc[1], x.val)
+    s.offset += cst.fullspan
+    PTree(cst, loc[1], loc[1], cst.val)
 end
 
-function p_operator(x, s)
+function p_operator(cst::CSTParser.EXPR, s::State)
     loc = cursor_loc(s)
-    val = string(CSTParser.Expr(x))
-    s.offset += x.fullspan
-    PTree(x, loc[1], loc[1], val)
+    val = string(CSTParser.Expr(cst))
+    s.offset += cst.fullspan
+    PTree(cst, loc[1], loc[1], val)
 end
 
-function p_keyword(x, s)
+function p_keyword(cst::CSTParser.EXPR, s::State)
     loc = cursor_loc(s)
-    val = x.kind === Tokens.ABSTRACT ? "abstract" :
-        x.kind === Tokens.BAREMODULE ? "baremodule" :
-        x.kind === Tokens.BEGIN ? "begin" :
-        x.kind === Tokens.BREAK ? "break" :
-        x.kind === Tokens.CATCH ? "catch" :
-        x.kind === Tokens.CONST ? "const" :
-        x.kind === Tokens.CONTINUE ? "continue" :
-        x.kind === Tokens.NEW ? "new" :
-        x.kind === Tokens.DO ? "do" :
-        x.kind === Tokens.IF ? "if" :
-        x.kind === Tokens.ELSEIF ? "elseif" :
-        x.kind === Tokens.ELSE ? "else" :
-        x.kind === Tokens.END ? "end" :
-        x.kind === Tokens.EXPORT ? "export" :
-        x.kind === Tokens.FINALLY ? "finally" :
-        x.kind === Tokens.FOR ? "for" :
-        x.kind === Tokens.FUNCTION ? "function" :
-        x.kind === Tokens.GLOBAL ? "global" :
-        x.kind === Tokens.IMPORT ? "import" :
-        x.kind === Tokens.LET ? "let" :
-        x.kind === Tokens.LOCAL ? "local" :
-        x.kind === Tokens.MACRO ? "macro" :
-        x.kind === Tokens.MODULE ? "module" :
-        x.kind === Tokens.MUTABLE ? "mutable" :
-        x.kind === Tokens.OUTER ? "outer " :
-        x.kind === Tokens.PRIMITIVE ? "primitive" :
-        x.kind === Tokens.QUOTE ? "quote" :
-        x.kind === Tokens.RETURN ? "return" :
-        x.kind === Tokens.STRUCT ? "struct" :
-        x.kind === Tokens.TYPE ? "type" :
-        x.kind === Tokens.TRY ? "try" :
-        x.kind === Tokens.USING ? "using" : x.kind === Tokens.WHILE ? "while" : ""
-    s.offset += x.fullspan
-    PTree(x, loc[1], loc[1], val)
+    val = cst.kind === Tokens.ABSTRACT ? "abstract" :
+        cst.kind === Tokens.BAREMODULE ? "baremodule" :
+        cst.kind === Tokens.BEGIN ? "begin" :
+        cst.kind === Tokens.BREAK ? "break" :
+        cst.kind === Tokens.CATCH ? "catch" :
+        cst.kind === Tokens.CONST ? "const" :
+        cst.kind === Tokens.CONTINUE ? "continue" :
+        cst.kind === Tokens.NEW ? "new" :
+        cst.kind === Tokens.DO ? "do" :
+        cst.kind === Tokens.IF ? "if" :
+        cst.kind === Tokens.ELSEIF ? "elseif" :
+        cst.kind === Tokens.ELSE ? "else" :
+        cst.kind === Tokens.END ? "end" :
+        cst.kind === Tokens.EXPORT ? "export" :
+        cst.kind === Tokens.FINALLY ? "finally" :
+        cst.kind === Tokens.FOR ? "for" :
+        cst.kind === Tokens.FUNCTION ? "function" :
+        cst.kind === Tokens.GLOBAL ? "global" :
+        cst.kind === Tokens.IMPORT ? "import" :
+        cst.kind === Tokens.LET ? "let" :
+        cst.kind === Tokens.LOCAL ? "local" :
+        cst.kind === Tokens.MACRO ? "macro" :
+        cst.kind === Tokens.MODULE ? "module" :
+        cst.kind === Tokens.MUTABLE ? "mutable" :
+        cst.kind === Tokens.OUTER ? "outer " :
+        cst.kind === Tokens.PRIMITIVE ? "primitive" :
+        cst.kind === Tokens.QUOTE ? "quote" :
+        cst.kind === Tokens.RETURN ? "return" :
+        cst.kind === Tokens.STRUCT ? "struct" :
+        cst.kind === Tokens.TYPE ? "type" :
+        cst.kind === Tokens.TRY ? "try" :
+        cst.kind === Tokens.USING ? "using" : cst.kind === Tokens.WHILE ? "while" : ""
+    s.offset += cst.fullspan
+    PTree(cst, loc[1], loc[1], val)
 end
 
-function p_punctuation(x, s)
+function p_punctuation(cst::CSTParser.EXPR, s::State)
     loc = cursor_loc(s)
-    val = x.kind === Tokens.LPAREN ? "(" :
-        x.kind === Tokens.LBRACE ? "{" :
-        x.kind === Tokens.LSQUARE ? "[" :
-        x.kind === Tokens.RPAREN ? ")" :
-        x.kind === Tokens.RBRACE ? "}" :
-        x.kind === Tokens.RSQUARE ? "]" :
-        x.kind === Tokens.COMMA ? "," :
-        x.kind === Tokens.SEMICOLON ? ";" :
-        x.kind === Tokens.AT_SIGN ? "@" : x.kind === Tokens.DOT ? "." : ""
-    s.offset += x.fullspan
-    PTree(x, loc[1], loc[1], val)
+    val = cst.kind === Tokens.LPAREN ? "(" :
+        cst.kind === Tokens.LBRACE ? "{" :
+        cst.kind === Tokens.LSQUARE ? "[" :
+        cst.kind === Tokens.RPAREN ? ")" :
+        cst.kind === Tokens.RBRACE ? "}" :
+        cst.kind === Tokens.RSQUARE ? "]" :
+        cst.kind === Tokens.COMMA ? "," :
+        cst.kind === Tokens.SEMICOLON ? ";" :
+        cst.kind === Tokens.AT_SIGN ? "@" : cst.kind === Tokens.DOT ? "." : ""
+    s.offset += cst.fullspan
+    PTree(cst, loc[1], loc[1], val)
 end
 
-function p_literal(x, s)
+function p_literal(cst::CSTParser.EXPR, s::State)
     loc = cursor_loc(s)
-    if !is_str_or_cmd(x.kind)
-        val = x.val
-        if x.kind === Tokens.FLOAT && x.val[end] == '.'
+    if !is_str_or_cmd(cst.kind)
+        val = cst.val
+        if cst.kind === Tokens.FLOAT && cst.val[end] == '.'
             # If a floating point ends in `.`, add trailing zero.
             val *= '0'
-        elseif x.kind === Tokens.FLOAT && x.val[1] == '.'
+        elseif cst.kind === Tokens.FLOAT && cst.val[1] == '.'
             val = '0' * val
         end
-        s.offset += x.fullspan
-        return PTree(x, loc[1], loc[1], val)
+        s.offset += cst.fullspan
+        return PTree(cst, loc[1], loc[1], val)
     end
 
     # Strings are unescaped by CSTParser
@@ -543,20 +543,20 @@ function p_literal(x, s)
     # IDENTIFIER where as CSTParser parses it as a LITERAL.
     # An IDENTIFIER won't show up in the string literal lookup table.
     if str_info === nothing &&
-       (x.parent.typ === CSTParser.x_Str || x.parent.typ === CSTParser.x_Cmd)
-        s.offset += x.fullspan
-        return PTree(x, loc[1], loc[1], x.val)
+       (cst.parent.typ === CSTParser.x_Str || cst.parent.typ === CSTParser.x_Cmd)
+        s.offset += cst.fullspan
+        return PTree(cst, loc[1], loc[1], cst.val)
     end
 
     startline, endline, str = str_info
     # @debug "" loc startline endline str
 
-    s.offset += x.fullspan
+    s.offset += cst.fullspan
 
     lines = split(str, "\n")
 
     if length(lines) == 1
-        return PTree(x, loc[1], loc[1], lines[1])
+        return PTree(cst, loc[1], loc[1], lines[1])
     end
 
     sidx = loc[2]
@@ -569,7 +569,7 @@ function p_literal(x, s)
 
     # @debug "" lines x.val loc loc[2] sidx
 
-    t = PTree(CSTParser.StringH, -1, -1, loc[2] - 1, 0, nothing, PTree[], Ref(x), false, 0)
+    t = PTree(CSTParser.StringH, -1, -1, loc[2] - 1, 0, nothing, PTree[], Ref(cst), false, 0)
     for (i, l) in enumerate(lines)
         ln = startline + i - 1
         l = i == 1 ? l : l[sidx:end]
@@ -591,16 +591,16 @@ function p_literal(x, s)
 end
 
 # StringH
-function p_stringh(x, s)
+function p_stringh(cst::CSTParser.EXPR, s::State)
     loc = cursor_loc(s)
     startline, endline, str = s.doc.lit_strings[s.offset-1]
 
-    s.offset += x.fullspan
+    s.offset += cst.fullspan
 
     lines = split(str, "\n")
 
     if length(lines) == 1
-        t = PTree(x, startline, startline, lines[1])
+        t = PTree(cst, startline, startline, lines[1])
         t.typ = CSTParser.LITERAL
         return t
     end
@@ -615,7 +615,7 @@ function p_stringh(x, s)
 
     # @debug "" lines x.val loc loc[2] sidx
 
-    t = PTree(x, loc[2] - 1)
+    t = PTree(cst, loc[2] - 1)
     for (i, l) in enumerate(lines)
         ln = startline + i - 1
         l = i == 1 ? l : l[sidx:end]
@@ -638,30 +638,30 @@ end
 
 
 # MacroCall
-function p_macrocall(x, s)
-    t = PTree(x, nspaces(s))
-    if x.args[1].typ === CSTParser.GlobalRefDoc
-        # x.args[1] is empty and fullspan is 0 so we can skip it
-        if x.args[2].typ === CSTParser.LITERAL
-            add_node!(t, p_literal(x.args[2], s), s, max_padding = 0)
-        elseif x.args[2].typ == CSTParser.StringH
-            add_node!(t, p_stringh(x.args[2], s), s)
+function p_macrocall(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    if cst[1].typ === CSTParser.GlobalRefDoc
+        # cst[1] is empty and fullspan is 0 so we can skip it
+        if cst[2].typ === CSTParser.LITERAL
+            add_node!(t, p_literal(cst[2], s), s, max_padding = 0)
+        elseif cst[2].typ == CSTParser.StringH
+            add_node!(t, p_stringh(cst[2], s), s)
         end
-        add_node!(t, pretty(x.args[3], s), s, max_padding = 0)
+        add_node!(t, pretty(cst[3], s), s, max_padding = 0)
         return t
     end
 
-    args = get_args(x)
+    args = get_args(cst)
     nest = length(args) > 0 && !(length(args) == 1 && unnestable_arg(args[1]))
-    has_closer = is_closer(x.args[end])
+    has_closer = is_closer(cst.args[end])
 
     # @info "" has_closer
 
     # same as CSTParser.Call but whitespace sensitive
-    for (i, a) in enumerate(x)
+    for (i, a) in enumerate(cst)
         n = pretty(a, s)
         if a.typ === CSTParser.MacroName
-            if a.fullspan - a.span > 0 && length(x) > 1
+            if a.fullspan - a.span > 0 && length(cst) > 1
                 add_node!(t, n, s, join_lines = true)
                 add_node!(t, Whitespace(1), s)
             else
@@ -674,16 +674,16 @@ function p_macrocall(x, s)
         elseif is_closer(n) && nest
             add_node!(t, Placeholder(0), s)
             add_node!(t, n, s, join_lines = true)
-        elseif CSTParser.is_comma(a) && i < length(x) && !is_punc(x.args[i+1])
+        elseif CSTParser.is_comma(a) && i < length(cst) && !is_punc(cst[i+1])
             add_node!(t, n, s, join_lines = true)
             add_node!(t, Placeholder(1), s)
         elseif a.fullspan - a.span > 0
-            if has_closer && i < length(x) - 1
+            if has_closer && i < length(cst) - 1
                 add_node!(t, n, s, join_lines = true)
-                if x.args[i+1].typ !== CSTParser.Parameters
+                if cst[i+1].typ !== CSTParser.Parameters
                     add_node!(t, Whitespace(1), s)
                 end
-            elseif !has_closer && i < length(x)
+            elseif !has_closer && i < length(cst)
                 add_node!(t, n, s, join_lines = true)
                 add_node!(t, Whitespace(1), s)
             else
@@ -698,18 +698,18 @@ end
 
 # Block
 # length Block is the length of the longest expr
-function p_block(x, s; ignore_single_line = false, from_quote = false, join_body = false)
-    t = PTree(x, nspaces(s))
+function p_block(cst::CSTParser.EXPR, s::State; ignore_single_line = false, from_quote = false, join_body = false)
+    t = PTree(cst, nspaces(s))
     single_line = ignore_single_line ? false :
-        cursor_loc(s)[1] == cursor_loc(s, s.offset + x.span - 1)[1]
+        cursor_loc(s)[1] == cursor_loc(s, s.offset + cst.span - 1)[1]
 
     # @info "" from_quote single_line ignore_single_line join_body
-    for (i, a) in enumerate(x)
+    for (i, a) in enumerate(cst)
         n = pretty(a, s)
         if from_quote && !single_line
             if i == 1 || CSTParser.is_comma(a)
                 add_node!(t, n, s, join_lines = true)
-            elseif CSTParser.is_comma(x.args[i-1])
+            elseif CSTParser.is_comma(cst[i-1])
                 add_node!(t, Whitespace(1), s)
                 add_node!(t, n, s, join_lines = true)
             else
@@ -719,7 +719,7 @@ function p_block(x, s; ignore_single_line = false, from_quote = false, join_body
         elseif single_line
             if i == 1 || CSTParser.is_comma(a)
                 add_node!(t, n, s, join_lines = true)
-            elseif CSTParser.is_comma(x.args[i-1])
+            elseif CSTParser.is_comma(cst[i-1])
                 add_node!(t, Placeholder(1), s)
                 add_node!(t, n, s, join_lines = true)
             else
@@ -728,9 +728,9 @@ function p_block(x, s; ignore_single_line = false, from_quote = false, join_body
                 add_node!(t, n, s, join_lines = true)
             end
         else
-            if i < length(x) && CSTParser.is_comma(a) && is_punc(x.args[i+1])
+            if i < length(cst) && CSTParser.is_comma(a) && is_punc(cst[i+1])
                 add_node!(t, n, s, join_lines = true)
-            elseif CSTParser.is_comma(a) && i != length(x)
+            elseif CSTParser.is_comma(a) && i != length(cst)
                 add_node!(t, n, s, join_lines = true)
                 join_body && add_node!(t, Placeholder(1), s)
             elseif join_body
@@ -745,133 +745,133 @@ function p_block(x, s; ignore_single_line = false, from_quote = false, join_body
 end
 
 # Abstract
-function p_abstract(x, s)
-    t = PTree(x, nspaces(s))
-    add_node!(t, pretty(x.args[1], s), s)
+function p_abstract(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    add_node!(t, pretty(cst[1], s), s)
     add_node!(t, Whitespace(1), s)
-    add_node!(t, pretty(x.args[2], s), s, join_lines = true)
+    add_node!(t, pretty(cst[2], s), s, join_lines = true)
     add_node!(t, Whitespace(1), s)
-    add_node!(t, pretty(x.args[3], s), s, join_lines = true)
+    add_node!(t, pretty(cst[3], s), s, join_lines = true)
     add_node!(t, Whitespace(1), s)
-    add_node!(t, pretty(x.args[4], s), s, join_lines = true)
+    add_node!(t, pretty(cst[4], s), s, join_lines = true)
     t
 end
 
 # Primitive
-function p_primitive(x, s)
-    t = PTree(x, nspaces(s))
-    add_node!(t, pretty(x.args[1], s), s)
+function p_primitive(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    add_node!(t, pretty(cst[1], s), s)
     add_node!(t, Whitespace(1), s)
-    add_node!(t, pretty(x.args[2], s), s, join_lines = true)
+    add_node!(t, pretty(cst[2], s), s, join_lines = true)
     add_node!(t, Whitespace(1), s)
-    add_node!(t, pretty(x.args[3], s), s, join_lines = true)
+    add_node!(t, pretty(cst[3], s), s, join_lines = true)
     add_node!(t, Whitespace(1), s)
-    add_node!(t, pretty(x.args[4], s), s, join_lines = true)
+    add_node!(t, pretty(cst[4], s), s, join_lines = true)
     add_node!(t, Whitespace(1), s)
-    add_node!(t, pretty(x.args[5], s), s, join_lines = true)
+    add_node!(t, pretty(cst[5], s), s, join_lines = true)
     t
 end
 
 # FunctionDef/Macro
-function p_function(x, s)
-    t = PTree(x, nspaces(s))
-    add_node!(t, pretty(x.args[1], s), s)
+function p_function(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    add_node!(t, pretty(cst[1], s), s)
     add_node!(t, Whitespace(1), s)
-    add_node!(t, pretty(x.args[2], s), s, join_lines = true)
-    if length(x) > 3
-        if x.args[3].fullspan == 0
+    add_node!(t, pretty(cst[2], s), s, join_lines = true)
+    if length(cst) > 3
+        if cst[3].fullspan == 0
             add_node!(t, Whitespace(1), s)
-            add_node!(t, pretty(x.args[4], s), s, join_lines = true)
+            add_node!(t, pretty(cst[4], s), s, join_lines = true)
         else
             s.indent += s.indent_size
             add_node!(
                 t,
-                p_block(x.args[3], s, ignore_single_line = true),
+                p_block(cst[3], s, ignore_single_line = true),
                 s,
                 max_padding = s.indent_size,
             )
             s.indent -= s.indent_size
-            add_node!(t, pretty(x.args[4], s), s)
+            add_node!(t, pretty(cst[4], s), s)
         end
     else
         # function stub, i.e. "function foo end"
         # this should be on one line
         add_node!(t, Whitespace(1), s)
-        add_node!(t, pretty(x.args[3], s), s, join_lines = true)
+        add_node!(t, pretty(cst[3], s), s, join_lines = true)
     end
     t
 end
 
 # Struct
-function p_struct(x, s)
-    t = PTree(x, nspaces(s))
-    add_node!(t, pretty(x.args[1], s), s)
+function p_struct(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    add_node!(t, pretty(cst[1], s), s)
     add_node!(t, Whitespace(1), s)
-    add_node!(t, pretty(x.args[2], s), s, join_lines = true)
-    if x.args[3].fullspan == 0
+    add_node!(t, pretty(cst[2], s), s, join_lines = true)
+    if cst[3].fullspan == 0
         add_node!(t, Whitespace(1), s)
-        add_node!(t, pretty(x.args[4], s), s, join_lines = true)
+        add_node!(t, pretty(cst[4], s), s, join_lines = true)
     else
         s.indent += s.indent_size
         add_node!(
             t,
-            p_block(x.args[3], s, ignore_single_line = true),
+            p_block(cst[3], s, ignore_single_line = true),
             s,
             max_padding = s.indent_size,
         )
         s.indent -= s.indent_size
-        add_node!(t, pretty(x.args[4], s), s)
+        add_node!(t, pretty(cst[4], s), s)
     end
     t
 end
 
 # Mutable
-function p_mutable(x, s)
-    t = PTree(x, nspaces(s))
-    add_node!(t, pretty(x.args[1], s), s)
+function p_mutable(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    add_node!(t, pretty(cst[1], s), s)
     add_node!(t, Whitespace(1), s)
-    add_node!(t, pretty(x.args[2], s), s, join_lines = true)
+    add_node!(t, pretty(cst[2], s), s, join_lines = true)
     add_node!(t, Whitespace(1), s)
-    add_node!(t, pretty(x.args[3], s), s, join_lines = true)
-    if x.args[4].fullspan == 0
+    add_node!(t, pretty(cst[3], s), s, join_lines = true)
+    if cst[4].fullspan == 0
         add_node!(t, Whitespace(1), s)
-        add_node!(t, pretty(x.args[5], s), s, join_lines = true)
+        add_node!(t, pretty(cst[5], s), s, join_lines = true)
     else
         s.indent += s.indent_size
         add_node!(
             t,
-            p_block(x.args[4], s, ignore_single_line = true),
+            p_block(cst[4], s, ignore_single_line = true),
             s,
             max_padding = s.indent_size,
         )
         s.indent -= s.indent_size
-        add_node!(t, pretty(x.args[5], s), s)
+        add_node!(t, pretty(cst[5], s), s)
     end
     t
 end
 
 # ModuleH/BareModule
-function p_module(x, s)
-    t = PTree(x, nspaces(s))
-    add_node!(t, pretty(x.args[1], s), s)
+function p_module(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    add_node!(t, pretty(cst[1], s), s)
     add_node!(t, Whitespace(1), s)
-    add_node!(t, pretty(x.args[2], s), s, join_lines = true)
-    if x.args[3].fullspan == 0
+    add_node!(t, pretty(cst[2], s), s, join_lines = true)
+    if cst[3].fullspan == 0
         add_node!(t, Whitespace(1), s)
-        add_node!(t, pretty(x.args[4], s), s, join_lines = true)
+        add_node!(t, pretty(cst[4], s), s, join_lines = true)
     else
-        add_node!(t, pretty(x.args[3], s), s, max_padding = 0)
-        add_node!(t, pretty(x.args[4], s), s)
+        add_node!(t, pretty(cst[3], s), s, max_padding = 0)
+        add_node!(t, pretty(cst[4], s), s)
     end
     t
 end
 
 # Const/Local/Global/Return
-function p_vardef(x, s)
-    t = PTree(x, nspaces(s))
-    add_node!(t, pretty(x.args[1], s), s)
-    if x.args[2].fullspan != 0
-        for a in x.args[2:end]
+function p_vardef(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    add_node!(t, pretty(cst[1], s), s)
+    if cst[2].fullspan != 0
+        for a in cst.args[2:end]
             add_node!(t, Whitespace(1), s)
             add_node!(t, pretty(a, s), s, join_lines = true)
         end
@@ -880,9 +880,9 @@ function p_vardef(x, s)
 end
 
 # TopLevel
-function p_toplevel(x, s)
-    t = PTree(x, nspaces(s))
-    for a in x.args
+function p_toplevel(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    for a in cst.args
         if a.kind === Tokens.NOTHING
             s.offset += a.fullspan
             continue
@@ -894,47 +894,47 @@ function p_toplevel(x, s)
 end
 
 # Begin
-function p_begin(x, s)
-    t = PTree(x, nspaces(s))
-    add_node!(t, pretty(x.args[1], s), s)
-    if x.args[2].fullspan == 0
+function p_begin(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    add_node!(t, pretty(cst[1], s), s)
+    if cst[2].fullspan == 0
         add_node!(t, Whitespace(1), s)
-        add_node!(t, pretty(x.args[3], s), s, join_lines = true)
+        add_node!(t, pretty(cst[3], s), s, join_lines = true)
     else
         s.indent += s.indent_size
         add_node!(
             t,
-            p_block(x.args[2], s, ignore_single_line = true),
+            p_block(cst[2], s, ignore_single_line = true),
             s,
             max_padding = s.indent_size,
         )
         s.indent -= s.indent_size
-        add_node!(t, pretty(x.args[3], s), s)
+        add_node!(t, pretty(cst[3], s), s)
     end
     t
 end
 
 # Quote
-function p_quote(x, s)
-    t = PTree(x, nspaces(s))
-    if x.args[1].typ === CSTParser.KEYWORD && x.args[1].kind === Tokens.QUOTE
-        add_node!(t, pretty(x.args[1], s), s)
-        if x.args[2].fullspan == 0
+function p_quote(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    if cst[1].typ === CSTParser.KEYWORD && cst[1].kind === Tokens.QUOTE
+        add_node!(t, pretty(cst[1], s), s)
+        if cst[2].fullspan == 0
             add_node!(t, Whitespace(1), s)
-            add_node!(t, pretty(x.args[3], s), s, join_lines = true)
+            add_node!(t, pretty(cst[3], s), s, join_lines = true)
         else
             s.indent += s.indent_size
             add_node!(
                 t,
-                p_block(x.args[2], s, ignore_single_line = true),
+                p_block(cst[2], s, ignore_single_line = true),
                 s,
                 max_padding = s.indent_size,
             )
             s.indent -= s.indent_size
-            add_node!(t, pretty(x.args[3], s), s)
+            add_node!(t, pretty(cst[3], s), s)
         end
     else
-        for a in x.args
+        for a in cst.args
             add_node!(t, pretty(a, s), s, join_lines = true)
         end
     end
@@ -952,16 +952,16 @@ end
 # y, back = let
 #     body
 # end
-function p_let(x, s)
-    t = PTree(x, nspaces(s))
-    add_node!(t, pretty(x.args[1], s), s)
-    if length(x.args) > 3
+function p_let(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    add_node!(t, pretty(cst[1], s), s)
+    if length(cst.args) > 3
         add_node!(t, Whitespace(1), s)
         s.indent += s.indent_size
-        if x.args[2].typ === CSTParser.Block
-            add_node!(t, p_block(x.args[2], s, join_body = true), s, join_lines = true)
+        if cst[2].typ === CSTParser.Block
+            add_node!(t, p_block(cst[2], s, join_body = true), s, join_lines = true)
         else
-            add_node!(t, pretty(x.args[2], s), s, join_lines = true)
+            add_node!(t, pretty(cst[2], s), s, join_lines = true)
         end
         s.indent -= s.indent_size
 
@@ -969,22 +969,22 @@ function p_let(x, s)
         s.indent += s.indent_size
         add_node!(
             t,
-            p_block(x.args[3], s, ignore_single_line = true),
+            p_block(cst[3], s, ignore_single_line = true),
             s,
             max_padding = s.indent_size,
         )
         s.indent -= s.indent_size
         # Possible newline after args if nested to act as a separator
         # to the block body.
-        if x.args[2].typ === CSTParser.Block && t.nodes[end-2].typ !== NOTCODE
+        if cst[2].typ === CSTParser.Block && t.nodes[end-2].typ !== NOTCODE
             add_node!(t.nodes[idx], Placeholder(0), s)
         end
-        add_node!(t, pretty(x.args[end], s), s)
+        add_node!(t, pretty(cst.args[end], s), s)
     else
         s.indent += s.indent_size
-        add_node!(t, p_block(x.args[2], s, ignore_single_line = true), s)
+        add_node!(t, p_block(cst[2], s, ignore_single_line = true), s)
         s.indent -= s.indent_size
-        add_node!(t, pretty(x.args[end], s), s)
+        add_node!(t, pretty(cst.args[end], s), s)
     end
     t
 end
@@ -1008,46 +1008,46 @@ end
 # for i = 1:10 body end
 #
 # https://github.com/domluna/JuliaFormatter.jl/issues/34
-function eq_to_in_normalization!(x, always_for_in)
-    if x.typ === CSTParser.BinaryOpCall
-        op = x.args[2]
-        arg2 = x.args[3]
+function eq_to_in_normalization!(cst::CSTParser.EXPR, always_for_in::Bool)
+    if cst.typ === CSTParser.BinaryOpCall
+        op = cst[2]
+        arg2 = cst[3]
 
         if always_for_in
-            x.args[2].kind = Tokens.IN
+            cst[2].kind = Tokens.IN
             return
         end
 
         if op.kind === Tokens.EQ && !is_colon_op(arg2)
-            x.args[2].kind = Tokens.IN
+            cst[2].kind = Tokens.IN
         elseif op.kind === Tokens.IN && is_colon_op(arg2)
-            x.args[2].kind = Tokens.EQ
+            cst[2].kind = Tokens.EQ
         end
-    elseif x.typ === CSTParser.Block || x.typ === CSTParser.InvisBrackets
-        for a in x.args
+    elseif cst.typ === CSTParser.Block || cst.typ === CSTParser.InvisBrackets
+        for a in cst
             eq_to_in_normalization!(a, always_for_in)
         end
     end
 end
 
 # For/While
-function p_loop(x, s)
-    t = PTree(x, nspaces(s))
-    add_node!(t, pretty(x.args[1], s), s)
+function p_loop(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    add_node!(t, pretty(cst[1], s), s)
     add_node!(t, Whitespace(1), s)
-    if x.args[1].kind === Tokens.FOR
-        eq_to_in_normalization!(x.args[2], s.opts.always_for_in)
+    if cst[1].kind === Tokens.FOR
+        eq_to_in_normalization!(cst[2], s.opts.always_for_in)
     end
-    if x.args[2].typ === CSTParser.Block
-        add_node!(t, p_block(x.args[2], s, join_body = true), s, join_lines = true)
+    if cst[2].typ === CSTParser.Block
+        add_node!(t, p_block(cst[2], s, join_body = true), s, join_lines = true)
     else
-        add_node!(t, pretty(x.args[2], s), s, join_lines = true)
+        add_node!(t, pretty(cst[2], s), s, join_lines = true)
     end
     idx = length(t.nodes)
     s.indent += s.indent_size
     add_node!(
         t,
-        p_block(x.args[3], s, ignore_single_line = true),
+        p_block(cst[3], s, ignore_single_line = true),
         s,
         max_padding = s.indent_size,
     )
@@ -1055,41 +1055,41 @@ function p_loop(x, s)
 
     # Possible newline after args if nested to act as a separator
     # to the block body.
-    if x.args[2].typ === CSTParser.Block && t.nodes[end-2].typ !== NOTCODE
+    if cst[2].typ === CSTParser.Block && t.nodes[end-2].typ !== NOTCODE
         add_node!(t.nodes[idx], Placeholder(0), s)
     end
-    add_node!(t, pretty(x.args[4], s), s)
+    add_node!(t, pretty(cst[4], s), s)
     t
 end
 
 # Do
-function p_do(x, s)
-    t = PTree(x, nspaces(s))
-    add_node!(t, pretty(x.args[1], s), s)
+function p_do(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    add_node!(t, pretty(cst[1], s), s)
     add_node!(t, Whitespace(1), s)
-    add_node!(t, pretty(x.args[2], s), s, join_lines = true)
-    if x.args[3].fullspan != 0
+    add_node!(t, pretty(cst[2], s), s, join_lines = true)
+    if cst[3].fullspan != 0
         add_node!(t, Whitespace(1), s)
-        add_node!(t, pretty(x.args[3], s), s, join_lines = true)
+        add_node!(t, pretty(cst[3], s), s, join_lines = true)
     end
-    if x.args[4].typ === CSTParser.Block
+    if cst[4].typ === CSTParser.Block
         s.indent += s.indent_size
         add_node!(
             t,
-            p_block(x.args[4], s, ignore_single_line = true),
+            p_block(cst[4], s, ignore_single_line = true),
             s,
             max_padding = s.indent_size,
         )
         s.indent -= s.indent_size
     end
-    add_node!(t, pretty(x.args[end], s), s)
+    add_node!(t, pretty(cst.args[end], s), s)
     t
 end
 
 # Try
-function p_try(x, s)
-    t = PTree(x, nspaces(s))
-    for a in x.args
+function p_try(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    for a in cst.args
         if a.fullspan == 0
         elseif a.typ === CSTParser.KEYWORD
             add_node!(t, pretty(a, s), s, max_padding = 0)
@@ -1115,27 +1115,27 @@ function p_try(x, s)
 end
 
 # If
-function p_if(x, s)
-    t = PTree(x, nspaces(s))
-    if x.args[1].typ === CSTParser.KEYWORD && x.args[1].kind === Tokens.IF
-        add_node!(t, pretty(x.args[1], s), s)
+function p_if(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    if cst[1].typ === CSTParser.KEYWORD && cst[1].kind === Tokens.IF
+        add_node!(t, pretty(cst[1], s), s)
         add_node!(t, Whitespace(1), s)
-        add_node!(t, pretty(x.args[2], s), s, join_lines = true)
+        add_node!(t, pretty(cst[2], s), s, join_lines = true)
         s.indent += s.indent_size
         add_node!(
             t,
-            p_block(x.args[3], s, ignore_single_line = true),
+            p_block(cst[3], s, ignore_single_line = true),
             s,
             max_padding = s.indent_size,
         )
         s.indent -= s.indent_size
 
         len = length(t)
-        if length(x.args) > 4
-            add_node!(t, pretty(x.args[4], s), s, max_padding = 0)
-            if x.args[4].kind === Tokens.ELSEIF
+        if length(cst.args) > 4
+            add_node!(t, pretty(cst[4], s), s, max_padding = 0)
+            if cst[4].kind === Tokens.ELSEIF
                 add_node!(t, Whitespace(1), s)
-                n = pretty(x.args[5], s)
+                n = pretty(cst[5], s)
                 add_node!(t, n, s, join_lines = true)
                 # "elseif n"
                 t.len = max(len, length(n))
@@ -1144,7 +1144,7 @@ function p_if(x, s)
                 s.indent += s.indent_size
                 add_node!(
                     t,
-                    p_block(x.args[5], s, ignore_single_line = true),
+                    p_block(cst[5], s, ignore_single_line = true),
                     s,
                     max_padding = s.indent_size,
                 )
@@ -1152,29 +1152,29 @@ function p_if(x, s)
             end
         end
         # END KEYWORD
-        add_node!(t, pretty(x.args[end], s), s)
+        add_node!(t, pretty(cst.args[end], s), s)
     else
         # "cond" part of "elseif cond"
         t.len += 7
-        add_node!(t, pretty(x.args[1], s), s)
+        add_node!(t, pretty(cst[1], s), s)
 
         s.indent += s.indent_size
         add_node!(
             t,
-            p_block(x.args[2], s, ignore_single_line = true),
+            p_block(cst[2], s, ignore_single_line = true),
             s,
             max_padding = s.indent_size,
         )
         s.indent -= s.indent_size
 
         len = length(t)
-        if length(x.args) > 2
+        if length(cst.args) > 2
             # this either else or elseif keyword
-            add_node!(t, pretty(x.args[3], s), s, max_padding = 0)
+            add_node!(t, pretty(cst[3], s), s, max_padding = 0)
 
-            if x.args[3].kind === Tokens.ELSEIF
+            if cst[3].kind === Tokens.ELSEIF
                 add_node!(t, Whitespace(1), s)
-                n = pretty(x.args[4], s)
+                n = pretty(cst[4], s)
                 add_node!(t, n, s, join_lines = true)
                 # "elseif n"
                 t.len = max(len, length(n))
@@ -1182,7 +1182,7 @@ function p_if(x, s)
                 s.indent += s.indent_size
                 add_node!(
                     t,
-                    p_block(x.args[4], s, ignore_single_line = true),
+                    p_block(cst[4], s, ignore_single_line = true),
                     s,
                     max_padding = s.indent_size,
                 )
@@ -1194,10 +1194,10 @@ function p_if(x, s)
 end
 
 # ChainOpCall/Comparison
-function p_chaincall(x, s; nonest = false, nospace = false)
-    t = PTree(x, nspaces(s))
+function p_chaincall(cst::CSTParser.EXPR, s::State; nonest = false, nospace = false)
+    t = PTree(cst, nspaces(s))
     nws = nospace ? 0 : 1
-    for (i, a) in enumerate(x)
+    for (i, a) in enumerate(cst)
         n = pretty(a, s)
         if a.typ === CSTParser.OPERATOR
             !nospace && add_node!(t, Whitespace(1), s)
@@ -1207,7 +1207,7 @@ function p_chaincall(x, s; nonest = false, nospace = false)
             else
                 add_node!(t, Placeholder(nws), s)
             end
-        elseif i == length(x) - 1 && is_punc(a) && is_punc(x.args[i+1])
+        elseif i == length(cst) - 1 && is_punc(a) && is_punc(cst[i+1])
             add_node!(t, n, s, join_lines = true)
         else
             add_node!(t, n, s, join_lines = true)
@@ -1217,10 +1217,10 @@ function p_chaincall(x, s; nonest = false, nospace = false)
 end
 
 # ColonOpCall
-function p_coloncall(x, s)
-    t = PTree(x, nspaces(s))
+function p_coloncall(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
     nospace = !s.opts.whitespace_ops_in_indices
-    for a in x
+    for a in cst
         if a.typ === CSTParser.BinaryOpCall
             n = p_binarycall(a, s, nonest = true, nospace = nospace)
         elseif a.typ === CSTParser.InvisBrackets
@@ -1245,9 +1245,9 @@ function p_coloncall(x, s)
 end
 
 # Kw
-function p_kw(x, s)
-    t = PTree(x, nspaces(s))
-    for a in x
+function p_kw(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    for a in cst
         if a.kind === Tokens.EQ
             add_node!(t, Whitespace(1), s)
             add_node!(t, pretty(a, s), s, join_lines = true)
@@ -1259,47 +1259,47 @@ function p_kw(x, s)
     t
 end
 
-is_str(x) = is_str_or_cmd(x.kind) || is_str_or_cmd(x.typ)
+is_str(cst::CSTParser.EXPR) = is_str_or_cmd(cst.kind) || is_str_or_cmd(cst.typ)
 
-is_iterable(x) =
+is_iterable(x::Union{CSTParser.EXPR,PTree}) =
     x.typ === CSTParser.TupleH || x.typ === CSTParser.Vect ||
     x.typ === CSTParser.Vcat || x.typ === CSTParser.Braces || x.typ === CSTParser.Call ||
     x.typ === CSTParser.Curly || x.typ === CSTParser.Comprehension ||
     x.typ === CSTParser.MacroCall || x.typ === CSTParser.InvisBrackets ||
     x.typ === CSTParser.Ref || x.typ === CSTParser.TypedVcat
 
-is_block(x::CSTParser.EXPR) =
-    x.typ === CSTParser.If || x.typ === CSTParser.Do || x.typ === CSTParser.Try ||
-    x.typ === CSTParser.For || x.typ === CSTParser.While || x.typ === CSTParser.Let
+is_block(cst::CSTParser.EXPR) =
+    cst.typ === CSTParser.If || cst.typ === CSTParser.Do || cst.typ === CSTParser.Try ||
+    cst.typ === CSTParser.For || cst.typ === CSTParser.While || cst.typ === CSTParser.Let
 
-nest_assignment(x::CSTParser.EXPR) = CSTParser.precedence(x[2].kind) == 1
+nest_assignment(cst::CSTParser.EXPR) = CSTParser.precedence(cst[2].kind) == 1
 
-unnestable_arg(x) =
-    is_iterable(x) || is_str(x) || x.typ === CSTParser.LITERAL ||
-    (x.typ === CSTParser.BinaryOpCall && x[2].kind === Tokens.DOT)
+unnestable_arg(cst::CSTParser.EXPR) =
+    is_iterable(cst) || is_str(cst) || cst.typ === CSTParser.LITERAL ||
+    (cst.typ === CSTParser.BinaryOpCall && cst[2].kind === Tokens.DOT)
 
-function nestable(x::CSTParser.EXPR)
-    CSTParser.defines_function(x) && x[1].typ !== CSTParser.UnaryOpCall && return true
-    nest_assignment(x) && !is_str(x[3]) && return true
-    CSTParser.precedence(x[2]) in (1, 6) && return false
+function nestable(cst::CSTParser.EXPR)
+    CSTParser.defines_function(cst) && cst[1].typ !== CSTParser.UnaryOpCall && return true
+    nest_assignment(cst) && !is_str(cst[3]) && return true
+    CSTParser.precedence(cst[2]) in (1, 6) && return false
     true
 end
 
-function nest_arg2(x::CSTParser.EXPR)
-    if CSTParser.defines_function(x)
-        arg2 = x.args[3]
-        arg2.typ === CSTParser.Block && (arg2 = arg2.args[1])
+function nest_arg2(cst::CSTParser.EXPR)
+    if CSTParser.defines_function(cst)
+        arg2 = cst[3]
+        arg2.typ === CSTParser.Block && (arg2 = arg2[1])
         return is_block(arg2)
     end
     false
 end
 
 # BinaryOpCall
-function p_binarycall(x, s; nonest = false, nospace = false)
-    t = PTree(x, nspaces(s))
-    op = x[2]
+function p_binarycall(cst::CSTParser.EXPR, s::State; nonest = false, nospace = false)
+    t = PTree(cst, nspaces(s))
+    op = cst[2]
     nonest = nonest || op.kind === Tokens.COLON
-    if x.parent.typ === CSTParser.Curly &&
+    if cst.parent.typ === CSTParser.Curly &&
        op.kind in (Tokens.ISSUBTYPE, Tokens.ISSUPERTYPE) && !s.opts.whitespace_typedefs
         nospace = true
     elseif op.kind === Tokens.COLON
@@ -1307,18 +1307,18 @@ function p_binarycall(x, s; nonest = false, nospace = false)
     end
     nospace_args = s.opts.whitespace_ops_in_indices ? false : nospace
 
-    if x[1].typ === CSTParser.BinaryOpCall
-        n = p_binarycall(x[1], s, nonest = nonest, nospace = nospace_args)
-    elseif x[1].typ === CSTParser.InvisBrackets
-        n = p_invisbrackets(x[1], s, nonest = nonest, nospace = nospace_args)
-    elseif x[1].typ === CSTParser.ChainOpCall || x[1].typ === CSTParser.Comparison
-        n = p_chaincall(x[1], s, nonest = nonest, nospace = nospace_args)
+    if cst[1].typ === CSTParser.BinaryOpCall
+        n = p_binarycall(cst[1], s, nonest = nonest, nospace = nospace_args)
+    elseif cst[1].typ === CSTParser.InvisBrackets
+        n = p_invisbrackets(cst[1], s, nonest = nonest, nospace = nospace_args)
+    elseif cst[1].typ === CSTParser.ChainOpCall || cst[1].typ === CSTParser.Comparison
+        n = p_chaincall(cst[1], s, nonest = nonest, nospace = nospace_args)
     else
-        n = pretty(x[1], s)
+        n = pretty(cst[1], s)
     end
 
     if op.kind === Tokens.COLON &&
-       s.opts.whitespace_ops_in_indices && !is_leaf(x[1]) && !is_iterable(x[1])
+       s.opts.whitespace_ops_in_indices && !is_leaf(cst[1]) && !is_iterable(cst[1])
         paren = PTree(CSTParser.PUNCTUATION, n.startline, n.startline, "(")
         add_node!(t, paren, s)
         add_node!(t, n, s, join_lines = true)
@@ -1328,12 +1328,12 @@ function p_binarycall(x, s; nonest = false, nospace = false)
         add_node!(t, n, s)
     end
 
-    narg2 = nest_arg2(x)
+    narg2 = nest_arg2(cst)
     narg2 && (t.force_nest = true)
-    nest = (nestable(x) && !nonest) || narg2
-    # @info "" nestable(x) !nonest narg2 nest x[2]
+    nest = (nestable(cst) && !nonest) || narg2
+    # @info "" nestable(cst) !nonest narg2 nest cst[2]
 
-    if op.fullspan == 0 && x[3].typ === CSTParser.IDENTIFIER
+    if op.fullspan == 0 && cst[3].typ === CSTParser.IDENTIFIER
         # do nothing
     elseif op.kind === Tokens.EX_OR
         add_node!(t, Whitespace(1), s)
@@ -1353,18 +1353,18 @@ function p_binarycall(x, s; nonest = false, nospace = false)
         nest ? add_node!(t, Placeholder(1), s) : add_node!(t, Whitespace(1), s)
     end
 
-    if x[3].typ === CSTParser.BinaryOpCall
-        n = p_binarycall(x[3], s, nonest = nonest, nospace = nospace_args)
-    elseif x[3].typ === CSTParser.InvisBrackets
-        n = p_invisbrackets(x[3], s, nonest = nonest, nospace = nospace_args)
-    elseif x[3].typ === CSTParser.ChainOpCall || x[3].typ === CSTParser.Comparison
-        n = p_chaincall(x[3], s, nonest = nonest, nospace = nospace_args)
+    if cst[3].typ === CSTParser.BinaryOpCall
+        n = p_binarycall(cst[3], s, nonest = nonest, nospace = nospace_args)
+    elseif cst[3].typ === CSTParser.InvisBrackets
+        n = p_invisbrackets(cst[3], s, nonest = nonest, nospace = nospace_args)
+    elseif cst[3].typ === CSTParser.ChainOpCall || cst[3].typ === CSTParser.Comparison
+        n = p_chaincall(cst[3], s, nonest = nonest, nospace = nospace_args)
     else
-        n = pretty(x[3], s)
+        n = pretty(cst[3], s)
     end
 
     if op.kind === Tokens.COLON &&
-       s.opts.whitespace_ops_in_indices && !is_leaf(x[3]) && !is_iterable(x[3])
+       s.opts.whitespace_ops_in_indices && !is_leaf(cst[3]) && !is_iterable(cst[3])
         paren = PTree(CSTParser.PUNCTUATION, n.startline, n.startline, "(")
         add_node!(t, paren, s, join_lines = true)
         add_node!(t, n, s, join_lines = true)
@@ -1384,24 +1384,24 @@ end
 
 # WhereOpCall
 # A where B
-function p_wherecall(x, s)
-    t = PTree(x, nspaces(s))
-    add_node!(t, pretty(x.args[1], s), s)
+function p_wherecall(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    add_node!(t, pretty(cst[1], s), s)
 
     add_node!(t, Whitespace(1), s)
-    add_node!(t, pretty(x.args[2], s), s, join_lines = true)
+    add_node!(t, pretty(cst[2], s), s, join_lines = true)
     add_node!(t, Whitespace(1), s)
 
     # Used to mark where `B` starts.
     add_node!(t, Placeholder(0), s)
 
-    nest = length(CSTParser.get_where_params(x)) > 0
-    args = get_args(x.args[3:end])
-    # nest = length(args) > 0 && !(length(CSTParser.get_where_params(x)) == 1 && unnestable_arg(x[1]))
+    nest = length(CSTParser.get_where_params(cst)) > 0
+    args = get_args(cst.args[3:end])
+    # nest = length(args) > 0 && !(length(CSTParser.get_where_params(cst)) == 1 && unnestable_arg(cst[1]))
     nest = length(args) > 0 && !(length(args) == 1 && unnestable_arg(args[1]))
     add_braces =
-        !CSTParser.is_lbrace(x[3]) && x.parent.typ !== CSTParser.Curly &&
-        x[3].typ !== CSTParser.Curly && x[3].typ !== CSTParser.BracesCat
+        !CSTParser.is_lbrace(cst[3]) && cst.parent.typ !== CSTParser.Curly &&
+        cst[3].typ !== CSTParser.Curly && cst[3].typ !== CSTParser.BracesCat
 
     add_braces && add_node!(
         t,
@@ -1411,8 +1411,8 @@ function p_wherecall(x, s)
     )
 
     nws = s.opts.whitespace_typedefs ? 1 : 0
-    # @debug "" nest in_braces x.args[3].val == "{" x.args[end].val
-    for (i, a) in enumerate(x.args[3:end])
+    # @debug "" nest in_braces cst[3].val == "{" cst.args[end].val
+    for (i, a) in enumerate(cst.args[3:end])
         if is_opener(a) && nest
             add_node!(t, pretty(a, s), s, join_lines = true)
             add_node!(t, Placeholder(0), s)
@@ -1422,7 +1422,7 @@ function p_wherecall(x, s)
             add_node!(t, Placeholder(0), s)
             add_node!(t, pretty(a, s), s, join_lines = true)
             s.indent -= s.indent_size
-        elseif CSTParser.is_comma(a) && !is_punc(x.args[i+3])
+        elseif CSTParser.is_comma(a) && !is_punc(cst[i+3])
             add_node!(t, pretty(a, s), s, join_lines = true)
             add_node!(t, Placeholder(nws), s)
         elseif a.typ === CSTParser.BinaryOpCall
@@ -1446,50 +1446,50 @@ function p_wherecall(x, s)
 end
 
 # Conditional
-function p_condcall(x, s)
-    t = PTree(x, nspaces(s))
-    add_node!(t, pretty(x.args[1], s), s)
+function p_condcall(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    add_node!(t, pretty(cst[1], s), s)
     add_node!(t, Whitespace(1), s)
-    add_node!(t, pretty(x.args[2], s), s, join_lines = true)
+    add_node!(t, pretty(cst[2], s), s, join_lines = true)
     add_node!(t, Placeholder(1), s)
 
-    add_node!(t, pretty(x.args[3], s), s, join_lines = true)
+    add_node!(t, pretty(cst[3], s), s, join_lines = true)
     add_node!(t, Whitespace(1), s)
-    add_node!(t, pretty(x.args[4], s), s, join_lines = true)
+    add_node!(t, pretty(cst[4], s), s, join_lines = true)
     add_node!(t, Placeholder(1), s)
 
-    add_node!(t, pretty(x.args[5], s), s, join_lines = true)
+    add_node!(t, pretty(cst[5], s), s, join_lines = true)
     t
 end
 
 # UnaryOpCall
-function p_unarycall(x, s; nospace = true)
-    t = PTree(x, nspaces(s))
-    add_node!(t, pretty(x[1], s), s)
+function p_unarycall(cst::CSTParser.EXPR, s::State; nospace = true)
+    t = PTree(cst, nspaces(s))
+    add_node!(t, pretty(cst[1], s), s)
     !nospace && add_node!(t, Whitespace(1), s)
-    add_node!(t, pretty(x[2], s), s, join_lines = true)
+    add_node!(t, pretty(cst[2], s), s, join_lines = true)
     t
 end
 
-function p_curly(x, s)
-    t = PTree(x, nspaces(s))
-    add_node!(t, pretty(x.args[1], s), s)
-    add_node!(t, pretty(x.args[2], s), s, join_lines = true)
+function p_curly(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    add_node!(t, pretty(cst[1], s), s)
+    add_node!(t, pretty(cst[2], s), s, join_lines = true)
 
-    args = get_args(x)
-    nest = length(args) > 0 && !(length(args) == 1 && unnestable_arg(x[1]))
+    args = get_args(cst)
+    nest = length(args) > 0 && !(length(args) == 1 && unnestable_arg(cst[1]))
 
     nws = s.opts.whitespace_typedefs ? 1 : 0
     if nest
         add_node!(t, Placeholder(0), s)
     end
 
-    for (i, a) in enumerate(x.args[3:end])
-        if i + 2 == length(x) && nest
+    for (i, a) in enumerate(cst.args[3:end])
+        if i + 2 == length(cst) && nest
             add_node!(t, TrailingComma(), s)
             add_node!(t, Placeholder(0), s)
             add_node!(t, pretty(a, s), s, join_lines = true)
-        elseif CSTParser.is_comma(a) && i < length(x) - 3 && !is_punc(x.args[i+3])
+        elseif CSTParser.is_comma(a) && i < length(cst) - 3 && !is_punc(cst[i+3])
             add_node!(t, pretty(a, s), s, join_lines = true)
             add_node!(t, Placeholder(nws), s)
         else
@@ -1499,24 +1499,24 @@ function p_curly(x, s)
     t
 end
 
-function p_call(x, s)
-    t = PTree(x, nspaces(s))
-    add_node!(t, pretty(x.args[1], s), s)
-    add_node!(t, pretty(x.args[2], s), s, join_lines = true)
+function p_call(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    add_node!(t, pretty(cst[1], s), s)
+    add_node!(t, pretty(cst[2], s), s, join_lines = true)
 
-    args = get_args(x)
+    args = get_args(cst)
     nest = length(args) > 0 && !(length(args) == 1 && unnestable_arg(args[1]))
 
     if nest
         add_node!(t, Placeholder(0), s)
     end
 
-    for (i, a) in enumerate(x.args[3:end])
-        if i + 2 == length(x) && nest
+    for (i, a) in enumerate(cst.args[3:end])
+        if i + 2 == length(cst) && nest
             add_node!(t, TrailingComma(), s)
             add_node!(t, Placeholder(0), s)
             add_node!(t, pretty(a, s), s, join_lines = true)
-        elseif CSTParser.is_comma(a) && i < length(x) - 3 && !is_punc(x.args[i+3])
+        elseif CSTParser.is_comma(a) && i < length(cst) - 3 && !is_punc(cst[i+3])
             add_node!(t, pretty(a, s), s, join_lines = true)
             add_node!(t, Placeholder(1), s)
         else
@@ -1527,12 +1527,12 @@ function p_call(x, s)
 end
 
 # InvisBrackets
-function p_invisbrackets(x, s; nonest = false, nospace = false)
-    t = PTree(x, nspaces(s))
-    nest = !is_iterable(x[2]) && !nonest
+function p_invisbrackets(cst::CSTParser.EXPR, s::State; nonest = false, nospace = false)
+    t = PTree(cst, nspaces(s))
+    nest = !is_iterable(cst[2]) && !nonest
     # @info "nest invis" nonest
 
-    for (i, a) in enumerate(x)
+    for (i, a) in enumerate(cst)
         if a.typ === CSTParser.Block
             add_node!(t, p_block(a, s, from_quote = true), s, join_lines = true)
         elseif a.typ === CSTParser.BinaryOpCall
@@ -1565,13 +1565,13 @@ function p_invisbrackets(x, s; nonest = false, nospace = false)
 end
 
 # TupleH
-function p_tuple(x, s)
-    t = PTree(x, nspaces(s))
+function p_tuple(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
 
-    args = get_args(x)
+    args = get_args(cst)
     nest = length(args) > 0 && !(length(args) == 1 && unnestable_arg(args[1]))
 
-    for (i, a) in enumerate(x)
+    for (i, a) in enumerate(cst)
         n = pretty(a, s)
         if is_opener(n) && nest
             add_node!(t, n, s, join_lines = true)
@@ -1580,7 +1580,7 @@ function p_tuple(x, s)
             add_node!(t, TrailingComma(), s)
             add_node!(t, Placeholder(0), s)
             add_node!(t, n, s, join_lines = true)
-        elseif CSTParser.is_comma(a) && i < length(x) && !is_punc(x.args[i+1])
+        elseif CSTParser.is_comma(a) && i < length(cst) && !is_punc(cst[i+1])
             add_node!(t, n, s, join_lines = true)
             add_node!(t, Placeholder(1), s)
         else
@@ -1591,20 +1591,20 @@ function p_tuple(x, s)
 end
 
 # Braces
-function p_braces(x, s)
-    t = PTree(x, nspaces(s))
-    nest = length(x) > 2 && !(length(x) == 3 && unnestable_arg(x[2]))
+function p_braces(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    nest = length(cst) > 2 && !(length(cst) == 3 && unnestable_arg(cst[2]))
 
-    for (i, a) in enumerate(x)
+    for (i, a) in enumerate(cst)
         n = pretty(a, s)
         if i == 1 && nest
             add_node!(t, n, s, join_lines = true)
             add_node!(t, Placeholder(0), s)
-        elseif i == length(x) && nest
+        elseif i == length(cst) && nest
             add_node!(t, TrailingComma(), s)
             add_node!(t, Placeholder(0), s)
             add_node!(t, n, s, join_lines = true)
-        elseif CSTParser.is_comma(a) && i < length(x) && !is_punc(x.args[i+1])
+        elseif CSTParser.is_comma(a) && i < length(cst) && !is_punc(cst[i+1])
             add_node!(t, n, s, join_lines = true)
             add_node!(t, Placeholder(1), s)
         else
@@ -1615,20 +1615,20 @@ function p_braces(x, s)
 end
 
 # Vect
-function p_vect(x, s)
-    t = PTree(x, nspaces(s))
-    nest = length(x) > 2 && !(length(x) == 3 && unnestable_arg(x[2]))
+function p_vect(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    nest = length(cst) > 2 && !(length(cst) == 3 && unnestable_arg(cst[2]))
 
-    for (i, a) in enumerate(x)
+    for (i, a) in enumerate(cst)
         n = pretty(a, s)
         if i == 1 && nest
             add_node!(t, n, s, join_lines = true)
             add_node!(t, Placeholder(0), s)
-        elseif i == length(x) && nest
+        elseif i == length(cst) && nest
             add_node!(t, TrailingComma(), s)
             add_node!(t, Placeholder(0), s)
             add_node!(t, n, s, join_lines = true)
-        elseif CSTParser.is_comma(a) && i < length(x) && !is_punc(x.args[i+1])
+        elseif CSTParser.is_comma(a) && i < length(cst) && !is_punc(cst[i+1])
             add_node!(t, n, s, join_lines = true)
             add_node!(t, Placeholder(1), s)
         else
@@ -1640,13 +1640,13 @@ end
 
 
 # Parameters
-function p_params(x, s)
-    t = PTree(x, nspaces(s))
-    for (i, a) in enumerate(x)
+function p_params(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    for (i, a) in enumerate(cst)
         n = pretty(a, s)
-        if i == length(x) && CSTParser.is_comma(a)
+        if i == length(cst) && CSTParser.is_comma(a)
             # do nothing
-        elseif CSTParser.is_comma(a) && i < length(x) && !is_punc(x.args[i+1])
+        elseif CSTParser.is_comma(a) && i < length(cst) && !is_punc(cst[i+1])
             add_node!(t, n, s, join_lines = true)
             add_node!(t, Placeholder(1), s)
         else
@@ -1657,12 +1657,12 @@ function p_params(x, s)
 end
 
 # Import, Export, Using, ImportAll
-function p_import(x, s)
-    t = PTree(x, nspaces(s))
-    add_node!(t, pretty(x[1], s), s)
+function p_import(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    add_node!(t, pretty(cst[1], s), s)
     add_node!(t, Whitespace(1), s)
 
-    for (i, a) in enumerate(x.args[2:end])
+    for (i, a) in enumerate(cst.args[2:end])
         if CSTParser.is_comma(a) || CSTParser.is_colon(a)
             add_node!(t, pretty(a, s), s, join_lines = true)
             add_node!(t, Placeholder(1), s)
@@ -1674,11 +1674,11 @@ function p_import(x, s)
 end
 
 # Ref
-function p_ref(x, s)
-    t = PTree(x, nspaces(s))
-    nest = length(x) > 5 && !(length(x) == 5 && unnestable_arg(x[3]))
+function p_ref(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    nest = length(cst) > 5 && !(length(cst) == 5 && unnestable_arg(cst[3]))
     nospace = !s.opts.whitespace_ops_in_indices
-    for (i, a) in enumerate(x)
+    for (i, a) in enumerate(cst)
         if is_closer(a) && nest
             add_node!(t, TrailingComma(), s)
             add_node!(t, Placeholder(0), s)
@@ -1686,7 +1686,7 @@ function p_ref(x, s)
         elseif is_opener(a) && nest
             add_node!(t, pretty(a, s), s, join_lines = true)
             add_node!(t, Placeholder(0), s)
-        elseif CSTParser.is_comma(a) && i < length(x) && !is_punc(x.args[i+1])
+        elseif CSTParser.is_comma(a) && i < length(cst) && !is_punc(cst[i+1])
             add_node!(t, pretty(a, s), s, join_lines = true)
             add_node!(t, Placeholder(1), s)
         elseif a.typ === CSTParser.BinaryOpCall
@@ -1711,14 +1711,14 @@ function p_ref(x, s)
 end
 
 # Vcat/TypedVcat
-function p_vcat(x, s)
-    t = PTree(x, nspaces(s))
-    st = x.typ === CSTParser.Vcat ? 1 : 2
-    args = get_args(x)
+function p_vcat(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    st = cst.typ === CSTParser.Vcat ? 1 : 2
+    args = get_args(cst)
     nest = length(args) > 0 && !(length(args) == 1 && unnestable_arg(args[1]))
-    # @info "" nest length(x) st
+    # @info "" nest length(cst) st
 
-    for (i, a) in enumerate(x)
+    for (i, a) in enumerate(cst)
         n = pretty(a, s)
         diff_line = t.endline != t.startline
         if is_opener(a) && nest
@@ -1726,11 +1726,11 @@ function p_vcat(x, s)
             add_node!(t, Placeholder(0), s)
         elseif !is_closer(a) && i > st
             add_node!(t, n, s, join_lines = true)
-            if i != length(x) - 1
+            if i != length(cst) - 1
                 has_semicolon(s.doc, n.startline) && add_node!(t, TrailingSemicolon(), s)
                 add_node!(t, Placeholder(1), s)
             # Keep trailing semicolon if there's only one arg
-            elseif n_args(x) == 1
+            elseif n_args(cst) == 1
                 add_node!(t, Semicolon(), s)
                 add_node!(t, Placeholder(0), s)
             else
@@ -1746,11 +1746,11 @@ function p_vcat(x, s)
 end
 
 # Hcat/TypedHcat
-function p_hcat(x, s)
-    t = PTree(x, nspaces(s))
-    st = x.typ === CSTParser.Hcat ? 1 : 2
-    for (i, a) in enumerate(x)
-        if i > st && i < length(x) - 1
+function p_hcat(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    st = cst.typ === CSTParser.Hcat ? 1 : 2
+    for (i, a) in enumerate(cst)
+        if i > st && i < length(cst) - 1
             add_node!(t, pretty(a, s), s, join_lines = true)
             add_node!(t, Whitespace(1), s)
         else
@@ -1761,35 +1761,35 @@ function p_hcat(x, s)
 end
 
 # Row
-function p_row(x, s)
-    t = PTree(x, nspaces(s))
+function p_row(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
 
     # Currently {A <:B} is parsed as a Row type with elements A and <:B
     # instead of a BinaryOpCall A <: B, which is inconsistent with Meta.parse.
     #
     # This is used to overcome that current limitation.
-    in_braces = x.parent === nothing ? false : x.parent.typ === CSTParser.BracesCat
+    in_braces = cst.parent === nothing ? false : cst.parent.typ === CSTParser.BracesCat
     nospace = !s.opts.whitespace_typedefs
 
-    for (i, a) in enumerate(x)
-        if in_braces && i < length(x) && x[i+1].typ === CSTParser.UnaryOpCall
+    for (i, a) in enumerate(cst)
+        if in_braces && i < length(cst) && cst[i+1].typ === CSTParser.UnaryOpCall
             add_node!(t, pretty(a, s), s, join_lines = true)
             add_node!(t, Whitespace(nospace ? 0 : 1), s)
         elseif in_braces && a.typ === CSTParser.UnaryOpCall
             add_node!(t, p_unarycall(a, s, nospace = nospace), s, join_lines = true)
-            i < length(x) && add_node!(t, Whitespace(1), s)
+            i < length(cst) && add_node!(t, Whitespace(1), s)
         else
             add_node!(t, pretty(a, s), s, join_lines = true)
-            i < length(x) && add_node!(t, Whitespace(1), s)
+            i < length(cst) && add_node!(t, Whitespace(1), s)
         end
     end
     t
 end
 
 # Generator/Filter
-function p_gen(x, s)
-    t = PTree(x, nspaces(s))
-    for (i, a) in enumerate(x)
+function p_gen(cst::CSTParser.EXPR, s::State)
+    t = PTree(cst, nspaces(s))
+    for (i, a) in enumerate(cst)
         if a.typ === CSTParser.KEYWORD
             if a.kind === Tokens.FOR && parent_is(
                 a,
@@ -1805,23 +1805,17 @@ function p_gen(x, s)
             else
                 add_node!(t, Whitespace(1), s)
             end
-            # if a.kind === Tokens.FOR
-            #     add_node!(t, Placeholder(1), s)
-            # else
-            #     add_node!(t, Whitespace(1), s)
-            # end
 
-            # add_node!(t, Placeholder(1), s)
             add_node!(t, pretty(a, s), s, join_lines = true)
             add_node!(t, Whitespace(1), s)
             if a.kind === Tokens.FOR
-                for j = i+1:length(x)
-                    eq_to_in_normalization!(x.args[j], s.opts.always_for_in)
+                for j = i+1:length(cst)
+                    eq_to_in_normalization!(cst[j], s.opts.always_for_in)
                 end
             end
         elseif a.typ === CSTParser.BinaryOpCall
             add_node!(t, p_binarycall(a, s, nonest = true), s, join_lines = true)
-        elseif CSTParser.is_comma(a) && i < length(x) && !is_punc(x.args[i+1])
+        elseif CSTParser.is_comma(a) && i < length(cst) && !is_punc(cst[i+1])
             add_node!(t, pretty(a, s), s, join_lines = true)
             add_node!(t, Whitespace(1), s)
         else


### PR DESCRIPTION
- Variable renames. `PTree` -> `FST` (Formatted Syntax Tree). `fst` is used to refer to FST and `cst` is used to refer to a CST from CSTParser.jl
- More type annotations
- Each type has its own function in preparation for custom overrides via Cassette.
- Better docs.
- Update CSTParser