### PR TITLE
Add an option to place whitespace around `=` in keyword arguments

### DIFF
--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -50,6 +50,7 @@ normalize_line_ending(s::AbstractString) = replace(s, "\r\n" => "\n")
         pipe_to_function_call::Bool = false,
         short_to_long_function_def::Bool = false,
         always_use_return::Bool = false,
+        whitespace_in_kwargs::Bool = true,
     )::String
 
 Formats a Julia source passed in as a string, returning the formatted
@@ -68,7 +69,7 @@ be formatted across multiple lines.
 
 ### `always_for_in`
 
-If true `=` is always replaced with `in` if part of a `for` loop condition.
+If true, `=` is always replaced with `in` if part of a `for` loop condition.
 For example, `for i = 1:10` will be transformed to `for i in 1:10`.
 
 ### `whitespace_typedefs`
@@ -86,7 +87,7 @@ Example: `arr[(i1 + i2):(i3 + i4)]` instead of `arr[i1+i2:i3+i4]`.
 
 ### `remove_extra_newlines`
 
-If true superflous newlines will be removed. For example:
+If true, superflous newlines will be removed. For example:
 
 ```julia
 a = 1
@@ -106,7 +107,7 @@ b = 2
 
 ### `import_to_using`
 
-If true `import` expressions are rewritten to `using` expressions
+If true, `import` expressions are rewritten to `using` expressions
 in the following cases:
 
 ```julia
@@ -127,7 +128,7 @@ using C: C
 
 ### `pipe_to_function_call`
 
-If true `x |> f` is rewritten to `f(x)`.
+If true, `x |> f` is rewritten to `f(x)`.
 
 ### `short_to_long_function_def`
 
@@ -147,7 +148,7 @@ end
 
 ### `always_use_return`
 
-If true `return` will be prepended to the last expression where
+If true, `return` will be prepended to the last expression where
 applicable in function definitions, macro definitions, and do blocks.
 
 Example:
