### PR TITLE
Option for annotating untyped fields in struct definitions to ::Any 

### DIFF
--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -187,6 +187,25 @@ An exception to this is if the LHS ends with "!" then even if `whitespace_in_kwa
 false, `=` will still be surrounded by whitespace. The logic behind this intervention being
 on the following parse the `!` will be treated as part of `=`, as in a "not equal" binary
 operation. This would change the semantics of the code and is therefore disallowed.
+
+### `annotate_untyped_fields_with_any`
+
+Annotates fields in a type definitions with `::Any` if no type annotation is provided:
+
+```julia
+struct A
+    arg1
+end
+```
+
+to
+
+```julia
+struct A
+    arg1::Any
+end
+```
+
 """
 function format_text(
     text::AbstractString;
@@ -202,6 +221,7 @@ function format_text(
     short_to_long_function_def::Bool = false,
     always_use_return::Bool = false,
     whitespace_in_kwargs::Bool = true,
+    annotate_untyped_fields_with_any::Bool = true,
 )
     isempty(text) && return text
 
@@ -221,6 +241,7 @@ function format_text(
         short_to_long_function_def = short_to_long_function_def,
         always_use_return = always_use_return,
         whitespace_in_kwargs = whitespace_in_kwargs,
+annotate_untyped_fields_with_any = annotate_untyped_fields_with_any,
     )
     s = State(Document(text), indent, margin, opts)
     t = pretty(style, x, s)

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -241,7 +241,7 @@ function format_text(
         short_to_long_function_def = short_to_long_function_def,
         always_use_return = always_use_return,
         whitespace_in_kwargs = whitespace_in_kwargs,
-annotate_untyped_fields_with_any = annotate_untyped_fields_with_any,
+        annotate_untyped_fields_with_any = annotate_untyped_fields_with_any,
     )
     s = State(Document(text), indent, margin, opts)
     t = pretty(style, x, s)

--- a/src/options.jl
+++ b/src/options.jl
@@ -8,4 +8,5 @@ Base.@kwdef struct Options
     short_to_long_function_def::Bool = false
     always_use_return::Bool = false
     whitespace_in_kwargs::Bool = true
+    annotate_untyped_fields_with_any::Bool = true
 end

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -587,7 +587,7 @@ function p_struct(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
         s.indent += s.indent_size
         n = pretty(style, cst[3], s, ignore_single_line = true)
         if s.opts.annotate_untyped_fields_with_any
-           annotate_typefields_with_any!(n, s)
+            annotate_typefields_with_any!(n, s)
         end
         add_node!(t, n, s, max_padding = s.indent_size)
         s.indent -= s.indent_size

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -586,7 +586,9 @@ function p_struct(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
     else
         s.indent += s.indent_size
         n = pretty(style, cst[3], s, ignore_single_line = true)
-        annotate_typefields_with_any!(n, s)
+        if s.opts.annotate_untyped_fields_with_any
+           annotate_typefields_with_any!(n, s)
+        end
         add_node!(t, n, s, max_padding = s.indent_size)
         s.indent -= s.indent_size
         add_node!(t, pretty(style, cst[4], s), s)
@@ -611,7 +613,9 @@ function p_mutable(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
     else
         s.indent += s.indent_size
         n = pretty(style, cst[4], s, ignore_single_line = true)
-        annotate_typefields_with_any!(n, s)
+        if s.opts.annotate_untyped_fields_with_any
+            annotate_typefields_with_any!(n, s)
+        end
         add_node!(t, n, s, max_padding = s.indent_size)
         s.indent -= s.indent_size
         add_node!(t, pretty(style, cst[5], s), s)

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -1220,61 +1220,6 @@
         @test length(t) == 27
     end
 
-    @testset "structs" begin
-        str = """
-        struct name
-            arg::Any
-        end"""
-
-        str_ = """
-        struct name
-            arg
-        end"""
-        @test fmt(str_) == str
-
-        str_ = """
-        struct name
-        arg
-        end"""
-        @test fmt(str_) == str
-
-        str_ = """
-        struct name
-                arg
-            end"""
-        @test fmt(str_) == str
-
-        t = run_pretty(str_, 80)
-        @test length(t) == 12
-
-        str = """
-        mutable struct name
-            reallylongfieldname::Any
-        end"""
-
-        str_ = """
-        mutable struct name
-            reallylongfieldname
-        end"""
-        @test fmt(str_) == str
-
-        str_ = """
-        mutable struct name
-        reallylongfieldname
-        end"""
-        @test fmt(str_) == str
-
-        str_ = """
-        mutable struct name
-                reallylongfieldname
-            end"""
-        @test fmt(str_) == str
-
-        t = run_pretty(str_, 80)
-        @test length(t) == 28
-
-    end
-
     @testset "try" begin
         str = """
         try

--- a/test/options.jl
+++ b/test/options.jl
@@ -339,21 +339,21 @@
         struct name
             arg
         end"""
-        @test fmt(str_, annotate_untyped_fields_with_any=false) == str
+        @test fmt(str_, annotate_untyped_fields_with_any = false) == str
 
         str_ = """
         struct name
         arg
         end"""
-        @test fmt(str_, annotate_untyped_fields_with_any=false) == str
+        @test fmt(str_, annotate_untyped_fields_with_any = false) == str
 
         str_ = """
         struct name
                 arg
             end"""
-        @test fmt(str_, annotate_untyped_fields_with_any=false) == str
+        @test fmt(str_, annotate_untyped_fields_with_any = false) == str
 
-        t = run_pretty(str_, 80, opts = Options(annotate_untyped_fields_with_any=false))
+        t = run_pretty(str_, 80, opts = Options(annotate_untyped_fields_with_any = false))
         @test length(t) == 11
 
         str = """
@@ -365,21 +365,21 @@
         mutable struct name
             reallylongfieldname
         end"""
-        @test fmt(str_, annotate_untyped_fields_with_any=false) == str
+        @test fmt(str_, annotate_untyped_fields_with_any = false) == str
 
         str_ = """
         mutable struct name
         reallylongfieldname
         end"""
-        @test fmt(str_, annotate_untyped_fields_with_any=false) == str
+        @test fmt(str_, annotate_untyped_fields_with_any = false) == str
 
         str_ = """
         mutable struct name
                 reallylongfieldname
             end"""
-        @test fmt(str_, annotate_untyped_fields_with_any=false) == str
+        @test fmt(str_, annotate_untyped_fields_with_any = false) == str
 
-        t = run_pretty(str_, 80, opts = Options(annotate_untyped_fields_with_any=false))
+        t = run_pretty(str_, 80, opts = Options(annotate_untyped_fields_with_any = false))
         @test length(t) == 23
     end
 

--- a/test/options.jl
+++ b/test/options.jl
@@ -277,4 +277,110 @@
         @test fmt(str_, 4, 80, style = DefaultStyle(), whitespace_in_kwargs = true) == str
     end
 
+    @testset "annotate untyped fields with `Any`" begin
+        str = """
+        struct name
+            arg::Any
+        end"""
+
+        str_ = """
+        struct name
+            arg
+        end"""
+        @test fmt(str_) == str
+
+        str_ = """
+        struct name
+        arg
+        end"""
+        @test fmt(str_) == str
+
+        str_ = """
+        struct name
+                arg
+            end"""
+        @test fmt(str_) == str
+
+        t = run_pretty(str_, 80)
+        @test length(t) == 12
+
+        str = """
+        mutable struct name
+            reallylongfieldname::Any
+        end"""
+
+        str_ = """
+        mutable struct name
+            reallylongfieldname
+        end"""
+        @test fmt(str_) == str
+
+        str_ = """
+        mutable struct name
+        reallylongfieldname
+        end"""
+        @test fmt(str_) == str
+
+        str_ = """
+        mutable struct name
+                reallylongfieldname
+            end"""
+        @test fmt(str_) == str
+
+        t = run_pretty(str_, 80)
+        @test length(t) == 28
+
+        str = """
+        struct name
+            arg
+        end"""
+
+        str_ = """
+        struct name
+            arg
+        end"""
+        @test fmt(str_, annotate_untyped_fields_with_any=false) == str
+
+        str_ = """
+        struct name
+        arg
+        end"""
+        @test fmt(str_, annotate_untyped_fields_with_any=false) == str
+
+        str_ = """
+        struct name
+                arg
+            end"""
+        @test fmt(str_, annotate_untyped_fields_with_any=false) == str
+
+        t = run_pretty(str_, 80, opts = Options(annotate_untyped_fields_with_any=false))
+        @test length(t) == 11
+
+        str = """
+        mutable struct name
+            reallylongfieldname
+        end"""
+
+        str_ = """
+        mutable struct name
+            reallylongfieldname
+        end"""
+        @test fmt(str_, annotate_untyped_fields_with_any=false) == str
+
+        str_ = """
+        mutable struct name
+        reallylongfieldname
+        end"""
+        @test fmt(str_, annotate_untyped_fields_with_any=false) == str
+
+        str_ = """
+        mutable struct name
+                reallylongfieldname
+            end"""
+        @test fmt(str_, annotate_untyped_fields_with_any=false) == str
+
+        t = run_pretty(str_, 80, opts = Options(annotate_untyped_fields_with_any=false))
+        @test length(t) == 23
+    end
+
 end


### PR DESCRIPTION
defaults to `true`. fixes #246 