### PR TITLE
A couple of fixes

### DIFF
--- a/src/fst.jl
+++ b/src/fst.jl
@@ -105,8 +105,9 @@ end
 # TODO: Remove once this is fixed in CSTParser.
 # https://github.com/julia-vscode/CSTParser.jl/issues/108
 function get_args(cst::CSTParser.EXPR)
-    if cst.typ === CSTParser.MacroCall || cst.typ === CSTParser.TypedVcat ||
-       cst.typ === CSTParser.Ref || cst.typ === CSTParser.Curly || cst.typ === CSTParser.Call
+    if cst.typ === CSTParser.MacroCall ||
+       cst.typ === CSTParser.TypedVcat || cst.typ === CSTParser.Ref ||
+       cst.typ === CSTParser.Curly || cst.typ === CSTParser.Call
         return get_args(cst.args[2:end])
     elseif cst.typ === CSTParser.Parameters || cst.typ === CSTParser.Braces ||
            cst.typ === CSTParser.Vcat || cst.typ === CSTParser.TupleH ||
@@ -192,6 +193,10 @@ function add_node!(t::FST, n::FST, s::State; join_lines = false, max_padding = -
         push!(t.nodes, n)
         return
     elseif n.typ === CSTParser.Parameters
+        if length(n) == 0
+            n.startline = t.endline
+            n.endline = t.endline
+        end
         if n_args(t.ref[]) == n_args(n.ref[])
             # There are no arguments prior to params
             # so we can remove the initial placeholder.

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -147,13 +147,12 @@ function add_node!(t::FST, n::FST, s::State; join_lines = false, max_padding = -
                 break
             end
         end
-        # @info "" t.endline n.endline loc[1]
 
         # If there's no semicolon, treat it
         # as a PLeaf
         if n.startline == -1
             t.len += length(n)
-            n.startline = t.startline
+            n.startline = t.endline
             n.endline = t.endline
             push!(t.nodes, n)
             return

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -106,7 +106,7 @@ end
 # https://github.com/julia-vscode/CSTParser.jl/issues/108
 function get_args(cst::CSTParser.EXPR)
     if cst.typ === CSTParser.MacroCall || cst.typ === CSTParser.TypedVcat ||
-       cst.typ === CSTParser.Ref || cst.typ === CSTParser.Curly
+       cst.typ === CSTParser.Ref || cst.typ === CSTParser.Curly || cst.typ === CSTParser.Call
         return get_args(cst.args[2:end])
     elseif cst.typ === CSTParser.Parameters || cst.typ === CSTParser.Braces ||
            cst.typ === CSTParser.Vcat || cst.typ === CSTParser.TupleH ||
@@ -398,7 +398,8 @@ function unnestable_arg(cst::CSTParser.EXPR)
     is_iterable(cst) && return true
     is_str(cst) && return true
     cst.typ === CSTParser.LITERAL && return true
-    (cst.typ === CSTParser.BinaryOpCall && cst[2].kind === Tokens.DOT) && return true
+    cst.typ === CSTParser.UnaryOpCall && cst[2].kind === Tokens.DDDOT && return true
+    cst.typ === CSTParser.BinaryOpCall && cst[2].kind === Tokens.DOT && return true
     return false
 end
 

--- a/src/print.jl
+++ b/src/print.jl
@@ -64,7 +64,6 @@ function print_tree(
     ws = repeat(" ", max(indent, 0))
     for (i, n) in enumerate(nodes)
         if n.typ === NOTCODE
-            # @info "" i n.typ n.val n.startline n.endline  length(nodes) n.indent indent
             if notcode_indent > -1
                 n.indent = notcode_indent
             elseif i + 1 < length(nodes) && is_end(nodes[i+2])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4441,7 +4441,15 @@ some_function(
             )
             nothing
         end"""
-        @test fmt(str_) == str_
+        str = """
+        function f(args...)
+
+            next!(s.progress;
+            # comment
+        )
+            nothing
+        end"""
+        @test fmt(str_) == str
 
         # NOTE: when this passes delete the above test
         str = """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -459,7 +459,7 @@ end
         @test fmt(str) == str
 
         str = "foo(args...)"
-        @test fmt(str,m=1) == str
+        @test fmt(str, m = 1) == str
     end
 
     @testset "binary ops" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4432,4 +4432,28 @@ some_function(
         @test fmt(str_, remove_extra_newlines = true) == str
     end
 
+    @testset "#183" begin
+        str_ = """
+        function f(args...)
+
+            next!(s.progress;
+            # comment
+            )
+            nothing
+        end"""
+        @test fmt(str_) == str_
+
+        # NOTE: when this passes delete the above test
+        str = """
+        function f(args...)
+
+            next!(
+                s.progress;
+                # comment
+            )
+            nothing
+        end"""
+        @test_broken fmt(str_) == str
+    end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -457,6 +457,9 @@ end
             end
         end"""
         @test fmt(str) == str
+
+        str = "foo(args...)"
+        @test fmt(str,m=1) == str
     end
 
     @testset "binary ops" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -482,7 +482,7 @@ end
         @test fmt("a:b:c ") == "a:b:c"
         @test fmt("a::b:: c") == "a::b::c"
         @test fmt("a :: b::c") == "a::b::c"
-        # issue #74
+        # issue 74
         @test fmt("0:1/3:2") == "0:1/3:2"
         @test fmt("2a") == "2a"
         @test fmt("2(a+1)") == "2 * (a + 1)"
@@ -1120,7 +1120,7 @@ end
         t = run_pretty(str, 80)
         @test length(t) == 30
 
-        # issue #58
+        # issue 58
 
         str_ = """
         model = SDDP.LinearPolicyGraph(stages = 2, lower_bound = 1, direct_mode = false) do (subproblem1, subproblem2, subproblem3, subproblem4, subproblem5, subproblem6, subproblem7, subproblem8)


### PR DESCRIPTION
- stopgap solution for #183 
- prevents nesting when the single argument is a splat of args - `foo(args...)`