### PR TITLE
Resolve #262

### DIFF
--- a/src/fst.jl
+++ b/src/fst.jl
@@ -120,6 +120,8 @@ function is_importer_exporter(fst::FST)
     return false
 end
 
+@inline is_macrocall(fst::FST) = fst.typ === CSTParser.MacroCall || fst.typ === MacroBlock
+
 # f a function which returns a bool
 function parent_is(cst::CSTParser.EXPR, valid; ignore = (n) -> false)
     p = cst.parent

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -37,21 +37,34 @@ function walk(f, nodes::Vector{FST}, s::State, indent::Int)
     end
 end
 
+"""
+    walk(f, fst::FST, s::State)
+
+Walks `fst` calling `f` on each node.
+
+In situations where descending further into the FST is not desirable
+"""
 function walk(f, fst::FST, s::State)
-    f(fst, s)
-    is_leaf(fst) && return
+    stop = f(fst, s)
+    # @info "" cont
+    (stop != nothing || is_leaf(fst)) && return
+    # is_leaf(fst) && return
     walk(f, fst.nodes, s, fst.indent)
 end
 
 function reset_line_offset!(fst::FST, s::State)
     is_leaf(fst) || return
     s.line_offset += length(fst)
+    return nothing
 end
 
 function add_indent!(fst::FST, s::State, indent)
     indent == 0 && return
     lo = s.line_offset
-    f = (fst::FST, s::State) -> fst.indent += indent
+    f = (fst::FST, s::State) -> begin
+fst.indent += indent
+return nothing
+        end
     walk(f, fst, s)
     s.line_offset = lo
 end

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -42,13 +42,12 @@ end
 
 Walks `fst` calling `f` on each node.
 
-In situations where descending further into the FST is not desirable
+In situations where descending further into a subtree is not desirable `f`
+should return a value other than `nothing`.
 """
 function walk(f, fst::FST, s::State)
     stop = f(fst, s)
-    # @info "" cont
     (stop != nothing || is_leaf(fst)) && return
-    # is_leaf(fst) && return
     walk(f, fst.nodes, s, fst.indent)
 end
 

--- a/src/nest.jl
+++ b/src/nest.jl
@@ -62,9 +62,9 @@ function add_indent!(fst::FST, s::State, indent)
     indent == 0 && return
     lo = s.line_offset
     f = (fst::FST, s::State) -> begin
-fst.indent += indent
-return nothing
-        end
+        fst.indent += indent
+        return nothing
+    end
     walk(f, fst, s)
     s.line_offset = lo
 end

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -388,17 +388,19 @@ Module.@macro
 """
 function move_at_sign_to_the_end(fst::FST, s::State)
     t = FST[]
-    f = (t) -> (n, s) -> begin
-        if is_macrocall(n) || (n.typ === CSTParser.Quotenode && !is_leaf(n[1]))
-            # 1. Do not move "@" in nested macro calls 
-            # 2. Do not move "@" if in the middle of a chain, i.e. "a.@b.c"
-            # since it's semantically different to "@a.b.c" and "a.b.@c"
-            push!(t, n)
-            return false
-        elseif is_leaf(n)
-            push!(t, n)
-        end
-    end
+    f =
+        (t) ->
+            (n, s) -> begin
+                if is_macrocall(n) || (n.typ === CSTParser.Quotenode && !is_leaf(n[1]))
+                    # 1. Do not move "@" in nested macro calls
+                    # 2. Do not move "@" if in the middle of a chain, i.e. "a.@b.c"
+                    # since it's semantically different to "@a.b.c" and "a.b.@c"
+                    push!(t, n)
+                    return false
+                elseif is_leaf(n)
+                    push!(t, n)
+                end
+            end
     walk(f(t), fst, s)
 
     macroname = FST(CSTParser.MacroName, fst.indent)

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -394,8 +394,8 @@ function move_at_sign_to_the_end(fst::FST, s::State)
             push!(t, n)
             return false
         elseif is_leaf(n)
