### PR TITLE
Fixes issue 260

### DIFF
--- a/src/fst.jl
+++ b/src/fst.jl
@@ -19,12 +19,6 @@
     MacroBlock,
 )
 
-# nesting
-# DEFAULT
-# NEST
-# UNNEST
-# @enum()
-
 """
 Formatted Syntax Tree
 """

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -13,6 +13,7 @@
     INLINECOMMENT,
     TRAILINGCOMMA,
     TRAILINGSEMICOLON,
+    INVERSETRAILINGSEMICOLON,
 
     # no equivalent in CSTParser
     MacroBlock,
@@ -77,7 +78,9 @@ end
 @inline Semicolon() = FST(SEMICOLON, -1, -1, 0, 1, ";", nothing, nothing, false, 0)
 @inline TrailingComma() = FST(TRAILINGCOMMA, -1, -1, 0, 0, "", nothing, nothing, false, 0)
 @inline TrailingSemicolon() =
-    FST(TRAILINGSEMICOLON, -1, -1, 0, 1, ";", nothing, nothing, false, 0)
+    FST(TRAILINGSEMICOLON, -1, -1, 0, 0, "", nothing, nothing, false, 0)
+@inline InverseTrailingSemicolon() =
+    FST(INVERSETRAILINGSEMICOLON, -1, -1, 0, 1, ";", nothing, nothing, false, 0)
 @inline Whitespace(n) = FST(WHITESPACE, -1, -1, 0, n, " "^n, nothing, nothing, false, 0)
 @inline Placeholder(n) = FST(PLACEHOLDER, -1, -1, 0, n, " "^n, nothing, nothing, false, 0)
 @inline Notcode(startline, endline) =
@@ -152,6 +155,7 @@ function get_args(cst::CSTParser.EXPR)
         return get_args(cst.args[3:end])
     elseif cst.typ === CSTParser.Braces ||
            cst.typ === CSTParser.Vcat ||
+           cst.typ === CSTParser.BracesCat ||
            cst.typ === CSTParser.TupleH ||
            cst.typ === CSTParser.Vect ||
            cst.typ === CSTParser.InvisBrackets ||

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -439,10 +439,6 @@ function n_comprehension!(ds::DefaultStyle, fst::FST, s::State; indent = -1)
             else
                 nest_if_over_margin!(style, fst, s, i)
             end
-        elseif n.typ === TRAILINGSEMICOLON
-            n.val = ""
-            n.len = 0
-            nest!(style, n, s)
         elseif i == length(fst.nodes) && !closer
             nest!(style, n, s)
         else
@@ -807,10 +803,6 @@ function n_block!(ds::DefaultStyle, fst::FST, s::State; indent = -1)
             elseif n.typ === TRAILINGCOMMA
                 n.val = ","
                 n.len = 1
-                nest!(style, n, s)
-            elseif n.typ === TRAILINGSEMICOLON
-                n.val = ""
-                n.len = 0
                 nest!(style, n, s)
             elseif i < length(fst.nodes) - 1 && fst[i+2].typ === CSTParser.OPERATOR
                 # chainopcall / comparison

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -59,6 +59,8 @@ function pretty(ds::DefaultStyle, cst::CSTParser.EXPR, s::State; kwargs...)
         return p_typedcomprehension(style, cst, s)
     elseif cst.typ === CSTParser.Braces
         return p_braces(style, cst, s)
+    elseif cst.typ === CSTParser.BracesCat
+        return p_bracescat(style, cst, s)
     elseif cst.typ === CSTParser.TupleH
         return p_tupleh(style, cst, s)
     elseif cst.typ === CSTParser.InvisBrackets
@@ -1481,6 +1483,35 @@ end
 p_braces(style::S, cst::CSTParser.EXPR, s::State) where {S<:AbstractStyle} =
     p_braces(DefaultStyle(style), cst, s)
 
