### PR TITLE
rm importall:

### DIFF
--- a/src/nest.jl
+++ b/src/nest.jl
@@ -1,8 +1,8 @@
 # Nest
 #
 # If the line exceeds the print width it will be nested.
-# 
-# This is done by replacing `PLACEHOLDER` nodes with `NEWLINE` 
+#
+# This is done by replacing `PLACEHOLDER` nodes with `NEWLINE`
 # nodes and updating the PTree's indent.
 #
 # `extra_margin` provides additional width to consider from
@@ -116,8 +116,6 @@ function nest!(x::PTree, s::State)
     elseif x.typ === CSTParser.Export
         n_import!(x, s)
     elseif x.typ === CSTParser.Using
-        n_import!(x, s)
-    elseif x.typ === CSTParser.ImportAll
         n_import!(x, s)
     elseif x.typ === CSTParser.WhereOpCall
         n_wherecall!(x, s)

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -410,8 +410,6 @@ function pretty(x::CSTParser.EXPR, s::State)
         return p_vardef(x, s)
     elseif x.typ === CSTParser.Import
         return p_import(x, s)
-    elseif x.typ === CSTParser.ImportAll
-        return p_import(x, s)
     elseif x.typ === CSTParser.Export
         return p_import(x, s)
     elseif x.typ === CSTParser.Using
@@ -489,7 +487,6 @@ function p_keyword(x, s)
         x.kind === Tokens.FUNCTION ? "function" :
         x.kind === Tokens.GLOBAL ? "global" :
         x.kind === Tokens.IMPORT ? "import" :
-        x.kind === Tokens.IMPORTALL ? "importall" :
         x.kind === Tokens.LET ? "let" :
         x.kind === Tokens.LOCAL ? "local" :
         x.kind === Tokens.MACRO ? "macro" :


### PR DESCRIPTION
- update to https://github.com/julia-vscode/CSTParser.jl/pull/110

While JuliaFormatter.jl's CSTParser.jl's specification is still `^1.0.0` and so this update isn't needed immediately, but will be necessary in the future anyway :)
(and won't break backward-compatibility for julia v1.0)