### PR TITLE
Consistent indent for Binary and Chain operations

### DIFF
--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -286,6 +286,7 @@ function format_text(
     s = State(Document(text), indent, margin, opts)
     t = pretty(style, x, s)
     hascomment(s.doc, t.endline) && (add_node!(t, InlineComment(t.endline), s))
+    flatten_fst!(t)
     nest!(style, t, s)
 
     s.line_offset = 0
@@ -404,7 +405,7 @@ if VERSION < v"1.1.0"
             dir, base = _splitdir_nodrive(p)
             dir == p && (pushfirst!(out, dir); break)  # Reached root node.
             if !isempty(base)  # Skip trailing '/' in basename
-                pushfirst!(out, base)
+                pushfirst!(out, base)common
             end
             p = dir
         end

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -405,7 +405,7 @@ if VERSION < v"1.1.0"
             dir, base = _splitdir_nodrive(p)
             dir == p && (pushfirst!(out, dir); break)  # Reached root node.
             if !isempty(base)  # Skip trailing '/' in basename
-                pushfirst!(out, base)common
+                pushfirst!(out, base)
             end
             p = dir
         end

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -501,6 +501,7 @@ function flatten_binaryopcall(fst::FST; top = true)
         # @info "calling lhs"
         push!(nodes, flatten_binaryopcall(lhs, top = false)...)
     else
+        flatten_fst!(lhs)
         push!(nodes, lhs)
     end
     # everything except the indentation placeholder
@@ -510,6 +511,7 @@ function flatten_binaryopcall(fst::FST; top = true)
         # @info "calling rhs"
         push!(nodes, flatten_binaryopcall(rhs, top = false)...)
     else
+        flatten_fst!(rhs)
         push!(nodes, rhs)
     end
 
@@ -517,6 +519,7 @@ function flatten_binaryopcall(fst::FST; top = true)
 end
 
 function flatten_fst!(fst::FST)
+    is_leaf(fst) && return
     for n in fst.nodes
         if is_leaf(n)
             continue

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -106,12 +106,17 @@ end
 # https://github.com/julia-vscode/CSTParser.jl/issues/108
 function get_args(cst::CSTParser.EXPR)
     if cst.typ === CSTParser.MacroCall ||
-       cst.typ === CSTParser.TypedVcat || cst.typ === CSTParser.Ref ||
-       cst.typ === CSTParser.Curly || cst.typ === CSTParser.Call
+       cst.typ === CSTParser.TypedVcat ||
+       cst.typ === CSTParser.Ref ||
+       cst.typ === CSTParser.Curly ||
+       cst.typ === CSTParser.Call
         return get_args(cst.args[2:end])
-    elseif cst.typ === CSTParser.Parameters || cst.typ === CSTParser.Braces ||
-           cst.typ === CSTParser.Vcat || cst.typ === CSTParser.TupleH ||
-           cst.typ === CSTParser.Vect || cst.typ === CSTParser.InvisBrackets
+    elseif cst.typ === CSTParser.Parameters ||
+           cst.typ === CSTParser.Braces ||
+           cst.typ === CSTParser.Vcat ||
+           cst.typ === CSTParser.TupleH ||
+           cst.typ === CSTParser.Vect ||
+           cst.typ === CSTParser.InvisBrackets
         return get_args(cst.args)
     end
     CSTParser.get_args(cst)
@@ -160,8 +165,10 @@ function add_node!(t::FST, n::FST, s::State; join_lines = false, max_padding = -
         end
     elseif n.typ === TRAILINGCOMMA
         en = t.nodes[end]
-        if en.typ === CSTParser.Generator || en.typ === CSTParser.Filter ||
-           en.typ === CSTParser.Flatten || en.typ === CSTParser.MacroCall ||
+        if en.typ === CSTParser.Generator ||
+           en.typ === CSTParser.Filter ||
+           en.typ === CSTParser.Flatten ||
+           en.typ === CSTParser.MacroCall ||
            (is_comma(en) && t.typ === CSTParser.TupleH && n_args(t.ref[]) == 1)
             # don't insert trailing comma in these cases
         elseif is_comma(en)
@@ -264,7 +271,8 @@ function add_node!(t::FST, n::FST, s::State; join_lines = false, max_padding = -
             end
             add_node!(t, Newline(force_nest = true), s)
         elseif nt === PLACEHOLDER &&
-               current_line != n.startline && hascomment(s.doc, current_line)
+               current_line != n.startline &&
+               hascomment(s.doc, current_line)
             t.force_nest = true
             add_node!(t, InlineComment(current_line), s)
             # swap PLACEHOLDER (will be NEWLINE) with INLINECOMMENT node
@@ -475,7 +483,7 @@ into
     OP: RPIPE
     some_expression
 """
-function flatten_binaryopcall(fst::FST; top=true)
+function flatten_binaryopcall(fst::FST; top = true)
     nodes = FST[]
     op = fst.ref[][2]
     flattenable(op) || return nodes
@@ -491,7 +499,7 @@ function flatten_binaryopcall(fst::FST; top=true)
 
     if lhs_same_op
         # @info "calling lhs"
-        push!(nodes, flatten_binaryopcall(lhs, top=false)...)
+        push!(nodes, flatten_binaryopcall(lhs, top = false)...)
     else
         push!(nodes, lhs)
     end
@@ -500,7 +508,7 @@ function flatten_binaryopcall(fst::FST; top=true)
 
     if rhs_same_op
         # @info "calling rhs"
-        push!(nodes, flatten_binaryopcall(rhs, top=false)...)
+        push!(nodes, flatten_binaryopcall(rhs, top = false)...)
     else
         push!(nodes, rhs)
     end

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -429,6 +429,7 @@ end
     op.kind === Tokens.LAZY_AND && return true
     op.kind === Tokens.LAZY_OR && return true
     op.kind === Tokens.RPIPE && return true
+    return false
 end
 
 """

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -650,11 +650,10 @@ function n_binaryopcall!(ds::DefaultStyle, fst::FST, s::State)
             cst = rhs.ref[]
             line_margin = s.line_offset
 
-            if (
-                rhs.typ === CSTParser.BinaryOpCall &&
-                 cst[2].kind !== Tokens.IN
-            ) || rhs.typ === CSTParser.UnaryOpCall ||
-               rhs.typ === CSTParser.ChainOpCall || rhs.typ === CSTParser.Comparison
+            if (rhs.typ === CSTParser.BinaryOpCall && cst[2].kind !== Tokens.IN) ||
+               rhs.typ === CSTParser.UnaryOpCall ||
+               rhs.typ === CSTParser.ChainOpCall ||
+               rhs.typ === CSTParser.Comparison
                 line_margin += length(fst[end])
             elseif rhs.typ === CSTParser.Do && is_iterable(rhs[1])
                 rw, _ = length_to(fst, [NEWLINE], start = i2 + 1)
@@ -797,10 +796,12 @@ end
 n_block!(style::S, fst::FST, s::State; indent = 0) where {S<:AbstractStyle} =
     n_block!(DefaultStyle(style), fst, s, indent = indent)
 
-@inline n_comparison!(ds::DefaultStyle, fst::FST, s::State) = n_block!(ds, fst, s, indent=s.line_offset)
+@inline n_comparison!(ds::DefaultStyle, fst::FST, s::State) =
+    n_block!(ds, fst, s, indent = s.line_offset)
 n_comparison!(style::S, fst::FST, s::State) where {S<:AbstractStyle} =
     n_comparison!(DefaultStyle(style), fst, s)
 
-@inline n_chainopcall!(ds::DefaultStyle, fst::FST, s::State) = n_block!(ds, fst, s, indent=s.line_offset)
+@inline n_chainopcall!(ds::DefaultStyle, fst::FST, s::State) =
+    n_block!(ds, fst, s, indent = s.line_offset)
 n_chainopcall!(style::S, fst::FST, s::State) where {S<:AbstractStyle} =
     n_chainopcall!(DefaultStyle(style), fst, s)

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -652,7 +652,7 @@ function n_binaryopcall!(ds::DefaultStyle, fst::FST, s::State)
 
             if (
                 rhs.typ === CSTParser.BinaryOpCall &&
-                (!(is_lazy_op(cst) && !indent_nest) && cst[2].kind !== Tokens.IN)
+                 cst[2].kind !== Tokens.IN
             ) || rhs.typ === CSTParser.UnaryOpCall ||
                rhs.typ === CSTParser.ChainOpCall || rhs.typ === CSTParser.Comparison
                 line_margin += length(fst[end])

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -781,7 +781,7 @@ function n_block!(ds::DefaultStyle, fst::FST, s::State; indent = -1)
                 n.val = ""
                 n.len = 0
                 nest!(style, n, s)
-            elseif i < length(fst.nodes) -1 && fst[i+2].typ === CSTParser.OPERATOR
+            elseif i < length(fst.nodes) - 1 && fst[i+2].typ === CSTParser.OPERATOR
                 # chainopcall / comparison
                 diff = fst.indent - fst[i].indent
                 add_indent!(n, s, diff)

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -781,6 +781,12 @@ function n_block!(ds::DefaultStyle, fst::FST, s::State; indent = -1)
                 n.val = ""
                 n.len = 0
                 nest!(style, n, s)
+            elseif i < length(fst.nodes) -1 && fst[i+2].typ === CSTParser.OPERATOR
+                # chainopcall / comparison
+                diff = fst.indent - fst[i].indent
+                add_indent!(n, s, diff)
+                n.extra_margin = 1 + length(fst[i+2])
+                nest!(style, n, s)
             else
                 diff = fst.indent - fst[i].indent
                 add_indent!(n, s, diff)
@@ -788,7 +794,6 @@ function n_block!(ds::DefaultStyle, fst::FST, s::State; indent = -1)
                 nest!(style, n, s)
             end
         end
-
     else
         nest!(style, fst.nodes, s, fst.indent, extra_margin = fst.extra_margin)
     end

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -797,10 +797,10 @@ end
 n_block!(style::S, fst::FST, s::State; indent = 0) where {S<:AbstractStyle} =
     n_block!(DefaultStyle(style), fst, s, indent = indent)
 
-@inline n_comparison!(ds::DefaultStyle, fst::FST, s::State) = n_block!(ds, fst, s)
+@inline n_comparison!(ds::DefaultStyle, fst::FST, s::State) = n_block!(ds, fst, s, indent=s.line_offset)
 n_comparison!(style::S, fst::FST, s::State) where {S<:AbstractStyle} =
     n_comparison!(DefaultStyle(style), fst, s)
 
-@inline n_chainopcall!(ds::DefaultStyle, fst::FST, s::State) = n_block!(ds, fst, s)
+@inline n_chainopcall!(ds::DefaultStyle, fst::FST, s::State) = n_block!(ds, fst, s, indent=s.line_offset)
 n_chainopcall!(style::S, fst::FST, s::State) where {S<:AbstractStyle} =
     n_chainopcall!(DefaultStyle(style), fst, s)

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -361,7 +361,9 @@ function p_macrocall(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
         add_node!(t, pretty(style, cst[3], s), s, max_padding = 0)
         return t
     elseif length(cst) == 3 &&
-           cst[1].typ === CSTParser.MacroName && cst[1][2].val == "doc" && is_str(cst[2])
+           cst[1].typ === CSTParser.MacroName &&
+           cst[1][2].val == "doc" &&
+           is_str(cst[2])
         add_node!(t, pretty(style, cst[1], s), s)
         add_node!(t, Whitespace(1), s)
         add_node!(t, pretty(style, cst[2], s), s, join_lines = true)
@@ -1125,7 +1127,8 @@ function p_binaryopcall(
     op = cst[2]
     nonest = nonest || op.kind === Tokens.COLON
     if cst.parent.typ === CSTParser.Curly &&
-       op.kind in (Tokens.ISSUBTYPE, Tokens.ISSUPERTYPE) && !s.opts.whitespace_typedefs
+       op.kind in (Tokens.ISSUBTYPE, Tokens.ISSUPERTYPE) &&
+       !s.opts.whitespace_typedefs
         nospace = true
     elseif op.kind === Tokens.COLON
         nospace = true
@@ -1143,7 +1146,9 @@ function p_binaryopcall(
     end
 
     if op.kind === Tokens.COLON &&
-       s.opts.whitespace_ops_in_indices && !is_leaf(cst[1]) && !is_iterable(cst[1])
+       s.opts.whitespace_ops_in_indices &&
+       !is_leaf(cst[1]) &&
+       !is_iterable(cst[1])
         paren = FST(CSTParser.PUNCTUATION, n.startline, n.startline, "(")
         add_node!(t, paren, s)
         add_node!(t, n, s, join_lines = true)
@@ -1188,7 +1193,9 @@ function p_binaryopcall(
     end
 
     if op.kind === Tokens.COLON &&
-       s.opts.whitespace_ops_in_indices && !is_leaf(cst[3]) && !is_iterable(cst[3])
+       s.opts.whitespace_ops_in_indices &&
+       !is_leaf(cst[3]) &&
+       !is_iterable(cst[3])
         paren = FST(CSTParser.PUNCTUATION, n.startline, n.startline, "(")
         add_node!(t, paren, s, join_lines = true)
         add_node!(t, n, s, join_lines = true)
@@ -1232,7 +1239,8 @@ function p_whereopcall(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
     args = get_args(cst.args[3:end])
     nest = length(args) > 0 && !(length(args) == 1 && unnestable_arg(args[1]))
     add_braces =
-        !CSTParser.is_lbrace(cst[3]) && cst.parent.typ !== CSTParser.Curly &&
+        !CSTParser.is_lbrace(cst[3]) &&
+        cst.parent.typ !== CSTParser.Curly &&
         cst[3].typ !== CSTParser.Curly && cst[3].typ !== CSTParser.BracesCat
 
     brace = FST(CSTParser.PUNCTUATION, t.endline, t.endline, "{")

--- a/src/print.jl
+++ b/src/print.jl
@@ -49,7 +49,8 @@ end
 function print_tree(io::IOBuffer, fst::FST, s::State)
     notcode_indent = -1
     if fst.typ === CSTParser.BinaryOpCall ||
-       fst.typ === CSTParser.ConditionalOpCall || fst.typ === CSTParser.ModuleH
+       fst.typ === CSTParser.ConditionalOpCall ||
+       fst.typ === CSTParser.ModuleH
         notcode_indent = fst.indent
     end
     print_tree(io, fst.nodes, s, fst.indent, notcode_indent = notcode_indent)
@@ -90,7 +91,8 @@ function print_tree(
 
         if n.typ === NEWLINE && s.on && i < length(nodes)
             if is_closer(nodes[i+1]) ||
-               nodes[i+1].typ === CSTParser.Block || nodes[i+1].typ === CSTParser.Begin
+               nodes[i+1].typ === CSTParser.Block ||
+               nodes[i+1].typ === CSTParser.Begin
                 write(io, repeat(" ", max(nodes[i+1].indent, 0)))
                 s.line_offset = nodes[i+1].indent
             elseif !skip_indent(nodes[i+1])

--- a/src/styles/yas.jl
+++ b/src/styles/yas.jl
@@ -125,7 +125,8 @@ function p_whereopcall(ys::YASStyle, cst::CSTParser.EXPR, s::State)
     add_node!(t, Whitespace(1), s)
 
     add_braces =
-        !CSTParser.is_lbrace(cst[3]) && cst.parent.typ !== CSTParser.Curly &&
+        !CSTParser.is_lbrace(cst[3]) &&
+        cst.parent.typ !== CSTParser.Curly &&
         cst[3].typ !== CSTParser.Curly && cst[3].typ !== CSTParser.BracesCat
 
     brace = FST(CSTParser.PUNCTUATION, t.endline, t.endline, "{")

--- a/test/files/Docs.jl
+++ b/test/files/Docs.jl
@@ -282,7 +282,8 @@ function astname(x::Expr, ismacro::Bool)
         ismacro ? macroname(x) : x
         # Call overloading, e.g. `(a::A)(b) = b` or `function (a::A)(b) b end` should document `A(b)`
     elseif (isexpr(x, :function) || isexpr(x, :(=))) &&
-           isexpr(x.args[1], :call) && isexpr(x.args[1].args[1], :(::))
+           isexpr(x.args[1], :call) &&
+           isexpr(x.args[1].args[1], :(::))
         return astname(x.args[1].args[1].args[end], ismacro)
     else
         n = isexpr(x, (:module, :struct)) ? 2 : 1
@@ -297,7 +298,8 @@ macroname(s::Symbol) = Symbol('@', s)
 macroname(x::Expr) = Expr(x.head, x.args[1], macroname(x.args[end].value))
 
 isfield(@nospecialize x) =
-    isexpr(x, :.) && (isa(x.args[1], Symbol) || isfield(x.args[1])) &&
+    isexpr(x, :.) &&
+    (isa(x.args[1], Symbol) || isfield(x.args[1])) &&
     (isa(x.args[2], QuoteNode) || isexpr(x.args[2], :quote))
 
 # @doc expression builders.
@@ -340,7 +342,9 @@ function metadata(__source__, __module__, expr, ismodule)
                 end
             elseif isexpr(each, :function) || isexpr(each, :(=))
                 break
-            elseif isa(each, String) || isexpr(each, :string) || isexpr(each, :call) ||
+            elseif isa(each, String) ||
+                   isexpr(each, :string) ||
+                   isexpr(each, :call) ||
                    (isexpr(each, :macrocall) && each.args[1] === Symbol("@doc_str"))
                 # forms that might be doc strings
                 last_docstr = each
@@ -492,7 +496,8 @@ end
 # `true` to signify that at least one `@__doc__` has been found, and `false` otherwise.
 function finddoc(λ, def::Expr)
     if isexpr(def, :block, 2) &&
-       isexpr(def.args[1], :meta, 1) && def.args[1].args[1] === :doc
+       isexpr(def.args[1], :meta, 1) &&
+       def.args[1].args[1] === :doc
         # Found the macroexpansion of an `@__doc__` expression.
         λ(def)
         true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4584,8 +4584,8 @@ some_function(
 
             body
         end"""
-        @test fmt(str_,m=74) == str
-        @test fmt(str,m=75) == str_
+        @test fmt(str_, m = 74) == str
+        @test fmt(str, m = 75) == str_
     end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4586,6 +4586,35 @@ some_function(
         end"""
         @test fmt(str_, m = 74) == str
         @test fmt(str, m = 75) == str_
+
+        str_ = """
+        if argument1 && argument2 && (argument3 || argument4 || argument5) && argument6
+
+            body
+        end"""
+        str = """
+        if argument1 &&
+           argument2 &&
+           (argument3 || argument4 || argument5) &&
+           argument6
+
+            body
+        end"""
+        @test fmt(str_, m = 43) == str
+
+        str = """
+        if argument1 &&
+           argument2 &&
+           (
+               argument3 ||
+               argument4 ||
+               argument5
+           ) &&
+           argument6
+
+            body
+        end"""
+        @test fmt(str_, m = 42) == str
     end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4530,4 +4530,62 @@ some_function(
         @test fmt(str_) == str
     end
 
+    @testset "align ChainOpCall indent" begin
+        str_ = """
+        function _()
+            return some_expression *
+            some_expression *
+            some_expression *
+            some_expression *
+            some_expression *
+            some_expression *
+            some_expression
+        end"""
+        str = """
+        function _()
+            return some_expression *
+                   some_expression *
+                   some_expression *
+                   some_expression *
+                   some_expression *
+                   some_expression *
+                   some_expression
+        end"""
+        @test fmt(str_) == str
+
+        str_ = """
+        @some_macro some_expression *
+        some_expression *
+        some_expression *
+        some_expression *
+        some_expression *
+        some_expression *
+        some_expression"""
+        str = """
+        @some_macro some_expression *
+                    some_expression *
+                    some_expression *
+                    some_expression *
+                    some_expression *
+                    some_expression *
+                    some_expression"""
+        @test fmt(str_) == str
+
+        str_ = """
+        if some_expression && some_expression && some_expression && some_expression
+
+            body
+        end"""
+        str = """
+        if some_expression &&
+           some_expression &&
+           some_expression &&
+           some_expression
+
+            body
+        end"""
+        @test fmt(str_,m=74) == str
+        @test fmt(str,m=75) == str_
+    end
+
 end


### PR DESCRIPTION
This PR does 2 things:

1. BinaryOpCalls and ChainOpCalls now have a consistent indent. For example prior to this PR these would be format outputs.

```julia
julia> format_text(s, margin=1) |> print
return a *
       b
julia> format_text(s0, margin=1) |> print
return a *
b *
c
```

This PR

```julia
julia> format_text(s, margin=1) |> print
return a *
       b
julia> format_text(s0, margin=1) |> print
return a *
       b *
       c
```

This makes progress on #174 but it's doesn't use an indent multiple. In order to make the multiple of indent work well for these cases I think we need to surround with expressions with parenthesis. But, nonetheless I think this is a better outcome than before. Also, this PR makes that follow-up work much easier (if worthwhile).

2. For most binary operations CSTParser creates a ChainOpCall node if 2+ operations of the same kind are used consecutively. There are some exceptions such as, `&&`, `||`, `|>`, etc. This is due to precedence but leads to weird formatting, and required some hacky un-nesting to avoid results like this.

```julia
if argument1 &&
   argument2 && argument3 && argument4
    ...
end
```

This PR has a transform for these kind of binary op structures so that above exceeded the margin it would be formatted to:

```julia
if argument1 &&
   argument2 &&
   argument3 &&
   argument4
    ...
end
```

