### PR TITLE
Fixes last comment in a module being indented (when it shouldn't)

### DIFF
--- a/src/print.jl
+++ b/src/print.jl
@@ -48,7 +48,8 @@ end
 
 function print_tree(io::IOBuffer, fst::FST, s::State)
     notcode_indent = -1
-    if fst.typ === CSTParser.BinaryOpCall || fst.typ === CSTParser.ConditionalOpCall
+    if fst.typ === CSTParser.BinaryOpCall ||
+       fst.typ === CSTParser.ConditionalOpCall || fst.typ === CSTParser.ModuleH
         notcode_indent = fst.indent
     end
     print_tree(io, fst.nodes, s, fst.indent, notcode_indent = notcode_indent)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4501,4 +4501,20 @@ some_function(
 
     end
 
+    @testset "#193" begin
+        str = """
+        module Module
+        # comment
+        end"""
+        @test fmt(str) == str
+
+        str = """
+        module Module
+        # comment
+        @test
+        # comment
+        end"""
+        @test fmt(str) == str
+    end
+
 end


### PR DESCRIPTION
fixes #193 