+# BracesCat
+function p_bracescat(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
+    style = getstyle(ds)
+    t = FST(cst, nspaces(s))
+    nest = length(cst) > 2 && !(length(cst) == 3 && unnestable_arg(cst[2]))
+
+    for (i, a) in enumerate(cst)
+        n = pretty(style, a, s)
+        if i == 1 && nest
+            add_node!(t, n, s, join_lines = true)
+            add_node!(t, Placeholder(0), s)
+        elseif i == length(cst) && nest
+            add_node!(t, TrailingSemicolon(), s)
+            add_node!(t, Placeholder(0), s)
+            add_node!(t, n, s, join_lines = true)
+        else
+            add_node!(t, n, s, join_lines = true)
+            if i != length(cst) -1 
+                add_node!(t, Semicolon(), s)
+                add_node!(t, Placeholder(1), s)
+            end
+        end
+    end
+    t
+end
+p_bracescat(style::S, cst::CSTParser.EXPR, s::State) where {S<:AbstractStyle} =
+    p_bracescat(DefaultStyle(style), cst, s)
+
+
 # Vect
 function p_vect(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
     style = getstyle(ds)
@@ -1645,7 +1676,7 @@ function p_vcat(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
         elseif !is_closer(a) && i > st
             add_node!(t, n, s, join_lines = true)
             if i != length(cst) - 1
-                has_semicolon(s.doc, n.startline) && add_node!(t, TrailingSemicolon(), s)
+                has_semicolon(s.doc, n.startline) && add_node!(t, InverseTrailingSemicolon(), s)
                 add_node!(t, Placeholder(1), s)
                 # Keep trailing semicolon if there's only one arg
             elseif n_args(cst) == 1
@@ -1690,6 +1721,8 @@ p_hcat(style::S, cst::CSTParser.EXPR, s::State) where {S<:AbstractStyle} =
 @inline p_typedhcat(ds::DefaultStyle, cst::CSTParser.EXPR, s::State) = p_hcat(ds, cst, s)
 p_typedhcat(style::S, cst::CSTParser.EXPR, s::State) where {S<:AbstractStyle} =
     p_typedhcat(DefaultStyle(style), cst, s)
+
+
 
 # Row
 function p_row(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -1500,7 +1500,7 @@ function p_bracescat(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
             add_node!(t, n, s, join_lines = true)
         else
             add_node!(t, n, s, join_lines = true)
-            if i != length(cst) -1 
+            if i != length(cst) - 1
                 add_node!(t, Semicolon(), s)
                 add_node!(t, Placeholder(1), s)
             end
@@ -1510,7 +1510,6 @@ function p_bracescat(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
 end
 p_bracescat(style::S, cst::CSTParser.EXPR, s::State) where {S<:AbstractStyle} =
     p_bracescat(DefaultStyle(style), cst, s)
-
 
 # Vect
 function p_vect(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
@@ -1676,7 +1675,8 @@ function p_vcat(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
         elseif !is_closer(a) && i > st
             add_node!(t, n, s, join_lines = true)
             if i != length(cst) - 1
-                has_semicolon(s.doc, n.startline) && add_node!(t, InverseTrailingSemicolon(), s)
+                has_semicolon(s.doc, n.startline) &&
+                    add_node!(t, InverseTrailingSemicolon(), s)
                 add_node!(t, Placeholder(1), s)
                 # Keep trailing semicolon if there's only one arg
             elseif n_args(cst) == 1
@@ -1721,8 +1721,6 @@ p_hcat(style::S, cst::CSTParser.EXPR, s::State) where {S<:AbstractStyle} =
 @inline p_typedhcat(ds::DefaultStyle, cst::CSTParser.EXPR, s::State) = p_hcat(ds, cst, s)
 p_typedhcat(style::S, cst::CSTParser.EXPR, s::State) where {S<:AbstractStyle} =
     p_typedhcat(DefaultStyle(style), cst, s)
-
-
 
 # Row
 function p_row(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -4795,4 +4795,19 @@ some_function(
             )"""
         @test fmt(str_, 4, 1) == str
     end
+
+    @testset "issue 260 - BracesCat" begin
+        str = "{1; 2; 3}"
+        @test fmt(str, 4, length(str)) == str
+
+        str_ = "{1; 2; 3}"
+        str = """
+        {
+          1;
+          2;
+          3;
+        }"""
+        @test fmt(str_, 2, length(str_)-1) == str
+        @test fmt(str, 2, length(str_)) == str_
+    end
 end

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -4807,7 +4807,7 @@ some_function(
           2;
           3;
         }"""
-        @test fmt(str_, 2, length(str_)-1) == str
+        @test fmt(str_, 2, length(str_) - 1) == str
         @test fmt(str, 2, length(str_)) == str_
     end
 end


### PR DESCRIPTION
fixes #260 

The BracesCat type wasn't being dispatched on since this type comes up very, very rarely.

This also adds a new leaf type INVERSETRAILINGSEMICOLON which behaves how TRAILINGSEMICOLON previously did. TRAILINGSEMICOLON is now behaves the same as TRAILINGCOMMA but with different punctuation obviously.
