### PR TITLE
Fix case where configuration file is not applied

### DIFF
--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -360,6 +360,12 @@ function format(paths; options...)
             format_file(path; opts...)
         else
             for (root, dirs, files) in walkdir(path)
+                base_opts = if (config = find_config_file(path)) !== nothing
+                    overwrite_options(options, config)
+                else
+                    options
+                end
+
                 for file in files
                     _, ext = splitext(file)
                     ext == ".jl" || continue
@@ -367,9 +373,9 @@ function format(paths; options...)
                     ".git" in splitpath(full_path) && continue
                     dir = relpath(root)
                     opts = if (config = find_config_file(dir)) !== nothing
-                        overwrite_options(options, config)
+                        overwrite_options(base_opts, config)
                     else
-                        options
+                        base_opts
                     end
                     format_file(full_path; opts...)
                 end

--- a/test/config.jl
+++ b/test/config.jl
@@ -79,13 +79,13 @@
 
     # test directory walk with nested configs
     # test_nested_config
-    # ├─ .JuliaFormatter.toml (config4)
-    # ├─ code.jl (before -> after4)
+    # ├─ .JuliaFormatter.toml (config2)
+    # ├─ code.jl (before -> after2)
     # ├─ sub1
-    # │  ├─ .JuliaFormatter.toml (config2)
-    # │  └─ sub_code1.jl (before -> after2)
+    # │  ├─ .JuliaFormatter.toml (config4)
+    # │  └─ sub_code1.jl (before -> after4)
     # └─ sub2
-    #    └─ sub_code2.jl (before -> after4)
+    #    └─ sub_code2.jl (before -> after2)
     sandbox_dir = joinpath(@__DIR__, "test_nested_config")
     mkdir(sandbox_dir)
     try
@@ -105,6 +105,45 @@
         open(io -> write(io, before), sub_code2_path, "w")
 
         format(sandbox_dir)
+        @test read(code_path, String) == after2
+        @test read(sub_code1_path, String) == after4
+        @test read(sub_code2_path, String) == after2
+    finally
+        rm(sandbox_dir; recursive = true)
+    end
+
+    # test directory walk with nested configs
+    # same as above except format from within the
+    # top level directory, i.e. `format(".")`
+    #
+    # test_nested_config
+    # ├─ .JuliaFormatter.toml (config2)
+    # ├─ code.jl (before -> after2)
+    # ├─ sub1
+    # │  ├─ .JuliaFormatter.toml (config4)
+    # │  └─ sub_code1.jl (before -> after4)
+    # └─ sub2
+    #    └─ sub_code2.jl (before -> after2)
+    sandbox_dir = joinpath(@__DIR__, "test_nested_config")
+    mkdir(sandbox_dir)
+    try
+        sub1_dir = joinpath(sandbox_dir, "sub1")
+        sub2_dir = joinpath(sandbox_dir, "sub2")
+        mkdir(sub1_dir)
+        mkdir(sub2_dir)
+        config_path = joinpath(sandbox_dir, CONFIG_FILE_NAME)
+        code_path = joinpath(sandbox_dir, "code.jl")
+        sub_config1_path = joinpath(sub1_dir, CONFIG_FILE_NAME)
+        sub_code1_path = joinpath(sub1_dir, "sub_code1.jl")
+        sub_code2_path = joinpath(sub2_dir, "sub_code2.jl")
+        open(io -> write(io, config2), config_path, "w")
+        open(io -> write(io, before), code_path, "w")
+        open(io -> write(io, config4), sub_config1_path, "w")
+        open(io -> write(io, before), sub_code1_path, "w")
+        open(io -> write(io, before), sub_code2_path, "w")
+
+        cd(sandbox_dir)
+        format(".")
         @test read(code_path, String) == after2
         @test read(sub_code1_path, String) == after4
         @test read(sub_code2_path, String) == after2

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -263,7 +263,6 @@
         @test fmt(str_) == str
     end
 
-
     @testset "tuples" begin
         @test fmt("(a,)") == "(a,)"
         @test fmt("a,b") == "a, b"
