### PR TITLE
Fix #268 -  surround dot op with whitespace if LHS is a number literal

### DIFF
--- a/src/fst.jl
+++ b/src/fst.jl
@@ -99,7 +99,7 @@ end
     (cst.typ === CSTParser.BinaryOpCall && cst[2].kind === Tokens.COLON) ||
     cst.typ === CSTParser.ColonOpCall
 
-@inline function is_number(cst::CSTParser.EXPR) 
+@inline function is_number(cst::CSTParser.EXPR)
     cst.typ === CSTParser.LITERAL || return false
     return cst.kind === Tokens.INTEGER || cst.kind === Tokens.FLOAT
 end

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -99,6 +99,11 @@ end
     (cst.typ === CSTParser.BinaryOpCall && cst[2].kind === Tokens.COLON) ||
     cst.typ === CSTParser.ColonOpCall
 
+@inline function is_number(cst::CSTParser.EXPR) 
+    cst.typ === CSTParser.LITERAL || return false
+    return cst.kind === Tokens.INTEGER || cst.kind === Tokens.FLOAT
+end
+
 function is_multiline(fst::FST)
     fst.typ === CSTParser.StringH && return true
     if fst.typ === CSTParser.x_Str && fst[2].typ === CSTParser.StringH

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -1200,7 +1200,12 @@ function p_chainopcall(
                 add_node!(t, Placeholder(nws), s)
             end
         elseif is_opcall(a)
-            add_node!(t, pretty(style, a, s, nospace=nospace, nonest=nonest), s, join_lines = true)
+            add_node!(
+                t,
+                pretty(style, a, s, nospace = nospace, nonest = nonest),
+                s,
+                join_lines = true,
+            )
         elseif i == length(cst) - 1 && is_punc(a) && is_punc(cst[i+1])
             add_node!(t, pretty(style, a, s), s, join_lines = true)
         else

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -4731,4 +4731,12 @@ some_function(
         end"""
         @test fmt(str_) == str
     end
+
+    @testset "issue 268 - whitespace around dot op if LHS is number literal" begin
+        str = "xs[-5 .<= xs .& xs .<= 5]"
+        @test fmt(str) == str
+        str_ = "xs[(-5 .<= xs) .& (xs .<= 5)]"
+        str = "xs[(-5 .<= xs).&(xs.<=5)]"
+        @test fmt(str_) == str
+    end
 end


### PR DESCRIPTION
This avoids ambiguity in the following case

```
xs[-5 .<= xs .& xs .<= 5]
```

which was formatted to

```
xs[-5.<=xs .& xs.<=5]
```

which creates an amiguity with `-5.<=xs`. The parser cannot determine whether this is a dot operator `.<=` or a float `5.` followed by `<=`

**SIDENOTE: In the formatted result above `.&` should not be surrounded by whitespace so this also fixes that bug by propagating `nonest` and `nospace` arguments through ChainOpCall and Comparison type nodes.**