### PR TITLE
doc: add YAS style doc to index

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,6 +11,7 @@ makedocs(
         "Skipping Formatting" => "skipping_formatting.md",
         "Syntax Transforms" => "transforms.md",
         "Custom Styles" => "custom_styles.md",
+        "YAS Style" => "yas_style.md",
         "API Reference" => "api.md",
     ],
 )


### PR DESCRIPTION
I also would like to point out here that the current stable document still points to v0.3's one.