### PR TITLE
More nesting for Comprehensions and generators

### DIFF
--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -48,7 +48,6 @@ function Document(text::AbstractString)
     str = ""
 
     for t in CSTParser.Tokenize.tokenize(text)
-        # @info "token" t
         if t.kind === Tokens.WHITESPACE
             offset = t.startbyte
             for c in t.val
@@ -122,7 +121,6 @@ function Document(text::AbstractString)
                 idx1 = findfirst(c -> c == '\n', str)
                 idx2 = findlast(c -> c == '\n', str)
                 str = str[idx1:idx2]
-                # @info "format skip str" str
                 push!(format_skips, (pop!(stack), t.startpos[1], str))
                 str = ""
                 format_on = true
@@ -150,7 +148,6 @@ function Document(text::AbstractString)
         str = str[idx1:end]
         push!(format_skips, (stack[1], -1, str))
     end
-    # @info "" comments
     Document(text, ranges, line_to_range, lit_strings, comments, semicolons, format_skips)
 end
 

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -352,13 +352,24 @@ n_invisbrackets!(style::S, fst::FST, s::State) where {S<:AbstractStyle} =
 
 function n_comprehension!(ds::DefaultStyle, fst::FST, s::State; indent=-1)
     style = getstyle(ds)
-    line_offset = s.line_offset
-closer = is_closer(fst[end])
-
+    line_margin = s.line_offset + length(fst) + fst.extra_margin
+    # @info "ENTERING" idx fst.typ s.line_offset length(fst) fst.extra_margin
+    closer = is_closer(fst[end])
+    if closer && (line_margin > s.margin || fst.force_nest)
+        idx = findfirst(n -> n.typ === PLACEHOLDER, fst.nodes)
+        if idx !== nothing
+            fst[idx] = Newline(length = fst[idx].len)
+        end
+        idx = findlast(n -> n.typ === PLACEHOLDER, fst.nodes)
+        if idx !== nothing
+            fst[idx] = Newline(length = fst[idx].len)
+        end
+    end
 
     if indent >= 0
         fst.indent = indent
         else
+            # fst.indent += s.indent_size
                 add_indent!(fst, s, s.indent_size)
         end
 

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -79,7 +79,6 @@ function dedent!(fst::FST, s::State)
     end
     fst.typ === CSTParser.ConditionalOpCall && return
     fst.typ === CSTParser.StringH && return
-    # fst.typ === CSTParser.BinaryOpCall && return
 
     # dedent
     fst.indent -= s.indent_size
@@ -364,16 +363,7 @@ function n_comprehension!(ds::DefaultStyle, fst::FST, s::State; indent = -1)
         if idx !== nothing
             fst[idx] = Newline(length = fst[idx].len)
         end
-    end
-
-    if indent >= 0
-        fst.indent = indent
-    else
-        # fst.indent += s.indent_size
         add_indent!(fst, s, s.indent_size)
-    end
-
-    if closer
         fst[end].indent = fst.indent - s.indent_size
     end
 

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -350,7 +350,7 @@ n_invisbrackets!(style::S, fst::FST, s::State) where {S<:AbstractStyle} =
     n_invisbrackets!(DefaultStyle(style), fst, s)
 
 
-function n_comprehension!(ds::DefaultStyle, fst::FST, s::State; indent=-1)
+function n_comprehension!(ds::DefaultStyle, fst::FST, s::State; indent = -1)
     style = getstyle(ds)
     line_margin = s.line_offset + length(fst) + fst.extra_margin
     # @info "ENTERING" idx fst.typ s.line_offset length(fst) fst.extra_margin
@@ -368,10 +368,10 @@ function n_comprehension!(ds::DefaultStyle, fst::FST, s::State; indent=-1)
 
     if indent >= 0
         fst.indent = indent
-        else
-            # fst.indent += s.indent_size
-                add_indent!(fst, s, s.indent_size)
-        end
+    else
+        # fst.indent += s.indent_size
+        add_indent!(fst, s, s.indent_size)
+    end
 
     if closer
         fst[end].indent = fst.indent - s.indent_size
