### PR TITLE
Fix #200

### DIFF
--- a/src/print.jl
+++ b/src/print.jl
@@ -107,11 +107,11 @@ function print_stringh(io::IOBuffer, fst::FST, s::State)
     # The indent of StringH is set to the the offset
     # of when the quote is first encountered in the source file.
 
-    # This difference notes if there is a change due to formatting.
+    # This difference notes the indent change due to formatting.
     diff = s.line_offset - fst.indent
 
     # The new indent for the string is the index of when a character in
-    # the multiline string is FIRST encountered in the source file minus
+    # the multiline string is FIRST encountered in the source file plus
     # the above difference.
     fst.indent = max(fst[1].indent + diff, 0)
     print_tree(io, fst, s)

--- a/src/print.jl
+++ b/src/print.jl
@@ -107,13 +107,13 @@ function print_stringh(io::IOBuffer, fst::FST, s::State)
     # The indent of StringH is set to the the offset
     # of when the quote is first encountered in the source file.
 
-    # This difference notes if there is a change due to nesting.
-    diff = fst.indent + 1 - s.line_offset
+    # This difference notes if there is a change due to formatting.
+    diff = s.line_offset - fst.indent
 
-    # The new indent for the string is index of when a character in
-    # the multiline string is FIRST encountered in the source file - the above difference
-    # +1 since the character is 1 space after the indent
-    fst.indent = max(fst[1].indent + 1 - diff, 0)
+    # The new indent for the string is the index of when a character in
+    # the multiline string is FIRST encountered in the source file minus
+    # the above difference.
+    fst.indent = max(fst[1].indent + diff, 0)
     print_tree(io, fst, s)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4617,4 +4617,26 @@ some_function(
         @test fmt(str_, m = 42) == str
     end
 
+    @testset "issue 200" begin
+        str_ = """
+        begin
+            f() do
+                @info @sprintf \"\"\"
+                Δmass   = %.16e\"\"\" abs(weightedsum(Q) - weightedsum(Qe)) / weightedsum(Qe)
+            end
+        end"""
+
+        # NOTE: this looks slightly off because we're compensating for escaping quotes
+        str = """
+        begin
+            f() do
+                @info @sprintf \"\"\"
+                Δmass   = %.16e\"\"\" abs(weightedsum(Q) - weightedsum(Qe)) /
+                                   weightedsum(Qe)
+            end
+        end"""
+        @test fmt(str_, m = 81) == str
+        @test fmt(str, m = 82) == str_
+    end
+
 end


### PR DESCRIPTION
Sets line offset correctly after encourtering a NEWLINE node in
a StringH node (multiline string).

Additionally simplified setting the indent of StringH during the
printing phase.