### PR TITLE
re-fixes #234

### DIFF
--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -360,22 +360,16 @@ function format(paths; options...)
             format_file(path; opts...)
         else
             for (root, dirs, files) in walkdir(path)
-                base_opts = if (config = find_config_file(path)) !== nothing
-                    overwrite_options(options, config)
-                else
-                    options
-                end
-
                 for file in files
                     _, ext = splitext(file)
                     ext == ".jl" || continue
                     full_path = joinpath(root, file)
                     ".git" in splitpath(full_path) && continue
-                    dir = relpath(root)
+                    dir = realpath(root)
                     opts = if (config = find_config_file(dir)) !== nothing
-                        overwrite_options(base_opts, config)
+                        overwrite_options(options, config)
                     else
-                        base_opts
+                        options
                     end
                     format_file(full_path; opts...)
                 end

--- a/test/config.jl
+++ b/test/config.jl
@@ -126,6 +126,7 @@
     #    └─ sub_code2.jl (before -> after2)
     sandbox_dir = joinpath(@__DIR__, "test_nested_config")
     mkdir(sandbox_dir)
+    original_dir = pwd()
     try
         sub1_dir = joinpath(sandbox_dir, "sub1")
         sub2_dir = joinpath(sandbox_dir, "sub2")
@@ -148,6 +149,7 @@
         @test read(sub_code1_path, String) == after4
         @test read(sub_code2_path, String) == after2
     finally
+        cd(original_dir)
         rm(sandbox_dir; recursive = true)
     end
 end


### PR DESCRIPTION
refixes #234 , will supercede #235 :

- fix typo(`relpath` to `realpath`), and everything should work well
- ensure we `cd` back to the original directory after test