@@ -399,15 +399,16 @@ function n_comprehension!(ds::DefaultStyle, fst::FST, s::State; indent=-1)
         end
     end
 
-        if closer
-            s.line_offset = fst[end].indent + 1
-        end
+    if closer
+        s.line_offset = fst[end].indent + 1
+    end
 end
 
-n_comprehension!(style::S, fst::FST, s::State; indent=-1) where {S<:AbstractStyle} =
-    n_comprehension!(DefaultStyle(style), fst, s, indent=indent)
+n_comprehension!(style::S, fst::FST, s::State; indent = -1) where {S<:AbstractStyle} =
+    n_comprehension!(DefaultStyle(style), fst, s, indent = indent)
 
-@inline n_typedcomprehension!(ds::DefaultStyle, fst::FST, s::State) = n_comprehension!(ds, fst, s)
+@inline n_typedcomprehension!(ds::DefaultStyle, fst::FST, s::State) =
+    n_comprehension!(ds, fst, s)
 n_typedcomprehension!(style::S, fst::FST, s::State) where {S<:AbstractStyle} =
     n_typedcomprehension!(DefaultStyle(style), fst, s)
 
@@ -632,7 +633,7 @@ function n_binaryopcall!(ds::DefaultStyle, fst::FST, s::State)
     rhs = fst[end]
     rhs.typ === CSTParser.Block && (rhs = rhs[1])
     if length(idxs) == 2 && (line_margin > s.margin || fst.force_nest || rhs.force_nest)
-    # @info "ENTERING" fst.typ fst.extra_margin s.line_offset length(fst) idxs fst.ref[][2]
+        # @info "ENTERING" fst.typ fst.extra_margin s.line_offset length(fst) idxs fst.ref[][2]
         line_offset = s.line_offset
         i1 = idxs[1]
         i2 = idxs[2]
@@ -833,5 +834,3 @@ n_comparison!(style::S, fst::FST, s::State) where {S<:AbstractStyle} =
 @inline n_chainopcall!(ds::DefaultStyle, fst::FST, s::State) = n_block!(ds, fst, s)
 n_chainopcall!(style::S, fst::FST, s::State) where {S<:AbstractStyle} =
     n_chainopcall!(DefaultStyle(style), fst, s)
