### PR TITLE
resolve #251

### DIFF
--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -1168,7 +1168,7 @@ function p_binaryopcall(
     nrhs && (t.force_nest = true)
     nest = (nestable(style, cst) && !nonest) || nrhs
 
-    if op.fullspan == 0 && cst[3].typ === CSTParser.IDENTIFIER
+    if op.fullspan == 0
         # noop
     elseif op.kind === Tokens.EX_OR
         add_node!(t, Whitespace(1), s)

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -1169,7 +1169,8 @@ function p_binaryopcall(
     nest = (nestable(style, cst) && !nonest) || nrhs
 
     if op.fullspan == 0
-        # noop
+        # Do nothing - represents a binary op with no textual representation.
+        # For example: `2a`, which is equivalent to `2 * a`.
     elseif op.kind === Tokens.EX_OR
         add_node!(t, Whitespace(1), s)
         add_node!(t, pretty(style, op, s), s, join_lines = true)

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -361,7 +361,9 @@
         # issue 74
         @test fmt("0:1/3:2") == "0:1/3:2"
         @test fmt("2a") == "2a"
-        @test fmt("2(a+1)") == "2 * (a + 1)"
+        # issue 251
+        @test fmt("2(a+1)") == "2(a + 1)"
+        @test fmt("1 / 2a^2") == "1 / 2a^2"
 
         str_ = "a[1:2 * num_source * num_dump-1]"
         str = "a[1:2*num_source*num_dump-1]"


### PR DESCRIPTION
I'm not sure why the decision was made to format `2(a + 1)` as `2 * (a +
1)`, perhaps it was simply stylistic. In any case as shown in #251 it can
  change the result of the computation so we'll stop doing it.