### PR TITLE
partially solve #233

### DIFF
--- a/src/passes.jl
+++ b/src/passes.jl
@@ -354,14 +354,17 @@ end
 """
 function prepend_return!(fst::FST, s::State)
     fst.typ === CSTParser.Block || return
-    fst[end].typ !== CSTParser.Return || return
+    ln = fst[end]
+    is_block(ln) && return
+    ln.typ === CSTParser.Return && return
+    ln.typ === CSTParser.MacroCall && return
+    ln.typ === MacroBlock && return
 
     ret = FST(CSTParser.Return, fst.indent)
-    ln = fst[end]
-    kw = FST(CSTParser.KEYWORD, fst[end].startline, fst[end].endline, "return")
+    kw = FST(CSTParser.KEYWORD, ln.startline, ln.endline, "return")
     add_node!(ret, kw, s)
     add_node!(ret, Whitespace(1), s)
-    add_node!(ret, fst[end], s, join_lines = true)
+    add_node!(ret, ln, s, join_lines = true)
     fst[end] = ret
 end
 

--- a/test/options.jl
+++ b/test/options.jl
@@ -251,6 +251,36 @@
             return expr2
         end"""
         @test fmt(str_, 4, length(str_) - 1, always_use_return = true) == str
+
+        str = """
+        function foo()
+            @macrocall(expr2)
+        end"""
+        @test fmt(str, 4, 92, always_use_return = true) == str
+
+        str = """
+        function foo()
+            @macroblock expr2
+        end"""
+        @test fmt(str, 4, 92, always_use_return = true) == str
+
+        str = """
+        function foo()
+            for i = 1:10
+                println(i)
+            end
+        end"""
+        @test fmt(str, 4, 92, always_use_return = true) == str
+
+        str = """
+        function f(a)
+            if a > 0
+                return -1
+            else
+                return 1
+            end
+        end"""
+        @test fmt(str, 4, 92, always_use_return = true) == str
     end
 
     @testset "whitespace in keyword arguments" begin


### PR DESCRIPTION
node types that `return` can be prepended on are further restricted.

we could do some more sophisticated analysis to cleverly insert the
return in certain cases but I don't think it's worth it at the moment.