@@ -547,7 +546,6 @@
             body
           end"""
         @test fmt(str_, 2, 39) == str
-
 
         str = """
         foo =
@@ -1275,7 +1273,6 @@
         t = run_pretty(str_, 80)
         @test length(t) == 28
 
-
     end
 
     @testset "try" begin
@@ -1360,7 +1357,6 @@
             catch err
                 arg
             end""") == str
-
 
         str = """
         try
@@ -1594,7 +1590,6 @@
                       cool!\"\"\"
         end"""
         @test fmt(str_) == str
-
 
         str = """
         begin
@@ -2486,7 +2481,6 @@
         d"""
         @test fmt("a | b | c | d", 4, 1) == str
 
-
         str = """
         a, b, c, d"""
         @test fmt("a, b, c, d", 4, 10) == str
@@ -2729,8 +2723,6 @@
         @test fmt(str_) == str_
         @test fmt(str_, 2, 1) == str
 
-
-
         # https://github.com/domluna/JuliaFormatter.jl/issues/9#issuecomment-481607068
         str = """
         this_is_a_long_variable_name = Dict{Symbol,Any}(
@@ -2779,7 +2771,6 @@
                :mesh_dim => Cint(3),)"""
         @test fmt(str_, 4, 80) == str
 
-
         str = """
         func(
             a,
@@ -2816,8 +2807,6 @@
         )"""
         @test fmt(str, 4, 1) == str_
 
-
-
         # Ref
         str = "a[1+2]"
         @test fmt("a[1 + 2]", 4, 1) == str
@@ -2837,7 +2826,6 @@
         )"""
         @test fmt(str_, 2, length(str_) - 1) == str
         @test fmt(str_, 2, 1) == str
-
 
         str_ = "(a <= b <= c <= d)"
         @test fmt(str_, 4, length(str_)) == str_
@@ -3075,7 +3063,6 @@
             end
         )"""
         @test fmt(str_, 4, 20) == str
-
 
         str = "export @esc, isexpr, isline, iscall, rmlines, unblock, block, inexpr, namify, isdef"
         _, s = run_nest(str, length(str))
@@ -3586,7 +3573,6 @@
             body
         end"""
         @test fmt(str) == str
-
 
         # issue 155
         str_ = raw"""
@@ -4141,9 +4127,7 @@ some_function(
         )"""
         @test fmt(str_) == str
 
-
     end
-
 
     @testset "issue #150" begin
         str_ = "const SymReg{B,MT} = ArrayReg{B,Basic,MT} where {MT <:AbstractMatrix{Basic}}"

--- a/test/files/.JuliaFormatter.toml
+++ b/test/files/.JuliaFormatter.toml
@@ -1,0 +1,1 @@
+remove_extra_newlines = false

--- a/test/yas_style.jl
+++ b/test/yas_style.jl
@@ -251,7 +251,6 @@
                        last(spike_annotation))"""
         @test yasfmt(str_, 4, 62) == str
 
-
         str_ = raw"""ecg_signal = signal_from_template(eeg_signal; channel_names=[:avl, :avr], file_extension=Symbol("lpcm.zst"))"""
         str = raw"""
         ecg_signal = signal_from_template(eeg_signal; channel_names=[:avl, :avr],
@@ -270,7 +269,6 @@
                                                          :avr],
                                           file_extension=Symbol("lpcm.zst"))"""
         @test yasfmt(str_, 4, 1) == str
-
 
     end
 
@@ -351,7 +349,6 @@
               for x in xs)
         """
         @test yasfmt(str_, 2, 80) == str
-
 
         str_ = """spike_annotation = first(ann for ann in recording.annotations if ann.value == "epileptiform_spike")"""
         str = """


### PR DESCRIPTION
Fix case where if configuration file would not be applied to directory sub2 in the sturcture below when inside of dir and `format(".")` is called.

dir
├─ .JuliaFormatter.toml (config2)
├─ code.jl (before -> after2)
├─ sub1
│  ├─ .JuliaFormatter.toml (config4)
│  └─ sub_code1.jl (before -> after4)
└─ sub2
   └─ sub_code2.jl (before -> after2)

The description for one of the configuration test cases was off a little as well. That's been updated.