### PR TITLE
Make format_file and format return true if file(s) already formatted

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -64,7 +64,7 @@ format(
 )
 ```
 
-The `text` argument to `format_text` is a string containing the code to be formatted; the formatted code is retuned as a new string. The `file` argument to `format_file` is the path of a file to be formatted. The `format` function is either called with a singe string to format if it is a `.jl` file or to recuse into looking for `.jl` files if it is a directory. It can also be called with a collection of such paths to iterate over.
+The `text` argument to `format_text` is a string containing the code to be formatted; the formatted code is retuned as a new string. The `file` argument to `format_file` is the path of a file to be formatted. The `format` function is either called with a singe string to format if it is a `.jl` file or to recuse into looking for `.jl` files if it is a directory. It can also be called with a collection of such paths to iterate over. The `format_file` and `format` functions will return `true` if the file(s) are already formatted (i.e. if no changes were made to the file(s)) and `false` if changes were required to format the file(s).
 
 [`format`](@ref) calls [`format_file`](@ref) which in turn calls [`format_text`](@ref).
 

--- a/test/config.jl
+++ b/test/config.jl
@@ -17,7 +17,7 @@
         open(io -> write(io, config2), config_path, "w")
         open(io -> write(io, before), code_path, "w")
 
-        format(code_path)
+        @test format(code_path) == false
         @test read(code_path, String) == after2
     finally
         rm(sandbox_dir; recursive = true)
@@ -44,10 +44,12 @@
         open(io -> write(io, before), sub_code_path, "w")
         open(io -> write(io, before), subsub_code_path, "w")
 
-        format(sub_code_path)
+        @test format(sub_code_path) == false
         @test read(sub_code_path, String) == after2
-        format(subsub_code_path)
+        @test format(subsub_code_path) == false
         @test read(subsub_code_path, String) == after2
+        @test format(sub_code_path) == true
+        @test format(subsub_code_path) == true
     finally
         rm(sandbox_dir; recursive = true)
     end
@@ -70,9 +72,10 @@
         open(io -> write(io, before), code_path, "w")
         open(io -> write(io, before), sub_code_path, "w")
 
-        format(sandbox_dir)
+        @test format(sandbox_dir) == false
         @test read(code_path, String) == after2
         @test read(sub_code_path, String) == after2
+        @test format(sandbox_dir) == true
     finally
         rm(sandbox_dir; recursive = true)
     end
@@ -104,10 +107,11 @@
         open(io -> write(io, before), sub_code1_path, "w")
         open(io -> write(io, before), sub_code2_path, "w")
 
-        format(sandbox_dir)
+        @test format(sandbox_dir) == false
         @test read(code_path, String) == after2
         @test read(sub_code1_path, String) == after4
         @test read(sub_code2_path, String) == after2
+        @test format(sandbox_dir) == true
     finally
         rm(sandbox_dir; recursive = true)
     end
@@ -144,10 +148,11 @@
         open(io -> write(io, before), sub_code2_path, "w")
 
         cd(sandbox_dir)
-        format(".")
+        @test format(".") == false
         @test read(code_path, String) == after2
         @test read(sub_code1_path, String) == after4
         @test read(sub_code2_path, String) == after2
+        @test format(".") == true
     finally
         cd(original_dir)
         rm(sandbox_dir; recursive = true)

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -3630,8 +3630,8 @@
         open(f1, "w") do io
             write(io, "a = 10\n\n\n\n\n\n")
         end
-        format_file(f1)
-        format_file(f1)
+        @test format_file(f1) == false
+        @test format_file(f1) == true
         open(f1) do io
             res = read(io, String)
             @test res == str


### PR DESCRIPTION
Makes the functions `format` and `format_file` return a boolean: `true` if the files were already formatted and `false` if not.  This simplifies the process of checking whether files are formatted during CI. E.g. `julia -e 'using JuliaFormatter; format(".") || exit(1)'`

Previously those functions return `nothing` so this should not break most code.