@@ -167,6 +168,25 @@ function foo()
     return expr2
 end
 ```
+
+### `whitespace_in_kwargs`
+
+If true, `=` in keyword arguments will be surrounded by whitespace.
+
+```julia
+f(; a=4)
+```
+
+to
+
+```julia
+f(; a = 4)
+```
+
+An exception to this is if the LHS ends with "!" then even if `whitespace_in_kwargs` is
+false, `=` will still be surrounded by whitespace. The logic behind this intervention being
+on the following parse the `!` will be treated as part of `=`, as in a "not equal" binary
+operation. This would change the semantics of the code and is therefore disallowed.
 """
 function format_text(
     text::AbstractString;
@@ -181,6 +201,7 @@ function format_text(
     pipe_to_function_call::Bool = false,
     short_to_long_function_def::Bool = false,
     always_use_return::Bool = false,
+    whitespace_in_kwargs::Bool = true,
 )
     isempty(text) && return text
 
@@ -199,6 +220,7 @@ function format_text(
         pipe_to_function_call = pipe_to_function_call,
         short_to_long_function_def = short_to_long_function_def,
         always_use_return = always_use_return,
+        whitespace_in_kwargs = whitespace_in_kwargs,
     )
     s = State(Document(text), indent, margin, opts)
     t = pretty(style, x, s)

--- a/src/options.jl
+++ b/src/options.jl
@@ -7,4 +7,5 @@ Base.@kwdef struct Options
     pipe_to_function_call::Bool = false
     short_to_long_function_def::Bool = false
     always_use_return::Bool = false
+    whitespace_in_kwargs::Bool = true
 end

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -1101,15 +1101,19 @@ p_colonopcall(style::S, cst::CSTParser.EXPR, s::State) where {S<:AbstractStyle} 
 function p_kw(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
     style = getstyle(ds)
     t = FST(cst, nspaces(s))
-    for a in cst
-        if a.kind === Tokens.EQ
-            add_node!(t, Whitespace(1), s)
-            add_node!(t, pretty(style, a, s), s, join_lines = true)
-            add_node!(t, Whitespace(1), s)
-        else
-            add_node!(t, pretty(style, a, s), s, join_lines = true)
-        end
+
+    exclamation = cst[1].typ === CSTParser.IDENTIFIER && endswith(cst[1].val, "!")
+
+    add_node!(t, pretty(style, cst[1], s), s, join_lines = true)
+    if s.opts.whitespace_in_kwargs || exclamation
+        add_node!(t, Whitespace(1), s)
+        add_node!(t, pretty(style, cst[2], s), s, join_lines = true)
+        add_node!(t, Whitespace(1), s)
+    else
+        add_node!(t, pretty(style, cst[2], s), s, join_lines = true)
     end
+    add_node!(t, pretty(style, cst[3], s), s, join_lines = true)
+
     t
 end
 p_kw(style::S, cst::CSTParser.EXPR, s::State) where {S<:AbstractStyle} =

--- a/src/styles/yas.jl
+++ b/src/styles/yas.jl
@@ -14,6 +14,7 @@ Recommended options are:
 - `pipe_to_function_call` = true
 - `short_to_long_function_def` = true
 - `always_use_return` = true
+- `whitespace_in_kwargs` = false
 """
 struct YASStyle <: AbstractStyle end
 @inline getstyle(s::YASStyle) = s
@@ -22,14 +23,6 @@ function nestable(::YASStyle, cst::CSTParser.EXPR)
     (CSTParser.defines_function(cst) || nest_assignment(cst)) && return false
     (cst[2].kind === Tokens.PAIR_ARROW || cst[2].kind === Tokens.ANON_FUNC) && return false
     return true
-end
-
-function p_kw(ys::YASStyle, cst::CSTParser.EXPR, s::State)
-    t = FST(cst, nspaces(s))
-    for a in cst
-        add_node!(t, pretty(ys, a, s), s, join_lines = true)
-    end
-    t
 end
 
 function p_import(ys::YASStyle, cst::CSTParser.EXPR, s::State)

--- a/test/files/Onda.jl/.JuliaFormatter.toml
+++ b/test/files/Onda.jl/.JuliaFormatter.toml
@@ -6,3 +6,4 @@ import_to_using = true
 pipe_to_function_call = true
 short_to_long_function_def = true
 always_use_return = true
+whitespace_in_kwargs = false

--- a/test/options.jl
+++ b/test/options.jl
@@ -253,4 +253,17 @@
         @test fmt(str_, 4, length(str_) - 1, always_use_return = true) == str
     end
 
+    @testset "whitespace in keyword arguments" begin
+        str_ = "f(; a = b)"
+        str = "f(; a=b)"
+        @test fmt(str_, 4, 92, whitespace_in_kwargs = false) == str
+
+        str = "f(; a!) = a!"
+        @test fmt(str, 4, 92, whitespace_in_kwargs = false) == str
+
+        # issue 242
+        str = "f(; a! = 4)"
+        @test fmt(str, 4, 92, whitespace_in_kwargs = false) == str
+    end
+
 end

--- a/test/options.jl
+++ b/test/options.jl
@@ -262,7 +262,7 @@
         @test fmt(str, 4, 92, whitespace_in_kwargs = false) == str
 
         # issue 242
-        str = "f(; a! = 4)"
+        str = "f(a, b! = 1; c! = 2, d! = 3)"
         @test fmt(str, 4, 92, whitespace_in_kwargs = false) == str
     end
 

--- a/test/options.jl
+++ b/test/options.jl
@@ -262,8 +262,9 @@
         @test fmt(str, 4, 92, whitespace_in_kwargs = false) == str
 
         # issue 242
-        str = "f(a, b! = 1; c! = 2, d! = 3)"
-        @test fmt(str, 4, 92, whitespace_in_kwargs = false) == str
+        str_ = "f(a, b! = 1; c! = 2, d = 3, e! = 4)"
+        str = "f(a, b! = 1; c! = 2, d=3, e! = 4)"
+        @test fmt(str_, 4, 92, whitespace_in_kwargs = false) == str
     end
 
 end

--- a/test/yas_style.jl
+++ b/test/yas_style.jl
@@ -1,7 +1,7 @@
 @testset "YAS style" begin
     @testset "basic" begin
         str_ = "foo(; k =v)"
-        str = "foo(; k=v)"
+        str = "foo(; k = v)"
         @test yasfmt(str_, 4, 80) == str
 
         str_ = "( k1 =v1,  k2=v2)"
@@ -253,21 +253,21 @@
 
         str_ = raw"""ecg_signal = signal_from_template(eeg_signal; channel_names=[:avl, :avr], file_extension=Symbol("lpcm.zst"))"""
         str = raw"""
-        ecg_signal = signal_from_template(eeg_signal; channel_names=[:avl, :avr],
-                                          file_extension=Symbol("lpcm.zst"))"""
+        ecg_signal = signal_from_template(eeg_signal; channel_names = [:avl, :avr],
+                                          file_extension = Symbol("lpcm.zst"))"""
         @test yasfmt(str_, 4, length(str_) - 1) == str
-        @test yasfmt(str_, 4, 73) == str
+        @test yasfmt(str_, 4, 75) == str
 
         str = raw"""
         ecg_signal = signal_from_template(eeg_signal;
-                                          channel_names=[:avl, :avr],
-                                          file_extension=Symbol("lpcm.zst"))"""
-        @test yasfmt(str_, 4, 72) == str
+                                          channel_names = [:avl, :avr],
+                                          file_extension = Symbol("lpcm.zst"))"""
+        @test yasfmt(str_, 4, 73) == str
         str = raw"""
         ecg_signal = signal_from_template(eeg_signal;
-                                          channel_names=[:avl,
-                                                         :avr],
-                                          file_extension=Symbol("lpcm.zst"))"""
+                                          channel_names = [:avl,
+                                                           :avr],
+                                          file_extension = Symbol("lpcm.zst"))"""
         @test yasfmt(str_, 4, 1) == str
 
     end


### PR DESCRIPTION
Fixes #243

Additionally fixes #242 by disallowing whitespace to be removed if the
LHS identifier ends with "!"