### PR TITLE
Interval Tree

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -9,6 +9,12 @@ git-tree-sha1 = "7d10b92c4d9951ccf3009d960d9b66883c174474"
 uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
 version = "2.2.0"
 
+[[DataStructures]]
+deps = ["InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "5a431d46abf2ef2a4d5d00bd0ae61f651cf854c8"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.17.10"
+
 [[Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
@@ -23,6 +29,12 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[OrderedCollections]]
+deps = ["Random", "Serialization", "Test"]
+git-tree-sha1 = "c4c13474d23c60d20a67b217f1d7f22a40edf8f1"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.1.0"
 
 [[Random]]
 deps = ["Serialization"]

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.3.7"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tokenize = "0796e94c-ce3b-5d07-9a54-7f471281c624"
 


### PR DESCRIPTION
Uses an interval tree to query which line in the file an offset range corresponds to. Previously this was determined by looping over an array. This is heavily used to determine the cursor position during the prettify phase.

This isn't really an issue when a file is a couple thousand lines, but when formatting a large repo this should provide a substantial speedup since it's a O(n) -> O(lgn) improvement.

## Benchmarks

The string formatted is the contents of `runtests.jl` (~4600 lines)

**old**

```
BenchmarkTools.Trial:
  memory estimate:  13.70 MiB
  allocs estimate:  223063
  --------------
  minimum time:     26.294 ms (0.00% GC)
  median time:      27.123 ms (0.00% GC)
  mean time:        28.359 ms (4.93% GC)
  maximum time:     34.134 ms (17.61% GC)
  --------------
  samples:          177
  evals/sample:     1

```

**new**

```
BenchmarkTools.Trial:
  memory estimate:  15.20 MiB
  allocs estimate:  223103
  --------------
  minimum time:     15.131 ms (0.00% GC)
  median time:      15.704 ms (0.00% GC)
  mean time:        17.318 ms (9.88% GC)
  maximum time:     24.571 ms (30.20% GC)
  --------------
  samples:          289
  evals/sample:     1
```