### PR TITLE
MacroBlock trailing comma fix

### DIFF
--- a/src/fst.jl
+++ b/src/fst.jl
@@ -207,6 +207,7 @@ function add_node!(t::FST, n::FST, s::State; join_lines = false, max_padding = -
            en.typ === CSTParser.Filter ||
            en.typ === CSTParser.Flatten ||
            en.typ === CSTParser.MacroCall ||
+           en.typ === MacroBlock ||
            (is_comma(en) && t.typ === CSTParser.TupleH && n_args(t.ref[]) == 1)
             # don't insert trailing comma in these cases
         elseif is_comma(en)

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -4781,4 +4781,16 @@ some_function(
                arg2"""
         @test fmt(str_, 4, 1) == str
     end
+
+    @testset "issue 248" begin
+        str_ = """
+        var = call(a, @macrocall b)"""
+        str = """
+        var =
+            call(
+                a,
+                @macrocall b
+            )"""
+        @test fmt(str_, 4, 1) == str
+    end
 end


### PR DESCRIPTION
When `CSTParser.MacroCall` was split into itself and `MacroBlock` it was forgotten not to add a trailing comma if the final element is a `MacroBlock`.

difference for reference:

```
MacroCall @call(a, b)
MacroBlock @call a
```

fixes #248 