-                push!(t, n)
-        end 
+            push!(t, n)
+        end
     end
     walk(f(t), fst, s)
 

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -388,7 +388,15 @@ Module.@macro
 """
 function move_at_sign_to_the_end(fst::FST, s::State)
     t = FST[]
-    f = (t) -> (n, s) -> is_leaf(n) && push!(t, n)
+    f = (t) -> (n, s) -> begin
+        if is_macrocall(n)
+            # do not remove @ of nested macro calls
+            push!(t, n)
+            return false
+        elseif is_leaf(n)
+                push!(t, n)
+        end 
+    end
     walk(f(t), fst, s)
 
     macroname = FST(CSTParser.MacroName, fst.indent)

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -389,8 +389,10 @@ Module.@macro
 function move_at_sign_to_the_end(fst::FST, s::State)
     t = FST[]
     f = (t) -> (n, s) -> begin
-        if is_macrocall(n)
-            # do not remove @ of nested macro calls
+        if is_macrocall(n) || (n.typ === CSTParser.Quotenode && !is_leaf(n[1]))
+            # 1. Do not move "@" in nested macro calls 
+            # 2. Do not move "@" if in the middle of a chain, i.e. "a.@b.c"
+            # since it's semantically different to "@a.b.c" and "a.b.@c"
             push!(t, n)
             return false
         elseif is_leaf(n)
@@ -404,6 +406,8 @@ function move_at_sign_to_the_end(fst::FST, s::State)
         if n.val == "@"
             continue
         elseif i < length(t)
+            add_node!(macroname, n, s, join_lines = true)
+        elseif n.typ === CSTParser.Quotenode
             add_node!(macroname, n, s, join_lines = true)
         else
             at = FST(CSTParser.PUNCTUATION, n.startline, n.endline, "@")

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -432,6 +432,7 @@ function p_macrocall(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
     # @Module.macro -> Module.@macro
     t[1] = move_at_sign_to_the_end(t[1], s)
 
+    # !has_closer && length(t.nodes) > 1 && (t.typ = MacroBlock)
     !has_closer && (t.typ = MacroBlock)
     t
 end

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -4827,6 +4827,6 @@ some_function(
 
         str_ = raw":($(@__MODULE__.macro).@field.macro)"
         str = raw":($(__MODULE__.@macro).field.@macro)"
-        @test fmt(str) == str
+        @test fmt(str_) == str
     end
 end

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -4810,4 +4810,23 @@ some_function(
         @test fmt(str_, 2, length(str_) - 1) == str
         @test fmt(str, 2, length(str_)) == str_
     end
+
+    @testset "issue 262 - removal of @ in nested macrocall" begin
+        str = raw":($(@__MODULE__).@macro)"
+        @test fmt(str) == str
+
+        str = raw":($(@__MODULE__).property)"
+        @test fmt(str) == str
+
+        str = raw":($(@__MODULE__))"
+        @test fmt(str) == str
+
+        str_ = raw":($(@__MODULE__).@field.macro)"
+        str = raw":($(@__MODULE__).field.@macro)"
+        @test fmt(str_) == str
+
+        str_ = raw":($(@__MODULE__.macro).@field.macro)"
+        str = raw":($(__MODULE__.@macro).field.@macro)"
+        @test fmt(str) == str
+    end
 end

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -4821,12 +4821,36 @@ some_function(
         str = raw":($(@__MODULE__))"
         @test fmt(str) == str
 
-        str_ = raw":($(@__MODULE__).@field.macro)"
-        str = raw":($(@__MODULE__).field.@macro)"
-        @test fmt(str_) == str
+        str = raw":($(@__MODULE__).@field.macro)"
+        @test fmt(str) == str
 
         str_ = raw":($(@__MODULE__.macro).@field.macro)"
-        str = raw":($(__MODULE__.@macro).field.@macro)"
+        str = raw":($(__MODULE__.@macro).@field.macro)"
         @test fmt(str_) == str
+        @test fmt(str) == str
+
+        str_ = raw"@a.b.c"
+        str = raw"a.b.@c"
+        @test fmt(str_) == str
+        @test fmt(str) == str
+
+        str_ = raw"@a.b.c"
+        str = raw"a.b.@c"
+        @test fmt(str_) == str
+        @test fmt(str) == str
+
+        str = raw"a.@b.c"
+        @test fmt(str) == str
+
+        str = raw"a.@b.c.d"
+        @test fmt(str) == str
+
+        str = raw"a.b.@c.d"
+        @test fmt(str) == str
+
+        str_ = raw"@a.b.c.d"
+        str = raw"a.b.c.@d"
+        @test fmt(str_) == str
+        @test fmt(str) == str
     end
 end


### PR DESCRIPTION
During the pass to move @ to the end of the macro call, the FST walk was
descending into inner macro calls. This is problematic since all leaf
nodes with the value "@" were removed. This is solved by modifying `walk` to stop descending into a sub-tree if value other than `nothing` is returned from the passed function.
