### PR TITLE
fix #232

### DIFF
--- a/src/fst.jl
+++ b/src/fst.jl
@@ -91,6 +91,7 @@ end
 @inline is_leaf(fst::FST) = fst.nodes === nothing
 
 @inline is_punc(cst::CSTParser.EXPR) = CSTParser.ispunctuation(cst)
+@inline is_punc(fst::FST) = fst.typ === CSTParser.PUNCTUATION
 @inline is_end(x) = x.typ === CSTParser.KEYWORD && x.val == "end"
 @inline is_colon(x) = x.typ === CSTParser.OPERATOR && x.val == ":"
 @inline is_comma(fst::FST) =

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -112,6 +112,7 @@ end
 
 function import_to_usings(fst::FST, s::State)
     findfirst(is_colon, fst.nodes) === nothing || return FST[]
+    findfirst(n -> is_punc(n) && n.val == ".", fst.nodes) === nothing || return FST[]
 
     usings = FST[]
     idxs = findall(n -> n.typ === CSTParser.IDENTIFIER, fst.nodes)

--- a/test/options.jl
+++ b/test/options.jl
@@ -111,6 +111,10 @@
         @test fmt(str_, import_to_using = true) == str
         t = run_pretty(str_, 80, opts = Options(import_to_using = true))
         @test t.len == 13
+
+        # #232
+        str = """import A.b"""
+        @test fmt(str, import_to_using = true) == str
     end
 
     @testset "always convert `=` to `in` (for loops)" begin


### PR DESCRIPTION
If a punctuation "." is found in the import statement stop conversion to
using.

NOTE: When a dot is used prior to an identifier, such as .A, the type of
the dot is an operator, not punctuation. Thus, the above does not interfere
with this behavior.