### PR TITLE
Indent standalone lazy and/or expressions after first arg

### DIFF
--- a/docs/src/style.md
+++ b/docs/src/style.md
@@ -199,7 +199,7 @@ e1 :
 e2
 ```
 
-If nesting is required for a `=` binary operation, the RHS is placed on the following line.
+If nesting is required for a `=` binary operation, the RHS is placed on the following line and indented.
 
 ```julia
 foo() = body
@@ -209,6 +209,8 @@ foo() = body
 foo() =
     body
 ```
+
+Lazy `&&` and `||` operations are nested according to [`is_standalone_shortcircuit`](@ref) rules.
 
 All arguments of a function call (applies to any opening/closing punctuation type) are nested
 if the expression exceeds the margin. The arguments are indented one level. 

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -558,6 +558,7 @@ function is_standalone_shortcircuit(cst::CSTParser.EXPR)
         n === nothing && return true
         n.typ === CSTParser.InvisBrackets && return false
         n.typ === CSTParser.MacroCall && return false
+        n.typ === CSTParser.Return && return false
         n.typ === CSTParser.If && return false
         n.typ === CSTParser.Block && nest_assignment(n.parent) && return false
         n.typ === CSTParser.BinaryOpCall && nest_assignment(n) && return false
@@ -569,6 +570,7 @@ function is_standalone_shortcircuit(cst::CSTParser.EXPR)
         n.typ === CSTParser.If && return false
         n.typ === CSTParser.Block && return false
         n.typ === CSTParser.MacroCall && return false
+        n.typ === CSTParser.Return && return false
         n.typ === CSTParser.BinaryOpCall && nest_assignment(n) && return false
         return true
     end

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -70,9 +70,6 @@ function flatten_fst!(fst::FST)
     end
 end
 
-is_pipe(n) = op_kind(n) === Tokens.RPIPE
-
-
 """
     pipe_to_function_call_pass!(fst::FST)
 
@@ -81,7 +78,7 @@ Rewrites `x |> f` to `f(x)`.
 function pipe_to_function_call_pass!(fst::FST)
     is_leaf(fst) && return
 
-    if is_pipe(fst)
+    if op_kind(fst) === Tokens.RPIPE
         fst.nodes = pipe_to_function_call(fst)
         fst.typ = CSTParser.Call
         return
@@ -90,7 +87,7 @@ function pipe_to_function_call_pass!(fst::FST)
     for n in fst.nodes
         if is_leaf(n)
             continue
-        elseif is_pipe(n)
+        elseif op_kind(n) === Tokens.RPIPE
             n.nodes = pipe_to_function_call(n)
             n.typ = CSTParser.Call
         else

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -1718,12 +1718,7 @@ function p_generator(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
             if a.kind === Tokens.FOR && parent_is(
                 a,
                 is_iterable,
-                ignore_typs = (
-                    CSTParser.InvisBrackets,
-                    CSTParser.Generator,
-                    CSTParser.Flatten,
-                    CSTParser.Filter,
-                ),
+                ignore = n -> is_gen(n) || n.typ === CSTParser.InvisBrackets,
             )
                 add_node!(t, Placeholder(1), s)
             else

--- a/src/styles/yas.jl
+++ b/src/styles/yas.jl
@@ -269,6 +269,7 @@ end
 
 function p_generator(ys::YASStyle, cst::CSTParser.EXPR, s::State)
     t = FST(cst, nspaces(s))
+
     for (i, a) in enumerate(cst)
         # n = a.typ === CSTParser.BinaryOpCall ? pretty(ys, a, s, nonest = true) :
         #     pretty(ys, a, s)
@@ -277,12 +278,7 @@ function p_generator(ys::YASStyle, cst::CSTParser.EXPR, s::State)
             incomp = parent_is(
                 a,
                 is_iterable,
-                ignore_typs = (
-                    CSTParser.InvisBrackets,
-                    CSTParser.Generator,
-                    CSTParser.Flatten,
-                    CSTParser.Filter,
-                ),
+                ignore = n -> is_gen(n) || n.typ === CSTParser.InvisBrackets,
             )
 
             if is_block(cst[i-1])

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -4844,5 +4844,12 @@ some_function(
         @hello arg1 ||
                return arg2"""
         @test fmt(str_, 4, 1) == str
+
+        str_ = """
+        return arg1 || arg2"""
+        str = """
+        return arg1 ||
+               arg2"""
+        @test fmt(str_, 4, 1) == str
     end
 end

--- a/test/files/Docs.jl
+++ b/test/files/Docs.jl
@@ -221,7 +221,7 @@ function doc!(__module__::Module, b::Binding, str::DocStr, @nospecialize sig = U
         # that over-writing a docstring *may* have been accidental.  The warning
         # is suppressed for symbols in Main, for interactive use (#23011).
         __module__ == Main ||
-        @warn "Replacing docs for `$b :: $sig` in module `$(__module__)`"
+            @warn "Replacing docs for `$b :: $sig` in module `$(__module__)`"
     else
         # The ordering of docstrings for each Binding is defined by the order in which they
         # are initially added. Replacing a specific docstring does not change it's ordering.

--- a/test/files/reverse.jl
+++ b/test/files/reverse.jl
@@ -51,7 +51,8 @@ unwrapquote(x::QuoteNode) = x.value
 is_literal_getproperty(ex) =
     (
         iscall(ex, Base, :getproperty) ||
-        iscall(ex, Core, :getfield) || iscall(ex, Base, :getfield)
+        iscall(ex, Core, :getfield) ||
+        iscall(ex, Base, :getfield)
     ) && ex.args[3] isa Union{QuoteNode,Integer}
 
 function instrument_getproperty!(ir, v, ex)


### PR DESCRIPTION
I'm defining this as a lazy and/or expression that's NOT a component of a larger expression.

ref #222 

For demonstration purposes the maximum margin is set to 1.

Examples:

```julia
a && b

->

a &&
    b
```

```julia
a && b && c

->

a &&
    b &&
    c
```

the testset has more examples.

Something I'm still pondering is whether to treat `||` and `&&` as the same operation in this case.

So instead of `a || b && c` being

```
a ||
    b &&
        c
```

it would be

```
a ||
    b &&
    c
```

but this may be too pessimistic, since with a larger margin, which is what it would be in practice,
the former would be

 ```
a ||
    b && c
```