-
-

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -376,8 +376,6 @@ function p_macrocall(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
     nest = length(args) > 0 && !(length(args) == 1 && unnestable_arg(args[1]))
     has_closer = is_closer(cst.args[end])
 
-    # @info "" has_closer
-
     # same as CSTParser.Call but whitespace sensitive
     for (i, a) in enumerate(cst)
         n = pretty(style, a, s)
@@ -436,7 +434,6 @@ function p_block(
     single_line = ignore_single_line ? false :
         cursor_loc(s)[1] == cursor_loc(s, s.offset + cst.span - 1)[1]
 
-    # @info "" from_quote single_line ignore_single_line join_body
     for (i, a) in enumerate(cst)
         n = pretty(style, a, s)
         if from_quote && !single_line
@@ -1159,7 +1156,6 @@ function p_binaryopcall(
     nrhs = nest_rhs(cst)
     nrhs && (t.force_nest = true)
     nest = (nestable(style, cst) && !nonest) || nrhs
-    # @info "" nestable(cst) !nonest nrhs nest cst[2]
 
     if op.fullspan == 0 && cst[3].typ === CSTParser.IDENTIFIER
         # do nothing
@@ -1383,7 +1379,6 @@ function p_invisbrackets(
     style = getstyle(ds)
     t = FST(cst, nspaces(s))
     nest = !is_iterable(cst[2]) && !nonest
-    # @info "nest invis" nest nonest
 
     if is_block(cst[2])
         t.force_nest = true
@@ -1404,11 +1399,9 @@ function p_invisbrackets(
             n = pretty(style, a, s, nonest = nonest, nospace = nospace)
             add_node!(t, n, s, join_lines = true)
         elseif is_opener(a) && nest
-            # @info "opening"
             add_node!(t, pretty(style, a, s), s, join_lines = true)
             add_node!(t, Placeholder(0), s)
         elseif is_closer(a) && nest
-            # @info "closing"
             add_node!(t, Placeholder(0), s)
             add_node!(t, pretty(style, a, s), s, join_lines = true)
         else
@@ -1642,7 +1635,6 @@ function p_vcat(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
     st = cst.typ === CSTParser.Vcat ? 1 : 2
     args = get_args(cst)
     nest = length(args) > 0 && !(length(args) == 1 && unnestable_arg(args[1]))
-    # @info "" nest length(cst) st
 
     for (i, a) in enumerate(cst)
         n = pretty(style, a, s)

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -1773,5 +1773,5 @@ p_filter(style::S, cst::CSTParser.EXPR, s::State) where {S<:AbstractStyle} =
     p_filter(DefaultStyle(style), cst, s)
 
 @inline p_flatten(ds::DefaultStyle, cst::CSTParser.EXPR, s::State) = p_generator(ds, cst, s)
-p_filter(style::S, cst::CSTParser.EXPR, s::State) where {S<:AbstractStyle} =
+p_flatten(style::S, cst::CSTParser.EXPR, s::State) where {S<:AbstractStyle} =
     p_flatten(DefaultStyle(style), cst, s)

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -1756,8 +1756,6 @@ function p_generator(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
                     eq_to_in_normalization!(cst[j], s.opts.always_for_in)
                 end
             end
-        # elseif a.typ === CSTParser.BinaryOpCall
-        #     add_node!(t, pretty(style, a, s, nonest = true), s, join_lines = true)
         elseif CSTParser.is_comma(a) && i < length(cst) && !is_punc(cst[i+1])
             add_node!(t, pretty(style, a, s), s, join_lines = true)
             add_node!(t, Placeholder(1), s)

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -117,6 +117,8 @@ function pretty(ds::DefaultStyle, cst::CSTParser.EXPR, s::State; kwargs...)
         return p_generator(style, cst, s)
     elseif cst.typ === CSTParser.Filter
         return p_filter(style, cst, s)
+    elseif cst.typ === CSTParser.Flatten
+        return p_flatten(style, cst, s)
     elseif cst.typ === CSTParser.FileH
         return p_fileh(style, cst, s)
     end
@@ -1748,17 +1750,17 @@ function p_generator(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
             end
 
             add_node!(t, pretty(style, a, s), s, join_lines = true)
-            add_node!(t, Whitespace(1), s)
+            add_node!(t, Placeholder(1), s)
             if a.kind === Tokens.FOR
                 for j = i+1:length(cst)
                     eq_to_in_normalization!(cst[j], s.opts.always_for_in)
                 end
             end
-        elseif a.typ === CSTParser.BinaryOpCall
-            add_node!(t, pretty(style, a, s, nonest = true), s, join_lines = true)
+        # elseif a.typ === CSTParser.BinaryOpCall
+        #     add_node!(t, pretty(style, a, s, nonest = true), s, join_lines = true)
         elseif CSTParser.is_comma(a) && i < length(cst) && !is_punc(cst[i+1])
             add_node!(t, pretty(style, a, s), s, join_lines = true)
-            add_node!(t, Whitespace(1), s)
+            add_node!(t, Placeholder(1), s)
         else
             add_node!(t, pretty(style, a, s), s, join_lines = true)
         end
@@ -1771,3 +1773,7 @@ p_generator(style::S, cst::CSTParser.EXPR, s::State) where {S<:AbstractStyle} =
 @inline p_filter(ds::DefaultStyle, cst::CSTParser.EXPR, s::State) = p_generator(ds, cst, s)
 p_filter(style::S, cst::CSTParser.EXPR, s::State) where {S<:AbstractStyle} =
     p_filter(DefaultStyle(style), cst, s)
+
+@inline p_flatten(ds::DefaultStyle, cst::CSTParser.EXPR, s::State) = p_generator(ds, cst, s)
+p_filter(style::S, cst::CSTParser.EXPR, s::State) where {S<:AbstractStyle} =
+    p_flatten(DefaultStyle(style), cst, s)

--- a/src/print.jl
+++ b/src/print.jl
@@ -106,7 +106,6 @@ function print_stringh(io::IOBuffer, fst::FST, s::State)
 
     # This difference notes if there is a change due to nesting.
     diff = fst.indent + 1 - s.line_offset
-    # @info "" length(fst) s.line_offset
 
     # The new indent for the string is index of when a character in
     # the multiline string is FIRST encountered in the source file - the above difference

--- a/src/styles/yas.jl
+++ b/src/styles/yas.jl
@@ -175,30 +175,6 @@ end
 # Nesting
 #
 
-function nest_if_over_margin!(style, fst::FST, s::State, i::Int)
-    margin = s.line_offset
-    idx = findnext(n -> n.typ === PLACEHOLDER, fst.nodes, i + 1)
-    if idx === nothing
-        margin += sum(length.(fst[i+1:end])) + fst.extra_margin
-    else
-        margin += sum(length.(fst[i+1:idx]))
-    end
-
-    # len, found = length_to(fst, [PLACEHOLDER], start = i + 1)
-    # if found
-    #     margin += len
-    # else
-    #     margin += sum(length.(fst[i+1:end])) + fst.extra_margin
-    # end
-
-    if margin > s.margin || is_comment(fst[i+1]) || is_comment(fst[i-1])
-        fst[i] = Newline(length = fst[i].len)
-        s.line_offset = fst.indent
-    else
-        nest!(style, fst[i], s)
-    end
-end
-
 function n_call!(ys::YASStyle, fst::FST, s::State)
     line_offset = s.line_offset
     fst.indent = line_offset + sum(length.(fst[1:2]))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2711,7 +2711,16 @@ end
 
         str = """
         (
-          x for x = 1:10
+          x for
+          x = 1:10
+        )"""
+        @test fmt("(x   for x  in  1 : 10)", 2, 10) == str
+
+        str = """
+        (
+          x for
+          x =
+            1:10
         )"""
         @test fmt("(x   for x  in  1 : 10)", 2, 1) == str
 
@@ -3747,10 +3756,18 @@ end
     end
 
     @testset "comphrehensions types" begin
-        # This shouldn't before `for` otherwise the
-        # formatted text will result in a parsing error.
-        str = "var = (x, y) for x = 1:10, y = 1:10"
-        @test fmt(str, 4, length(str) - 1) == str
+        str_ = "var = (x, y) for x = 1:10, y = 1:10"
+        str = """
+        var = (x, y) for
+        x = 1:10, y = 1:10"""
+        @test fmt(str_, 4, length(str_) - 1) == str
+        @test fmt(str_, 4, 18) == str
+
+        str = """
+        var = (x, y) for
+        x = 1:10,
+        y = 1:10"""
+        @test fmt(str_, 4, 17) == str
 
         str_ = """
         begin
@@ -3759,7 +3776,6 @@ end
                 w,
             ) in enumerate(weightfn.(eachrow(subject.events))))
         end"""
-
         str = """
         begin
             weights = Dict(
@@ -3773,10 +3789,9 @@ end
         begin
             weights = Dict(
                 (file, i) => w for (file, subject) in subjects
-                for (
-                    i,
-                    w,
-                ) in enumerate(weightfn.(eachrow(subject.events)))
+                for
+                (i, w) in
+                enumerate(weightfn.(eachrow(subject.events)))
             )
         end"""
         @test fmt(str_, 4, 60) == str
@@ -3786,10 +3801,9 @@ end
             weights = Dict(
                 (file, i) => w
                 for (file, subject) in subjects
-                for (
-                    i,
-                    w,
-                ) in enumerate(weightfn.(eachrow(subject.events)))
+                for
+                (i, w) in
+                enumerate(weightfn.(eachrow(subject.events)))
             )
         end"""
         @test fmt(str_, 4, 50) == str
@@ -3811,8 +3825,7 @@ end
                 very_very_very_very_very_very_very_very_very_very_very_very_long_function_name(
                     very_very_very_very_very_very_very_very_very_very_very_very_long_argument,
                     very_very_very_very_very_very_very_very_very_very_very_very_long_argument,
-                )
-                for x in xs
+                ) for x in xs
             ))),
             another_argument,
         )"""
@@ -3826,9 +3839,9 @@ some_function(
                    very_very_very_very_very_very_very_very_very_very_very_very_long_argument,
                )
                for x in xs
-               ))),
+))),
            another_argument,
-       )"""
+        )"""
         @test fmt(str_) == str
 
         str = """
@@ -4080,10 +4093,11 @@ some_function(
         y1 = Any[
             if true
                 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_expr
-            end
-            for i = 1:1
+            end for i = 1:1
         ]"""
         @test fmt(str_) == str
+        s = run_nest(str_, 100)
+        @test s.line_offset == 1
 
         str_ = """
         y1 = [if true
@@ -4093,10 +4107,11 @@ some_function(
         y1 = [
             if true
                 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_expr
-            end
-            for i = 1:1
+            end for i = 1:1
         ]"""
         @test fmt(str_) == str
+        s = run_nest(str_, 100)
+        @test s.line_offset == 1
 
         str_ = """
         y1 = [if true
@@ -4109,6 +4124,8 @@ some_function(
             end for i = 1:1
         ]"""
         @test fmt(str_) == str
+        s = run_nest(str_, 100)
+        @test s.line_offset == 1
 
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4481,4 +4481,24 @@ some_function(
         @test_broken fmt(str_) == str
     end
 
+    @testset "#189" begin
+    str_ = """
+D2 = [
+        (b_hat * y - delta_hat[i] * y) * gamma[i] + (b * y_hat - delta[i] * y_hat) *
+                                                        gamma_hat[i] + (b_hat - y_hat) *
+                                                                       delta[i] + (b - y) *
+                                                                                  delta_hat[i] - delta[i] * delta_hat[i]
+        for i = 1:8
+    ]"""
+    str = """
+    D2 = [
+        (b_hat * y - delta_hat[i] * y) * gamma[i] +
+        (b * y_hat - delta[i] * y_hat) * gamma_hat[i] +
+        (b_hat - y_hat) * delta[i] +
+        (b - y) * delta_hat[i] - delta[i] * delta_hat[i] for i = 1:8
+    ]"""
+        @test fmt(str_) == str
+
+    end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4482,21 +4482,21 @@ some_function(
     end
 
     @testset "#189" begin
-    str_ = """
-D2 = [
-        (b_hat * y - delta_hat[i] * y) * gamma[i] + (b * y_hat - delta[i] * y_hat) *
-                                                        gamma_hat[i] + (b_hat - y_hat) *
-                                                                       delta[i] + (b - y) *
-                                                                                  delta_hat[i] - delta[i] * delta_hat[i]
-        for i = 1:8
-    ]"""
-    str = """
+        str_ = """
     D2 = [
-        (b_hat * y - delta_hat[i] * y) * gamma[i] +
-        (b * y_hat - delta[i] * y_hat) * gamma_hat[i] +
-        (b_hat - y_hat) * delta[i] +
-        (b - y) * delta_hat[i] - delta[i] * delta_hat[i] for i = 1:8
-    ]"""
+            (b_hat * y - delta_hat[i] * y) * gamma[i] + (b * y_hat - delta[i] * y_hat) *
+                                                            gamma_hat[i] + (b_hat - y_hat) *
+                                                                           delta[i] + (b - y) *
+                                                                                      delta_hat[i] - delta[i] * delta_hat[i]
+            for i = 1:8
+        ]"""
+        str = """
+        D2 = [
+            (b_hat * y - delta_hat[i] * y) * gamma[i] +
+            (b * y_hat - delta[i] * y_hat) * gamma_hat[i] +
+            (b_hat - y_hat) * delta[i] +
+            (b - y) * delta_hat[i] - delta[i] * delta_hat[i] for i = 1:8
+        ]"""
         @test fmt(str_) == str
 
     end


### PR DESCRIPTION
nesting for comprehension and generator expressions was quite rigid. This puts placeholders in a lot more spaces, generally leading to much better formatting.

fixes #189 