### PR TITLE
Allow CSTParser version to be >= 1.0.0 and upgrade CSTParser to 2.0.0

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -5,9 +5,9 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[CSTParser]]
 deps = ["Tokenize"]
-git-tree-sha1 = "3a483b911e1eacc9b897cd45229ef5dc3a49a7f2"
+git-tree-sha1 = "e8166cc32a3bfedc97eda16db428b1faba29ca8e"
 uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
-version = "1.1.1"
+version = "2.0.0"
 
 [[Distributed]]
 deps = ["Random", "Serialization", "Sockets"]

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tokenize = "0796e94c-ce3b-5d07-9a54-7f471281c624"
 
 [compat]
-CSTParser = "^1.0.0"
+CSTParser = ">= 1.0.0"
 Tokenize = "^0.5.5"
 julia = "1"


### PR DESCRIPTION
closes #163 