### PR TITLE
Custom Alignment

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,6 +10,7 @@ makedocs(
         "Code Style" => "style.md",
         "Skipping Formatting" => "skipping_formatting.md",
         "Syntax Transforms" => "transforms.md",
+        "Custom Alignment" => "custom_alignment.md",
         "Custom Styles" => "custom_styles.md",
         "YAS Style" => "yas_style.md",
         "Configuration File" => "config.md",

--- a/docs/src/custom_alignment.md
+++ b/docs/src/custom_alignment.md
@@ -139,7 +139,7 @@ end
 Align conditional expressions to either `?`, `:`, or both.
 
 ```julia
-# This will remain like if using YASStyle
+# This will remain like this if using YASStyle
 index = zeros(n <= typemax(Int8)  ? Int8  :
               n <= typemax(Int16) ? Int16 :
               n <= typemax(Int32) ? Int32 : Int64, n)
@@ -153,7 +153,6 @@ index = zeros(
 )
 
 # Note even if the maximum margin is set to 1, the alignment remains intact
-
 index = 
     zeros(
         n <= typemax(Int8)  ? Int8  :

--- a/docs/src/custom_alignment.md
+++ b/docs/src/custom_alignment.md
@@ -56,17 +56,38 @@ proceed with normal behavior.
 
 ## Alignment Options
 
+
 In order for alignment to occur the option must be set to `true`. Available options:
 
 - `align_assignment`
 - `align_struct_field`
 - `align_conditional`
+- `align_pair_arrow`
+
+> **Caveat: Since nesting is disabled when alignment occurs be careful when adding comments to the RHS expression. This will be fixed in a future release**
+
+For example:
+
+```julia
+const variable1 = 1
+const var2      = foo(10,
+    # comment,
+    20)
+```
+
+This will be formatted to
+
+```julia
+const variable1 = 1
+const var2      = foo(10, # comment, 20)
+```
+
+which causes a parsing error.
 
 ### `align_assignment`
 
 Align to `=`-like operators. This covers variable assignments and short definition functions.
 
-> **Caveat: since nesting is disabled when alignment occurs be careful when adding comments to the RHS expression.**
 
 ```julia
 const UTF8PROC_STABLE    = (1 << 1)
@@ -162,3 +183,23 @@ index =
     )
 
 ```
+
+### `align_assignment`
+
+Align pair arrows (`=>`).
+
+```julia
+pages = [
+    "Introduction"        => "index.md",
+    "How It Works"        => "how_it_works.md",
+    "Code Style"          => "style.md",
+    "Skipping Formatting" => "skipping_formatting.md",
+    "Syntax Transforms"   => "transforms.md",
+    "Custom Alignment"    => "custom_alignment.md",
+    "Custom Styles"       => "custom_styles.md",
+    "YAS Style"           => "yas_style.md",
+    "Configuration File"  => "config.md",
+    "API Reference"       => "api.md",
+]
+```
+

--- a/docs/src/custom_alignment.md
+++ b/docs/src/custom_alignment.md
@@ -184,7 +184,7 @@ index =
 
 ```
 
-### `align_assignment`
+### `align_pair_arrow`
 
 Align pair arrows (`=>`).
 

--- a/docs/src/custom_alignment.md
+++ b/docs/src/custom_alignment.md
@@ -1,0 +1,165 @@
+# Custom Alignment
+
+> Solution for [issue 179](https://github.com/domluna/JuliaFormatter.jl/issues/179)
+
+Custom alignment is determined by a whitespace heuristic:
+
+A token (typically an operator, i.e. `=, ?, ::, etc`) is custom aligned if there are 
+`> 1` whitespaces from the previous expression since the formatter only outputs 
+0 or 1 whitespaces for separation. If custom alignment is determined then all
+expressions in the code block will be aligned to the furthest aligned token.
+
+> NOTE: alignment overrides nesting behavior, meaning it ignores the allowed maximum margin
+
+### Example
+
+Suppose the source text is as follows
+
+```julia
+const variable1 = 1
+const var2      = 2
+const var3 = 3
+const var4 = 4
+const var5          = 5
+```
+
+If the `align_assignment` option is enabled the formatter will detect that `var2`
+is aligned to `variable1` AND `var2` has several whitespaces (>1) prior to
+`=`. Since `var3`,`var4`, and `var5` are part of the same code block (no comments
+or newlines separating code) they will also be aligned.
+
+So the output would be
+
+```julia
+const variable1 = 1
+const var2      = 2
+const var3      = 3
+const var4      = 4
+const var5      = 5
+```
+
+Notice how the `=` operator for `var5` is correctly positioned
+despite it being located further to the right than other `=` operators.
+
+However, if the source code is
+
+```julia
+const variable1 = 1
+const variable2 = 2
+const var3 = 3
+const var4 = 4
+const var5 = 5
+```
+
+It's now ambiguous whether this is meant to be aligned and so the formatter will
+proceed with normal behavior.
+
+## Alignment Options
+
+In order for alignment to occur the option must be set to `true`. Available options:
+
+- `align_assignment`
+- `align_struct_field`
+- `align_conditional`
+
+### `align_assignment`
+
+Align to `=`-like operators. This covers variable assignments and short definition functions.
+
+> **Caveat: since nesting is disabled when alignment occurs be careful when adding comments to the RHS expression.**
+
+```julia
+const UTF8PROC_STABLE    = (1 << 1)
+const UTF8PROC_COMPAT    = (1 << 2)
+const UTF8PROC_COMPOSE   = (1 << 3)
+const UTF8PROC_DECOMPOSE = (1 << 4)
+const UTF8PROC_IGNORE    = (1 << 5)
+const UTF8PROC_REJECTNA  = (1 << 6)
+const UTF8PROC_NLF2LS    = (1 << 7)
+const UTF8PROC_NLF2PS    = (1 << 8)
+const UTF8PROC_NLF2LF    = (UTF8PROC_NLF2LS | UTF8PROC_NLF2PS)
+const UTF8PROC_STRIPCC   = (1 << 9)
+const UTF8PROC_CASEFOLD  = (1 << 10)
+const UTF8PROC_CHARBOUND = (1 << 11)
+const UTF8PROC_LUMP      = (1 << 12)
+const UTF8PROC_STRIP     = (1 << 13)
+
+
+vcat(X::T...) where {T}         = T[X[i] for i = 1:length(X)]
+vcat(X::T...) where {T<:Number} = T[X[i] for i = 1:length(X)]
+hcat(X::T...) where {T}         = T[X[j] for i = 1:1, j = 1:length(X)]
+hcat(X::T...) where {T<:Number} = T[X[j] for i = 1:1, j = 1:length(X)]
+
+a  = 1
+bc = 2
+
+long_variable = 1
+other_var     = 2
+```
+
+### `align_struct_field`
+
+Align struct field definitions to `::` or `=` - whichever has higher precedence.
+
+```julia
+Base.@kwdef struct Options
+    indent_size::Int                       = 4
+    max_margin::Int                        = 92
+    always_for_in::Bool                    = false
+    whitespace_typedefs::Bool              = false
+    whitespace_ops_in_indices::Bool        = false
+    remove_extra_newlines::Bool            = false
+    import_to_using::Bool                  = false
+    pipe_to_function_call::Bool            = false
+    short_to_long_function_def::Bool       = false
+    always_use_return::Bool                = false
+    whitespace_in_kwargs::Bool             = true
+    annotate_untyped_fields_with_any::Bool = true
+    format_docstrings::Bool                = false
+    align_struct_fields::Bool              = false
+
+    # no custom whitespace so this block is not aligned
+    another_field1::BlahBlahBlah = 10
+    field2::Foo = 10
+
+    # no custom whitespace but single line blocks are not aligned
+    # either way
+    Options() = new()
+end
+
+
+mutable struct Foo
+    a             :: T
+    longfieldname :: T
+end
+```
+
+### `align_conditional`
+
+Align conditional expressions to either `?`, `:`, or both.
+
+```julia
+# This will remain like if using YASStyle
+index = zeros(n <= typemax(Int8)  ? Int8  :
+              n <= typemax(Int16) ? Int16 :
+              n <= typemax(Int32) ? Int32 : Int64, n)
+
+# Using DefaultStyle
+index = zeros(
+    n <= typemax(Int8)  ? Int8  :
+    n <= typemax(Int16) ? Int16 :
+    n <= typemax(Int32) ? Int32 : Int64,
+    n,
+)
+
+# Note even if the maximum margin is set to 1, the alignment remains intact
+
+index = 
+    zeros(
+        n <= typemax(Int8)  ? Int8  :
+        n <= typemax(Int16) ? Int16 :
+        n <= typemax(Int32) ? Int32 : Int64,
+        n,
+    )
+
+```

--- a/docs/src/yas_style.md
+++ b/docs/src/yas_style.md
@@ -20,8 +20,6 @@ The `.JuliaFormatter.toml` which represents these settings is
 
 ```toml
 style = "yas"
-indent = 4
-margin = 92
 always_for_in = true
 whitespace_ops_in_indices = true
 whitespace_typedefs = false

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -231,6 +231,10 @@ end
 Format code docstrings with the same options used for the code source.
 
 Markdown is formatted with [`CommonMark`](https://github.com/MichaelHatherly/CommonMark.jl) alongside Julia code.
+
+### `align_*`
+
+See `Custom Alignment` documentation.
 """
 function format_text(
     text::AbstractString;

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -39,6 +39,7 @@ include("options.jl")
 include("state.jl")
 include("fst.jl")
 include("passes.jl")
+include("align.jl")
 
 include("styles/default/pretty.jl")
 include("styles/default/nest.jl")
@@ -281,6 +282,7 @@ function format_text(cst::CSTParser.EXPR, style::AbstractStyle, s::State)
     s.opts.pipe_to_function_call && pipe_to_function_call_pass!(t)
 
     flatten_fst!(t)
+    align_fst!(t)
     nest!(style, t, s)
 
     s.line_offset = 0

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -250,8 +250,7 @@ function format_text(
     format_docstrings::Bool = false,
     align_struct_field::Bool = false,
     align_conditional::Bool = false,
-    align_const::Bool = false,
-    align_short_function_def::Bool = false,
+    align_assignment::Bool = false,
 )
     isempty(text) && return text
     opts = Options(
@@ -270,8 +269,7 @@ function format_text(
         format_docstrings = format_docstrings,
         align_struct_field = align_struct_field,
         align_conditional = align_conditional,
-        align_const = align_const,
-        align_short_function_def = align_short_function_def,
+        align_assignment = align_assignment,
     )
     return format_text(text, style, opts)
 end
@@ -291,7 +289,11 @@ function format_text(cst::CSTParser.EXPR, style::AbstractStyle, s::State)
     s.opts.pipe_to_function_call && pipe_to_function_call_pass!(t)
 
     flatten_fst!(t)
+
+    if s.opts.align_struct_field || s.opts.align_conditional || s.opts.align_assignment
     align_fst!(t, s.opts)
+    end
+
     nest!(style, t, s)
 
     s.line_offset = 0

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -291,7 +291,7 @@ function format_text(cst::CSTParser.EXPR, style::AbstractStyle, s::State)
     flatten_fst!(t)
 
     if s.opts.align_struct_field || s.opts.align_conditional || s.opts.align_assignment
-    align_fst!(t, s.opts)
+        align_fst!(t, s.opts)
     end
 
     nest!(style, t, s)

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -39,7 +39,7 @@ include("options.jl")
 include("state.jl")
 include("fst.jl")
 include("passes.jl")
-# include("align.jl")
+include("align.jl")
 
 include("styles/default/pretty.jl")
 include("styles/default/nest.jl")
@@ -249,6 +249,7 @@ function format_text(
     annotate_untyped_fields_with_any::Bool = true,
     format_docstrings::Bool = false,
     align_struct_fields::Bool = false,
+    align_conditionals::Bool = false,
 )
     isempty(text) && return text
     opts = Options(
@@ -266,6 +267,7 @@ function format_text(
         annotate_untyped_fields_with_any = annotate_untyped_fields_with_any,
         format_docstrings = format_docstrings,
         align_struct_fields = align_struct_fields,
+        align_conditionals = align_conditionals,
     )
     return format_text(text, style, opts)
 end
@@ -285,9 +287,8 @@ function format_text(cst::CSTParser.EXPR, style::AbstractStyle, s::State)
     s.opts.pipe_to_function_call && pipe_to_function_call_pass!(t)
 
     flatten_fst!(t)
-    align_fst_before_nest!(t, s.opts)
+    align_fst!(t, s.opts)
     nest!(style, t, s)
-    align_fst_after_nest!(t, s.opts)
 
     s.line_offset = 0
     io = IOBuffer()

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -296,7 +296,10 @@ function format_text(cst::CSTParser.EXPR, style::AbstractStyle, s::State)
 
     flatten_fst!(t)
 
-    if s.opts.align_struct_field || s.opts.align_conditional || s.opts.align_assignment || s.opts.align_pair_arrow
+    if s.opts.align_struct_field ||
+       s.opts.align_conditional ||
+       s.opts.align_assignment ||
+       s.opts.align_pair_arrow
         align_fst!(t, s.opts)
     end
 

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -248,8 +248,10 @@ function format_text(
     whitespace_in_kwargs::Bool = true,
     annotate_untyped_fields_with_any::Bool = true,
     format_docstrings::Bool = false,
-    align_struct_fields::Bool = false,
-    align_conditionals::Bool = false,
+    align_struct_field::Bool = false,
+    align_conditional::Bool = false,
+    align_const::Bool = false,
+    align_short_function_def::Bool = false,
 )
     isempty(text) && return text
     opts = Options(
@@ -266,8 +268,10 @@ function format_text(
         whitespace_in_kwargs = whitespace_in_kwargs,
         annotate_untyped_fields_with_any = annotate_untyped_fields_with_any,
         format_docstrings = format_docstrings,
-        align_struct_fields = align_struct_fields,
-        align_conditionals = align_conditionals,
+        align_struct_field = align_struct_field,
+        align_conditional = align_conditional,
+        align_const = align_const,
+        align_short_function_def = align_short_function_def,
     )
     return format_text(text, style, opts)
 end

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -285,8 +285,9 @@ function format_text(cst::CSTParser.EXPR, style::AbstractStyle, s::State)
     s.opts.pipe_to_function_call && pipe_to_function_call_pass!(t)
 
     flatten_fst!(t)
+    align_fst_before_nest!(t, s.opts)
     nest!(style, t, s)
-    align_fst!(t, s.opts)
+    align_fst_after_nest!(t, s.opts)
 
     s.line_offset = 0
     io = IOBuffer()

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -70,6 +70,7 @@ normalize_line_ending(s::AbstractString) = replace(s, "\r\n" => "\n")
         whitespace_in_kwargs::Bool = true,
         annotate_untyped_fields_with_any::Bool = true,
         format_docstrings::Bool = false,
+        align_struct_fields::Bool = false,
     )::String
 
 Formats a Julia source passed in as a string, returning the formatted
@@ -247,6 +248,7 @@ function format_text(
     whitespace_in_kwargs::Bool = true,
     annotate_untyped_fields_with_any::Bool = true,
     format_docstrings::Bool = false,
+    align_struct_fields::Bool = false,
 )
     isempty(text) && return text
     opts = Options(
@@ -263,6 +265,7 @@ function format_text(
         whitespace_in_kwargs = whitespace_in_kwargs,
         annotate_untyped_fields_with_any = annotate_untyped_fields_with_any,
         format_docstrings = format_docstrings,
+        align_struct_fields = align_struct_fields,
     )
     return format_text(text, style, opts)
 end
@@ -282,8 +285,8 @@ function format_text(cst::CSTParser.EXPR, style::AbstractStyle, s::State)
     s.opts.pipe_to_function_call && pipe_to_function_call_pass!(t)
 
     flatten_fst!(t)
-    align_fst!(t)
     nest!(style, t, s)
+    align_fst!(t, s.opts)
 
     s.line_offset = 0
     io = IOBuffer()

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -70,7 +70,10 @@ normalize_line_ending(s::AbstractString) = replace(s, "\r\n" => "\n")
         whitespace_in_kwargs::Bool = true,
         annotate_untyped_fields_with_any::Bool = true,
         format_docstrings::Bool = false,
-        align_struct_fields::Bool = false,
+        align_struct_field::Bool = false,
+        align_conditional::Bool = false,
+        align_assignment::Bool = false,
+        align_pair_arrow::Bool = false,
     )::String
 
 Formats a Julia source passed in as a string, returning the formatted

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -255,6 +255,7 @@ function format_text(
     align_struct_field::Bool = false,
     align_conditional::Bool = false,
     align_assignment::Bool = false,
+    align_pair_arrow::Bool = false,
 )
     isempty(text) && return text
     opts = Options(
@@ -274,6 +275,7 @@ function format_text(
         align_struct_field = align_struct_field,
         align_conditional = align_conditional,
         align_assignment = align_assignment,
+        align_pair_arrow = align_pair_arrow,
     )
     return format_text(text, style, opts)
 end
@@ -294,7 +296,7 @@ function format_text(cst::CSTParser.EXPR, style::AbstractStyle, s::State)
 
     flatten_fst!(t)
 
-    if s.opts.align_struct_field || s.opts.align_conditional || s.opts.align_assignment
+    if s.opts.align_struct_field || s.opts.align_conditional || s.opts.align_assignment || s.opts.align_pair_arrow
         align_fst!(t, s.opts)
     end
 

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -39,7 +39,7 @@ include("options.jl")
 include("state.jl")
 include("fst.jl")
 include("passes.jl")
-include("align.jl")
+# include("align.jl")
 
 include("styles/default/pretty.jl")
 include("styles/default/nest.jl")

--- a/src/align.jl
+++ b/src/align.jl
@@ -25,7 +25,7 @@ function align_fst!(fst::FST, opts::Options)
 
         if n.typ === CSTParser.BinaryOpCall && n[3].val == "=>"
             push!(pair_arrow_idxs, i)
-        end 
+        end
     end
 
     if opts.align_assignment

--- a/src/align.jl
+++ b/src/align.jl
@@ -132,7 +132,6 @@ function align_consts!(fst::FST)
         len = g[1]
         idxs = g[2]
         for i in idxs
-            @info "group" fst[i][3]
             align_binaryopcall!(fst[i][3], len)
         end
     end

--- a/src/align.jl
+++ b/src/align.jl
@@ -62,19 +62,26 @@ function align_struct!(fst::FST)
 
     # determine the longest field name in the struct
     bn = fst[idx]
-    max_fname_length = 0
+    max_field_len = 0
+    nfields = 0
     for n in bn.nodes
-        if n.typ === CSTParser.BinaryOpCall && length(n[1]) > max_fname_length
-            max_fname_length = length(n[1])
+        if n.typ === CSTParser.BinaryOpCall
+            nfields += 1
+            if length(n[1]) > max_field_len
+                max_field_len = length(n[1])
+            end
         end
     end
 
+    # Don't align unless there are multiple fields
+    nfields > 1 || return
+
     for n in bn.nodes
-        if n.typ === CSTParser.BinaryOpCall
-            diff = max_fname_length - length(n[1]) + 1
+        if n.typ === CSTParser.BinaryOpCall && !CSTParser.defines_function(n.ref[])
+            diff = max_field_len - length(n[1]) + 1
             # insert whitespace before and after operator
-            fidx = findfirst(x -> x.typ === WHITESPACE,n.nodes)
-            lidx = findlast(x -> x.typ === WHITESPACE,n.nodes)
+            fidx = findfirst(x -> x.typ === WHITESPACE, n.nodes)
+            lidx = findlast(x -> x.typ === WHITESPACE, n.nodes)
 
             if fidx === nothing
                 insert!(n, 2, Whitespace(diff))
@@ -89,4 +96,9 @@ function align_struct!(fst::FST)
     end
 end
 
-function align_conditionalopcall!(fst::FST) end
+"""
+    align_conditionalopcall!(fst::FST) 
+"""
+function align_conditionalopcall!(fst::FST)
+    return 0
+end

--- a/src/align.jl
+++ b/src/align.jl
@@ -69,20 +69,20 @@ struct AlignGroup
 end
 
 function align_to(g::AlignGroup)::Union{Nothing,Int}
-        # determine whether alignment might be warranted
-        max_len, max_idx =findmax(g.lens)
-        max_idxs = findall(==(g.line_offsets[max_idx]), g.line_offsets) 
-        length(max_idxs) > 1 || return nothing
-        # @info "" max_len max_idxs
+    # determine whether alignment might be warranted
+    max_len, max_idx = findmax(g.lens)
+    max_idxs = findall(==(g.line_offsets[max_idx]), g.line_offsets)
+    length(max_idxs) > 1 || return nothing
+    # @info "" max_len max_idxs
 
-        # is there custom whitespace?
-        for i in max_idxs
-            if max_len - g.lens[i] + 1 > 1
-                return max_len
-            end
+    # is there custom whitespace?
+    for i in max_idxs
+        if max_len - g.lens[i] + 1 > 1
+            return max_len
         end
+    end
 
-        return nothing
+    return nothing
 end
 
 function align_binaryopcall!(fst::FST, diff::Int)
@@ -186,7 +186,6 @@ function align_struct!(fst::FST)
     end
 end
 
-
 """
     align_const!(fst::FST) 
 
@@ -237,8 +236,6 @@ function align_consts!(fst::FST)
     return
 end
 
-
-
 """
 """
 function align_conditionalopcall!(fst::FST)
@@ -285,16 +282,16 @@ function align_conditionalopcall!(fst::FST)
 
     len = align_to(colon_group)
     for (i, idx) in enumerate(colon_group.node_idxs)
-            # the placeholder would be i+1 if not for a possible inline comment
-            nidx = findnext(n -> n.typ === PLACEHOLDER, nodes, idx+1)
-            if nodes[nidx+1].startline != nodes[nidx].startline
-                nodes[nidx] = Newline(nest_behavior=AlwaysNest)
-            end
+        # the placeholder would be i+1 if not for a possible inline comment
+        nidx = findnext(n -> n.typ === PLACEHOLDER, nodes, idx + 1)
+        if nodes[nidx+1].startline != nodes[nidx].startline
+            nodes[nidx] = Newline(nest_behavior = AlwaysNest)
+        end
 
-            if len !== nothing
-                diff = len - colon_group.lens[i] + 1
-                nodes[idx-1] = Whitespace(diff)
-            end
+        if len !== nothing
+            diff = len - colon_group.lens[i] + 1
+            nodes[idx-1] = Whitespace(diff)
+        end
     end
 
     fst.nodes = nodes

--- a/src/align.jl
+++ b/src/align.jl
@@ -51,8 +51,6 @@ function align_to(g::AlignGroup)::Union{Nothing,Int}
     max_idxs = findall(==(g.src_line_offsets[max_idx]), g.src_line_offsets)
     length(max_idxs) > 1 || return nothing
 
-    # @info "" max_idxs max_len max_idx g.src_line_offsets[max_idx]
-
     # is there custom whitespace?
     for i in max_idxs
         g.whitespaces[i] > 1 && return max_len
@@ -139,15 +137,11 @@ function align_struct!(fst::FST)
             idx = findfirst(x -> x.typ === CSTParser.OPERATOR, n.nodes)
             ws = n[idx].line_offset - (n.line_offset + nlen)
 
-            # @info "" ws nlen n[idx].line_offset n.line_offset
             push!(g, i, n[idx].line_offset, nlen, ws)
-
             prev_endline = n.endline
         end
     end
-    if length(g.lens) > 1
-        push!(groups, g)
-    end
+    push!(groups, g)
 
     for g in groups
         align_len = align_to(g)
@@ -177,14 +171,11 @@ function align_assignments!(fst::FST, assignment_idxs::Vector{Int})
         nlen = length(binop[1])
 
         ws = binop[3].line_offset - (binop.line_offset + nlen)
-        # @info "" ws nlen binop[3].line_offset binop.line_offset
         push!(g, i, binop[3].line_offset, nlen, ws)
 
         prev_endline = n.endline
     end
-    if length(g.lens) > 1
-        push!(groups, g)
-    end
+    push!(groups, g)
 
     for g in groups
         align_len = align_to(g)
@@ -238,8 +229,6 @@ function align_conditional!(fst::FST)
     cond_len = align_to(cond_group)
     colon_len = align_to(colon_group)
 
-    # @info "" cond_group colon_group cond_len colon_len
-
     cond_len === nothing && colon_len === nothing && return
 
     if cond_len !== nothing
@@ -265,7 +254,6 @@ function align_conditional!(fst::FST)
     fst.nodes = nodes
     fst.nest_behavior = NeverNest
     fst.indent = fst.line_offset - 1
-    # @info "" fst.indent fst.nest_behavior
 
     return
 end

--- a/src/align.jl
+++ b/src/align.jl
@@ -1,0 +1,81 @@
+function align_fst!(fst::FST, opts::Options)
+    is_leaf(fst) && return
+    for n in fst.nodes
+        if is_leaf(n)
+            continue
+        elseif n.typ === CSTParser.ConditionalOpCall
+            align_conditionalopcall!(n)
+        elseif opts.align_struct_fields && (n.typ === CSTParser.Struct || n.typ === CSTParser.Mutable)
+            align_struct!(n)
+        else
+            align_fst!(n, opts)
+        end
+    end
+end
+
+"""
+    align_struct!(fst::FST)
+
+Aligns struct fields.
+
+#### Example 1
+
+```julia
+struct Foo
+    a::T
+    longfieldname::B
+end
+```
+
+aligns into
+
+```julia
+struct Foo
+    a             :: T
+    longfieldname :: B
+end
+```
+
+#### Example 2
+
+```julia
+Base.@kwdef struct Foo
+    a::T = 10
+    longfieldname::B = false
+end
+```
+
+aligns into
+
+```julia
+Base.@kwdef struct Foo
+    a::T             = 10
+    longfieldname::B = false
+end
+```
+"""
+function align_struct!(fst::FST)
+    idx = findfirst(n -> n.typ === CSTParser.Block, fst.nodes)
+    idx === nothing && return
+    length(fst[idx]) == 0 && return
+
+    # determine the longest field name in the struct
+    max_fname_length = 0
+    for n in fst[idx].nodes
+        if n.typ === CSTParser.BinaryOpCall && length(n[1]) > max_fname_length
+            max_fname_length = length(n[1])
+        end
+    end
+
+    for n in fst[idx].nodes
+        if n.typ === CSTParser.BinaryOpCall
+            diff = max_fname_length - length(n[1]) + 1
+            # insert whitespace before and after operator
+            insert!(n, 2, Whitespace(diff))
+            insert!(n, 4, Whitespace(1))
+        end
+    end
+end
+
+function align_conditionalopcall!(fst::FST)
+end

--- a/src/align.jl
+++ b/src/align.jl
@@ -131,7 +131,7 @@ function align_struct!(fst::FST)
     for (i, n) in enumerate(block_fst.nodes)
         if n.typ === CSTParser.BinaryOpCall
             if n.startline - prev_endline > 1
-                    push!(groups, g)
+                push!(groups, g)
                 g = AlignGroup()
             end
 
@@ -139,7 +139,7 @@ function align_struct!(fst::FST)
             idx = findfirst(x -> x.typ === CSTParser.OPERATOR, n.nodes)
             ws = n[idx].line_offset - (n.line_offset + nlen)
 
-        # @info "" ws nlen n[idx].line_offset n.line_offset
+            # @info "" ws nlen n[idx].line_offset n.line_offset
             push!(g, i, n[idx].line_offset, nlen, ws)
 
             prev_endline = n.endline
@@ -169,11 +169,11 @@ function align_assignments!(fst::FST, assignment_idxs::Vector{Int})
     for i in assignment_idxs
         n = fst[i]
         if n.startline - prev_endline > 1
-                push!(groups, g)
+            push!(groups, g)
             g = AlignGroup()
         end
 
-        binop = n.typ === CSTParser.BinaryOpCall ?  n : n[3]
+        binop = n.typ === CSTParser.BinaryOpCall ? n : n[3]
         nlen = length(binop[1])
 
         ws = binop[3].line_offset - (binop.line_offset + nlen)

--- a/src/align.jl
+++ b/src/align.jl
@@ -236,16 +236,21 @@ function align_conditional!(fst::FST)
 
     cond_group = AlignGroup(cond_lens, cond_src_line_offsets, cond_idxs)
     colon_group = AlignGroup(colon_lens, colon_src_line_offsets, colon_idxs)
+    # @info "" cond_group colon_group
 
-    len = align_to(cond_group)
-    if len !== nothing
+    cond_len = align_to(cond_group)
+    colon_len = align_to(colon_group)
+    if cond_len === nothing && colon_len === nothing
+        return
+    end
+
+    if cond_len !== nothing
         for (i, idx) in enumerate(cond_group.node_idxs)
-            diff = len - cond_group.lens[i] + 1
+            diff = cond_len - cond_group.lens[i] + 1
             nodes[idx-1] = Whitespace(diff)
         end
     end
 
-    len = align_to(colon_group)
     for (i, idx) in enumerate(colon_group.node_idxs)
         # the placeholder would be i+1 if not for a possible inline comment
         nidx = findnext(n -> n.typ === PLACEHOLDER, nodes, idx + 1)
@@ -253,8 +258,8 @@ function align_conditional!(fst::FST)
             nodes[nidx] = Newline(nest_behavior = AlwaysNest)
         end
 
-        if len !== nothing
-            diff = len - colon_group.lens[i] + 1
+        if colon_len !== nothing
+            diff = colon_len - colon_group.lens[i] + 1
             nodes[idx-1] = Whitespace(diff)
         end
     end

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -19,13 +19,6 @@
     MacroBlock,
 )
 
-# @enum(NestBehavior, ALLOW, ALWAYS, NEVER)
-
-# struct Meta
-#     op_kind::Tokens.Kind
-#     is_function::Bool
-# end
-#
 @enum(NestBehavior, AllowNest, AlwaysNest, NeverNest)
 
 """
@@ -74,12 +67,21 @@ end
     fst.nodes[ind] = node
     fst.len += node.len
 end
+@inline Base.getindex(fst::FST, inds...) = fst.nodes[inds...]
+@inline Base.lastindex(fst::FST) = length(fst.nodes)
+@inline Base.firstindex(fst::FST) = 1
+@inline Base.length(fst::FST) = fst.len
+@inline function Base.iterate(fst::FST, state=1)
+    if state > length(fst.nodes)
+        return nothing
+    end
+    return fst.nodes[state], state+1
+end
+
 @inline function Base.insert!(fst::FST, ind::Int, node::FST)
     insert!(fst.nodes, ind, node)
     fst.len += node.len
 end
-@inline Base.getindex(fst::FST, inds...) = fst.nodes[inds...]
-@inline Base.lastindex(fst::FST) = length(fst.nodes)
 
 @inline Newline(; length = 0, nest_behavior = AllowNest) =
     FST(NEWLINE, -1, -1, 0, length, "\n", nothing, nothing, nest_behavior, 0, -1)
@@ -96,11 +98,9 @@ end
 @inline InlineComment(line) =
     FST(INLINECOMMENT, line, line, 0, 0, "", nothing, nothing, AllowNest, 0, -1)
 
-@inline Base.length(fst::FST) = fst.len
-
-must_nest(fst::FST) = fst.nest_behavior === AlwaysNest
-cant_nest(fst::FST) = fst.nest_behavior === NeverNest
-can_nest(fst::FST) = fst.nest_behavior === AllowNest
+@inline must_nest(fst::FST) = fst.nest_behavior === AlwaysNest
+@inline cant_nest(fst::FST) = fst.nest_behavior === NeverNest
+@inline can_nest(fst::FST) = fst.nest_behavior === AllowNest
 
 @inline is_leaf(cst::CSTParser.EXPR) = cst.args === nothing
 @inline is_leaf(fst::FST) = fst.nodes === nothing

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -19,6 +19,11 @@
     MacroBlock,
 )
 
+# struct Meta
+#     op_kind::Tokens.Kind
+#     is_function::Bool
+# end
+
 """
 Formatted Syntax Tree
 """

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -19,7 +19,7 @@
     MacroBlock,
 )
 
-@enum(NestBehavior, AllowNest, AlwaysNest, NeverNest)
+@enum(NestBehavior, AllowNest, AlwaysNest, NeverNest, NeverNestNode)
 
 """
 Formatted Syntax Tree
@@ -350,13 +350,15 @@ function add_node!(t::FST, n::FST, s::State; join_lines = false, max_padding = -
         t.startline = n.startline
         t.endline = n.endline
         t.len += length(n)
+        t.line_offset = n.line_offset
         push!(t.nodes, n)
+        # @info "" t.typ n.typ t.line_offset n.line_offset n.val
         return
     end
 
-    if t.line_offset <= 0
-        t.line_offset = n.line_offset
-    end
+    # if t.line_offset <= 0
+    #     t.line_offset = n.line_offset
+    # end
 
     if !is_prev_newline(t.nodes[end])
         current_line = t.endline

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -64,6 +64,10 @@ FST(typ::CSTParser.Head, indent::Integer) =
     fst.nodes[ind] = node
     fst.len += node.len
 end
+@inline function Base.insert!(fst::FST, ind::Int, node::FST)
+    insert!(fst.nodes, ind, node)
+    fst.len += node.len
+end
 @inline Base.getindex(fst::FST, inds...) = fst.nodes[inds...]
 @inline Base.lastindex(fst::FST) = length(fst.nodes)
 
@@ -532,7 +536,12 @@ function op_kind(cst::CSTParser.EXPR)::Union{Nothing,Tokens.Kind}
     return nothing
 end
 op_kind(::Nothing) = nothing
-op_kind(fst::FST) = fst.ref === nothing ? nothing : op_kind(fst.ref[])
+function op_kind(fst::FST)::Union{Nothing,Tokens.Kind}
+    fst.ref === nothing ? nothing : op_kind(fst.ref[])
+end
+
+get_op(fst::FST) = findfirst(n -> n.typ === CSTParser.OPERATOR, fst.nodes)
+get_op(cst::CSTParser.EXPR) = cst[2]
 
 is_lazy_op(kind) = kind === Tokens.LAZY_AND || kind === Tokens.LAZY_OR
 

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -540,18 +540,20 @@ function is_gen(x::Union{CSTParser.EXPR,FST})
     return false
 end
 
-function is_assignment(x::Union{CSTParser.EXPR,FST})
+function is_assignment(x::Union{FST,CSTParser.EXPR})
     if x.typ === CSTParser.BinaryOpCall && is_assignment(op_kind(x))
         return true
     end
+
     if (
         x.typ === CSTParser.Const ||
         x.typ === CSTParser.Local ||
         x.typ === CSTParser.Global ||
         x.typ === CSTParser.Outer
-    ) && is_assignment(x[3])
+    ) && is_assignment(x[end])
         return true
     end
+
     return false
 end
 is_assignment(kind::Tokens.Kind) = CSTParser.precedence(kind) == CSTParser.AssignmentOp

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -25,8 +25,6 @@
 # end
 #
 @enum(NestBehavior, AllowNest, AlwaysNest, NeverNest)
-# can_nest(nb::NestBehavior) = nb === AllowNest || nb === AlwaysNest
-
 
 """
 Formatted Syntax Tree
@@ -38,8 +36,8 @@ mutable struct FST
     # in the original source file.
     startline::Int
     endline::Int
-    indent::Int
 
+    indent::Int
     len::Int
     val::Union{Nothing,AbstractString}
     nodes::Union{Nothing,Vector{FST}}

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -54,12 +54,48 @@ FST(cst::CSTParser.EXPR, indent::Int) =
 FST(typ::CSTParser.Head, indent::Int) =
     FST(typ, -1, -1, indent, 0, nothing, FST[], nothing, AllowNest, 0, -1)
 
-function FST(cst::CSTParser.EXPR, line_offset::Int, startline::Int, endline::Int, val::AbstractString)
-    FST(cst.typ, startline, endline, 0, length(val), val, nothing, Ref(cst), AllowNest, 0, line_offset)
+function FST(
+    cst::CSTParser.EXPR,
+    line_offset::Int,
+    startline::Int,
+    endline::Int,
+    val::AbstractString,
+)
+    FST(
+        cst.typ,
+        startline,
+        endline,
+        0,
+        length(val),
+        val,
+        nothing,
+        Ref(cst),
+        AllowNest,
+        0,
+        line_offset,
+    )
 end
 
-function FST(typ::CSTParser.Head, line_offset::Int, startline::Int, endline::Int, val::AbstractString)
-    FST(typ, startline, endline, 0, length(val), val, nothing, nothing, AllowNest, 0, line_offset)
+function FST(
+    typ::CSTParser.Head,
+    line_offset::Int,
+    startline::Int,
+    endline::Int,
+    val::AbstractString,
+)
+    FST(
+        typ,
+        startline,
+        endline,
+        0,
+        length(val),
+        val,
+        nothing,
+        nothing,
+        AllowNest,
+        0,
+        line_offset,
+    )
 end
 
 @inline function Base.setindex!(fst::FST, node::FST, ind::Int)
@@ -71,11 +107,11 @@ end
 @inline Base.lastindex(fst::FST) = length(fst.nodes)
 @inline Base.firstindex(fst::FST) = 1
 @inline Base.length(fst::FST) = fst.len
-@inline function Base.iterate(fst::FST, state=1)
+@inline function Base.iterate(fst::FST, state = 1)
     if state > length(fst.nodes)
         return nothing
     end
-    return fst.nodes[state], state+1
+    return fst.nodes[state], state + 1
 end
 
 @inline function Base.insert!(fst::FST, ind::Int, node::FST)
@@ -86,13 +122,16 @@ end
 @inline Newline(; length = 0, nest_behavior = AllowNest) =
     FST(NEWLINE, -1, -1, 0, length, "\n", nothing, nothing, nest_behavior, 0, -1)
 @inline Semicolon() = FST(SEMICOLON, -1, -1, 0, 1, ";", nothing, nothing, AllowNest, 0, -1)
-@inline TrailingComma() = FST(TRAILINGCOMMA, -1, -1, 0, 0, "", nothing, nothing, AllowNest, 0, -1)
+@inline TrailingComma() =
+    FST(TRAILINGCOMMA, -1, -1, 0, 0, "", nothing, nothing, AllowNest, 0, -1)
 @inline TrailingSemicolon() =
     FST(TRAILINGSEMICOLON, -1, -1, 0, 0, "", nothing, nothing, AllowNest, 0, -1)
 @inline InverseTrailingSemicolon() =
     FST(INVERSETRAILINGSEMICOLON, -1, -1, 0, 1, ";", nothing, nothing, AllowNest, 0, -1)
-@inline Whitespace(n) = FST(WHITESPACE, -1, -1, 0, n, " "^n, nothing, nothing, AllowNest, 0, -1)
-@inline Placeholder(n) = FST(PLACEHOLDER, -1, -1, 0, n, " "^n, nothing, nothing, AllowNest, 0, -1)
+@inline Whitespace(n) =
+    FST(WHITESPACE, -1, -1, 0, n, " "^n, nothing, nothing, AllowNest, 0, -1)
+@inline Placeholder(n) =
+    FST(PLACEHOLDER, -1, -1, 0, n, " "^n, nothing, nothing, AllowNest, 0, -1)
 @inline Notcode(startline, endline) =
     FST(NOTCODE, startline, endline, 0, 0, "", nothing, nothing, AllowNest, 0, -1)
 @inline InlineComment(line) =

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -541,11 +541,12 @@ function is_assignment(x::Union{CSTParser.EXPR,FST})
     if x.typ === CSTParser.BinaryOpCall && is_assignment(op_kind(x))
         return true
     end
-    if (x.typ === CSTParser.Const ||
-    x.typ === CSTParser.Local  ||
-    x.typ === CSTParser.Global ||
-    x.typ === CSTParser.Outer
-       ) && is_assignment(x[3])
+    if (
+        x.typ === CSTParser.Const ||
+        x.typ === CSTParser.Local ||
+        x.typ === CSTParser.Global ||
+        x.typ === CSTParser.Outer
+    ) && is_assignment(x[3])
         return true
     end
     return false

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -537,6 +537,22 @@ function is_gen(x::Union{CSTParser.EXPR,FST})
     return false
 end
 
+function is_assignment(x::Union{CSTParser.EXPR,FST})
+    if x.typ === CSTParser.BinaryOpCall && is_assignment(op_kind(x))
+        return true
+    end
+    if (x.typ === CSTParser.Const ||
+    x.typ === CSTParser.Local  ||
+    x.typ === CSTParser.Global ||
+    x.typ === CSTParser.Outer
+       ) && is_assignment(x[3])
+        return true
+    end
+    return false
+end
+is_assignment(kind::Tokens.Kind) = CSTParser.precedence(kind) == 1
+is_assignment(::Nothing) = false
+
 function nest_block(cst::CSTParser.EXPR)
     cst.typ === CSTParser.If && return true
     cst.typ === CSTParser.Do && return true

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -252,7 +252,8 @@ end
 function add_node!(t::FST, n::FST, s::State; join_lines = false, max_padding = -1)
     if n.typ === SEMICOLON
         join_lines = true
-        loc = s.offset > length(s.doc.text) && t.typ === CSTParser.TopLevel ?
+        loc =
+            s.offset > length(s.doc.text) && t.typ === CSTParser.TopLevel ?
             cursor_loc(s, s.offset - 1) : cursor_loc(s)
         for l = t.endline:loc[1]
             if has_semicolon(s.doc, l)

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -156,6 +156,10 @@ end
     (cst.typ === CSTParser.BinaryOpCall && cst[2].kind === Tokens.COLON) ||
     cst.typ === CSTParser.ColonOpCall
 
+@inline is_colon_op(fst::FST) =
+    (fst.typ === CSTParser.BinaryOpCall && op_kind(fst) === Tokens.COLON) ||
+    fst.typ === CSTParser.ColonOpCall
+
 @inline function is_number(cst::CSTParser.EXPR)
     cst.typ === CSTParser.LITERAL || return false
     return cst.kind === Tokens.INTEGER || cst.kind === Tokens.FLOAT

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -554,7 +554,7 @@ function is_assignment(x::Union{CSTParser.EXPR,FST})
     end
     return false
 end
-is_assignment(kind::Tokens.Kind) = CSTParser.precedence(kind) == 1
+is_assignment(kind::Tokens.Kind) = CSTParser.precedence(kind) == CSTParser.AssignmentOp
 is_assignment(::Nothing) = false
 
 function nest_block(cst::CSTParser.EXPR)
@@ -576,7 +576,7 @@ function remove_empty_notcode(fst::FST)
     return false
 end
 
-nest_assignment(cst::CSTParser.EXPR) = CSTParser.precedence(cst[2].kind) == 1
+nest_assignment(cst::CSTParser.EXPR) = is_assignment(cst[2].kind)
 
 function unnestable_arg(cst::CSTParser.EXPR)
     is_iterable(cst) && return true

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -98,6 +98,10 @@ end
 
 @inline Base.length(fst::FST) = fst.len
 
+must_nest(fst::FST) = fst.nest_behavior === AlwaysNest
+cant_nest(fst::FST) = fst.nest_behavior === NeverNest
+can_nest(fst::FST) = fst.nest_behavior === AllowNest
+
 @inline is_leaf(cst::CSTParser.EXPR) = cst.args === nothing
 @inline is_leaf(fst::FST) = fst.nodes === nothing
 

--- a/src/options.jl
+++ b/src/options.jl
@@ -12,4 +12,5 @@ Base.@kwdef struct Options
     whitespace_in_kwargs::Bool = true
     annotate_untyped_fields_with_any::Bool = true
     format_docstrings::Bool = false
+    align_struct_fields::Bool = false
 end

--- a/src/options.jl
+++ b/src/options.jl
@@ -12,5 +12,8 @@ Base.@kwdef struct Options
     whitespace_in_kwargs::Bool = true
     annotate_untyped_fields_with_any::Bool = true
     format_docstrings::Bool = false
-    align_struct_fields::Bool = false
+    align_struct_field::Bool = false
+    align_const::Bool = false
+    align_short_function_def::Bool = false
+    align_conditional::Bool = false
 end

--- a/src/options.jl
+++ b/src/options.jl
@@ -15,4 +15,5 @@ Base.@kwdef struct Options
     align_struct_field::Bool = false
     align_assignment::Bool = false
     align_conditional::Bool = false
+    align_pair_arrow::Bool = false
 end

--- a/src/options.jl
+++ b/src/options.jl
@@ -13,7 +13,6 @@ Base.@kwdef struct Options
     annotate_untyped_fields_with_any::Bool = true
     format_docstrings::Bool = false
     align_struct_field::Bool = false
-    align_const::Bool = false
-    align_short_function_def::Bool = false
+    align_assignment::Bool = false
     align_conditional::Bool = false
 end

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -76,10 +76,8 @@ function flatten_fst!(fst::FST)
             else
                 flatten_fst!(n)
             end
-        elseif n.typ === CSTParser.ConditionalOpCall
-            @info "" length(n)
-            n.nodes = flatten_conditionalopcall(n)
-            @info "" length(n)
+        # elseif n.typ === CSTParser.ConditionalOpCall
+        #     n.nodes = flatten_conditionalopcall(n)
         else
             flatten_fst!(n)
         end

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -76,8 +76,8 @@ function flatten_fst!(fst::FST)
             else
                 flatten_fst!(n)
             end
-        elseif n.typ === CSTParser.ConditionalOpCall
-            n.nodes = flatten_conditionalopcall(n)
+        # elseif n.typ === CSTParser.ConditionalOpCall
+        #     n.nodes = flatten_conditionalopcall(n)
         else
             flatten_fst!(n)
         end

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -76,8 +76,8 @@ function flatten_fst!(fst::FST)
             else
                 flatten_fst!(n)
             end
-            # elseif n.typ === CSTParser.ConditionalOpCall
-            #     n.nodes = flatten_conditionalopcall(n)
+        elseif n.typ === CSTParser.ConditionalOpCall
+            n.nodes = flatten_conditionalopcall(n)
         else
             flatten_fst!(n)
         end

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -76,8 +76,8 @@ function flatten_fst!(fst::FST)
             else
                 flatten_fst!(n)
             end
-        # elseif n.typ === CSTParser.ConditionalOpCall
-        #     n.nodes = flatten_conditionalopcall(n)
+            # elseif n.typ === CSTParser.ConditionalOpCall
+            #     n.nodes = flatten_conditionalopcall(n)
         else
             flatten_fst!(n)
         end

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -49,6 +49,19 @@ function flatten_binaryopcall(fst::FST; top = true)
     return nodes
 end
 
+function flatten_conditionalopcall(fst::FST)
+    nodes = FST[]
+    for n in fst.nodes
+        if n.typ === CSTParser.ConditionalOpCall
+            push!(nodes, flatten_conditionalopcall(n)...)
+        else
+            flatten_fst!(n)
+            push!(nodes, n)
+        end
+    end
+    return nodes
+end
+
 function flatten_fst!(fst::FST)
     is_leaf(fst) && return
     for n in fst.nodes
@@ -63,6 +76,10 @@ function flatten_fst!(fst::FST)
             else
                 flatten_fst!(n)
             end
+        elseif n.typ === CSTParser.ConditionalOpCall
+            @info "" length(n)
+            n.nodes = flatten_conditionalopcall(n)
+            @info "" length(n)
         else
             flatten_fst!(n)
         end

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -114,12 +114,12 @@ function pipe_to_function_call(fst::FST)
     nodes = FST[]
     arg2 = fst[end]
     push!(nodes, arg2)
-    paren = FST(CSTParser.PUNCTUATION, arg2.endline, arg2.endline, "(")
+    paren = FST(CSTParser.PUNCTUATION, -1, arg2.endline, arg2.endline, "(")
     push!(nodes, paren)
     pipe_to_function_call_pass!(fst[1])
     arg1 = fst[1]
     push!(nodes, arg1)
-    paren = FST(CSTParser.PUNCTUATION, arg1.endline, arg1.endline, ")")
+    paren = FST(CSTParser.PUNCTUATION, -1, arg1.endline, arg1.endline, ")")
     push!(nodes, paren)
     return nodes
 end
@@ -139,7 +139,7 @@ function import_to_usings(fst::FST, s::State)
         use.startline = sl
         use.endline = el
 
-        add_node!(use, FST(CSTParser.KEYWORD, sl, el, "using"), s)
+        add_node!(use, FST(CSTParser.KEYWORD, -1, sl, el, "using"), s)
         add_node!(use, Whitespace(1), s)
 
         # collect the dots prior to a identifier
@@ -150,10 +150,10 @@ function import_to_usings(fst::FST, s::State)
             j -= 1
         end
 
-        add_node!(use, FST(CSTParser.IDENTIFIER, sl, el, name), s, join_lines = true)
-        add_node!(use, FST(CSTParser.OPERATOR, sl, el, ":"), s, join_lines = true)
+        add_node!(use, FST(CSTParser.IDENTIFIER, -1, sl, el, name), s, join_lines = true)
+        add_node!(use, FST(CSTParser.OPERATOR, -1, sl, el, ":"), s, join_lines = true)
         add_node!(use, Whitespace(1), s)
-        add_node!(use, FST(CSTParser.IDENTIFIER, sl, el, name), s, join_lines = true)
+        add_node!(use, FST(CSTParser.IDENTIFIER, -1, sl, el, name), s, join_lines = true)
 
         push!(usings, use)
     end
@@ -174,15 +174,17 @@ function annotate_typefields_with_any!(fst::FST, s::State)
             nn.startline = n.startline
             nn.endline = n.endline
             add_node!(nn, n, s)
+            line_offset = n.line_offset + length(n)
             add_node!(
                 nn,
-                FST(CSTParser.OPERATOR, n.startline, n.endline, "::"),
+                FST(CSTParser.OPERATOR, line_offset, n.startline, n.endline, "::"),
                 s,
                 join_lines = true,
             )
+            line_offset += 2
             add_node!(
                 nn,
-                FST(CSTParser.IDENTIFIER, n.startline, n.endline, "Any"),
+                FST(CSTParser.IDENTIFIER, line_offset, n.startline, n.endline, "Any"),
                 s,
                 join_lines = true,
             )
@@ -225,7 +227,7 @@ function short_to_long_function_def!(fst::FST, s::State)
     funcdef = FST(CSTParser.FunctionDef, fst.indent)
     if fst[1].typ === CSTParser.Call || fst[1].typ === CSTParser.WhereOpCall
         # function
-        kw = FST(CSTParser.KEYWORD, fst[1].startline, fst[1].endline, "function")
+        kw = FST(CSTParser.KEYWORD, -1, fst[1].startline, fst[1].endline, "function")
         add_node!(funcdef, kw, s)
         add_node!(funcdef, Whitespace(1), s)
 
@@ -240,7 +242,7 @@ function short_to_long_function_def!(fst::FST, s::State)
         add_indent!(funcdef[end], s, s.opts.indent_size)
 
         # end
-        kw = FST(CSTParser.KEYWORD, fst[end].startline, fst[end].endline, "end")
+        kw = FST(CSTParser.KEYWORD, -1, fst[end].startline, fst[end].endline, "end")
         add_node!(funcdef, kw, s)
 
         fst.typ = funcdef.typ
@@ -249,7 +251,7 @@ function short_to_long_function_def!(fst::FST, s::State)
     elseif fst[1].typ === CSTParser.BinaryOpCall &&
            fst[1][end].typ === CSTParser.WhereOpCall
         # function
-        kw = FST(CSTParser.KEYWORD, fst[1].startline, fst[1].endline, "function")
+        kw = FST(CSTParser.KEYWORD, -1, fst[1].startline, fst[1].endline, "function")
         add_node!(funcdef, kw, s)
         add_node!(funcdef, Whitespace(1), s)
 
@@ -257,7 +259,7 @@ function short_to_long_function_def!(fst::FST, s::State)
         add_node!(funcdef, fst[1][1], s, join_lines = true)
 
         whereop = fst[1][end]
-        decl = FST(CSTParser.OPERATOR, fst[1].startline, fst[1].endline, "::")
+        decl = FST(CSTParser.OPERATOR, -1, fst[1].startline, fst[1].endline, "::")
 
         # ::R where T
         add_node!(funcdef, decl, s, join_lines = true)
@@ -269,7 +271,7 @@ function short_to_long_function_def!(fst::FST, s::State)
         add_indent!(funcdef[end], s, s.opts.indent_size)
 
         # end
-        kw = FST(CSTParser.KEYWORD, fst[end].startline, fst[end].endline, "end")
+        kw = FST(CSTParser.KEYWORD, -1, fst[end].startline, fst[end].endline, "end")
         add_node!(funcdef, kw, s)
 
         fst.typ = funcdef.typ
@@ -375,7 +377,7 @@ function prepend_return!(fst::FST, s::State)
     ln.typ === MacroBlock && return
 
     ret = FST(CSTParser.Return, fst.indent)
-    kw = FST(CSTParser.KEYWORD, ln.startline, ln.endline, "return")
+    kw = FST(CSTParser.KEYWORD, -1, fst[end].startline, fst[end].endline, "return")
     add_node!(ret, kw, s)
     add_node!(ret, Whitespace(1), s)
     add_node!(ret, ln, s, join_lines = true)
@@ -428,7 +430,7 @@ function move_at_sign_to_the_end(fst::FST, s::State)
         elseif n.typ === CSTParser.Quotenode
             add_node!(macroname, n, s, join_lines = true)
         else
-            at = FST(CSTParser.PUNCTUATION, n.startline, n.endline, "@")
+            at = FST(CSTParser.PUNCTUATION, -1, n.startline, n.endline, "@")
             add_node!(macroname, at, s, join_lines = true)
             add_node!(macroname, n, s, join_lines = true)
         end

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -55,7 +55,6 @@ function flatten_conditionalopcall(fst::FST)
         if n.typ === CSTParser.ConditionalOpCall
             push!(nodes, flatten_conditionalopcall(n)...)
         else
-            flatten_fst!(n)
             push!(nodes, n)
         end
     end
@@ -76,8 +75,6 @@ function flatten_fst!(fst::FST)
             else
                 flatten_fst!(n)
             end
-            # elseif n.typ === CSTParser.ConditionalOpCall
-            #     n.nodes = flatten_conditionalopcall(n)
         else
             flatten_fst!(n)
         end

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -94,14 +94,17 @@ function dedent!(fst::FST, s::State)
             fst.indent -= s.opts.indent_size
         end
         return
+    elseif fst.typ === CSTParser.StringH 
+        return
+    elseif fst.typ === CSTParser.ConditionalOpCall && !cant_nest(fst)
+        return
     end
-    fst.typ === CSTParser.StringH && return
-    fst.typ === CSTParser.ConditionalOpCall && return
 
     # dedent
     fst.indent -= s.opts.indent_size
 
-    must_nest(fst) && return
+    # only unnest if it's allowed
+    can_nest(fst) || return
 
     nl_inds = findall(n -> n.typ === NEWLINE && can_nest(n), fst.nodes)
     length(nl_inds) > 0 || return

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -646,7 +646,6 @@ function n_conditionalopcall!(ds::DefaultStyle, fst::FST, s::State)
                 else
                     width += sum(length.(fst[i+1:i+3]))
                 end
-                # @debug "" s.line_offset l  s.opts.max_margin
                 if width <= s.opts.max_margin
                     fst[i] = Whitespace(1)
                 else

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -96,7 +96,7 @@ function dedent!(fst::FST, s::State)
         return
     end
     fst.typ === CSTParser.StringH && return
-    # fst.typ === CSTParser.ConditionalOpCall && return
+    fst.typ === CSTParser.ConditionalOpCall && return
 
     # dedent
     fst.indent -= s.opts.indent_size

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -672,11 +672,11 @@ end
 n_conditionalopcall!(style::S, fst::FST, s::State) where {S<:AbstractStyle} =
     n_conditionalopcall!(DefaultStyle(style), fst, s)
 
-function no_unnest(fst::FST) 
+function no_unnest(fst::FST)
     if fst.typ === CSTParser.BinaryOpCall ||
-        fst.typ === CSTParser.ConditionalOpCall  ||
-               fst.typ === CSTParser.ChainOpCall ||
-               fst.typ === CSTParser.Comparison
+       fst.typ === CSTParser.ConditionalOpCall ||
+       fst.typ === CSTParser.ChainOpCall ||
+       fst.typ === CSTParser.Comparison
         return contains_comment(fst)
     end
     return false

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -95,8 +95,8 @@ function dedent!(fst::FST, s::State)
         end
         return
     end
-    fst.typ === CSTParser.ConditionalOpCall && return
     fst.typ === CSTParser.StringH && return
+    # fst.typ === CSTParser.ConditionalOpCall && return
 
     # dedent
     fst.indent -= s.opts.indent_size

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -94,7 +94,7 @@ function dedent!(fst::FST, s::State)
             fst.indent -= s.opts.indent_size
         end
         return
-    elseif fst.typ === CSTParser.StringH 
+    elseif fst.typ === CSTParser.StringH
         return
     elseif fst.typ === CSTParser.ConditionalOpCall && !cant_nest(fst)
         return
@@ -572,7 +572,8 @@ function n_whereopcall!(ds::DefaultStyle, fst::FST, s::State)
             fst[end].indent = fst.indent
         end
 
-        over = (s.line_offset + Blen + fst.extra_margin > s.opts.max_margin) || must_nest(fst)
+        over =
+            (s.line_offset + Blen + fst.extra_margin > s.opts.max_margin) || must_nest(fst)
         fst.indent += s.opts.indent_size
         for (i, n) in enumerate(fst[2:end])
             if n.typ === NEWLINE
@@ -681,7 +682,7 @@ function n_binaryopcall!(ds::DefaultStyle, fst::FST, s::State)
     rhs = fst[end]
     rhs.typ === CSTParser.Block && (rhs = rhs[1])
     if length(idxs) == 2 &&
-        (line_margin > s.opts.max_margin || must_nest(fst) || must_nest(rhs))
+       (line_margin > s.opts.max_margin || must_nest(fst) || must_nest(rhs))
         line_offset = s.line_offset
         i1 = idxs[1]
         i2 = idxs[2]

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -178,7 +178,8 @@ p_operator(style::S, cst::CSTParser.EXPR, s::State) where {S<:AbstractStyle} =
 
 @inline function p_keyword(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
     loc = cursor_loc(s)
-    val = cst.kind === Tokens.ABSTRACT ? "abstract" :
+    val =
+        cst.kind === Tokens.ABSTRACT ? "abstract" :
         cst.kind === Tokens.BAREMODULE ? "baremodule" :
         cst.kind === Tokens.BEGIN ? "begin" :
         cst.kind === Tokens.BREAK ? "break" :
@@ -218,7 +219,8 @@ p_keyword(style::S, cst::CSTParser.EXPR, s::State) where {S<:AbstractStyle} =
 
 @inline function p_punctuation(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
     loc = cursor_loc(s)
-    val = cst.kind === Tokens.LPAREN ? "(" :
+    val =
+        cst.kind === Tokens.LPAREN ? "(" :
         cst.kind === Tokens.LBRACE ? "{" :
         cst.kind === Tokens.LSQUARE ? "[" :
         cst.kind === Tokens.RPAREN ? ")" :
@@ -631,7 +633,8 @@ function p_block(
 )
     style = getstyle(ds)
     t = FST(cst, nspaces(s))
-    single_line = ignore_single_line ? false :
+    single_line =
+        ignore_single_line ? false :
         cursor_loc(s)[1] == cursor_loc(s, s.offset + cst.span - 1)[1]
 
     for (i, a) in enumerate(cst)

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -429,7 +429,19 @@ end
         end
     end
 
-    t = FST(CSTParser.StringH, -1, -1, loc[2] - 1, 0, nothing, FST[], Ref(cst), AllowNest, 0, loc[2])
+    t = FST(
+        CSTParser.StringH,
+        -1,
+        -1,
+        loc[2] - 1,
+        0,
+        nothing,
+        FST[],
+        Ref(cst),
+        AllowNest,
+        0,
+        loc[2],
+    )
     for (i, l) in enumerate(lines)
         ln = startline + i - 1
         l = i == 1 ? l : l[sidx:end]

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -408,7 +408,6 @@ end
     end
 
     startline, endline, str = str_info
-    # @debug "" loc startline endline str
 
     if from_docstring && s.opts.format_docstrings
         str = format_docstring(ds, s, str)
@@ -429,8 +428,6 @@ end
             sidx = min(sidx, fc)
         end
     end
-
-    # @debug "" lines cst.val loc loc[2] sidx
 
     t = FST(CSTParser.StringH, -1, -1, loc[2] - 1, 0, nothing, FST[], Ref(cst), false, 0)
     for (i, l) in enumerate(lines)
@@ -485,8 +482,6 @@ function p_stringh(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
             sidx = min(sidx, fc)
         end
     end
-
-    # @debug "" lines cst.val loc loc[2] sidx
 
     t = FST(cst, loc[2] - 1)
     for (i, l) in enumerate(lines)

--- a/src/styles/yas/nest.jl
+++ b/src/styles/yas/nest.jl
@@ -146,12 +146,6 @@ function n_binaryopcall!(ys::YASStyle, fst::FST, s::State)
         return
     end
 
-    # line_offset = s.line_offset
-    walk(reset_line_offset!, fst.nodes[1:end-1], s, fst.indent)
+    walk(increment_line_offset!, fst.nodes[1:end-1], s, fst.indent)
     nest!(ys, fst[end], s)
-    # s.line_offset = line_offset
-    # nest!(ys, fst[1], s)
-    # s.line_offset = line_offset
-    # walk(reset_line_offset!, fst, s)
-
 end

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -240,7 +240,8 @@ function p_whereopcall(ys::YASStyle, cst::CSTParser.EXPR, s::State)
     end
 
     for (i, a) in enumerate(cst.args[3:end])
-        n = a.typ === CSTParser.BinaryOpCall ? pretty(ys, a, s, nospace = true) :
+        n =
+            a.typ === CSTParser.BinaryOpCall ? pretty(ys, a, s, nospace = true) :
             pretty(ys, a, s)
 
         if CSTParser.is_comma(a) && i + 2 == length(cst) - 1

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -166,10 +166,8 @@ end
 function p_comprehension(ys::YASStyle, cst::CSTParser.EXPR, s::State)
     t = FST(cst, nspaces(s))
 
-    if is_block(cst[2])
-        t.force_nest = true
-    elseif cst[2].typ === CSTParser.Generator && is_block(cst[2][1])
-        t.force_nest = true
+    if is_block(cst[2]) || (cst[2].typ === CSTParser.Generator && is_block(cst[2][1]))
+        t.nest_behavior = AlwaysNest
     end
 
     add_node!(t, pretty(ys, cst[1], s), s, join_lines = true)
@@ -181,10 +179,8 @@ end
 function p_typedcomprehension(ys::YASStyle, cst::CSTParser.EXPR, s::State)
     t = FST(cst, nspaces(s))
 
-    if is_block(cst[3])
-        t.force_nest = true
-    elseif cst[3].typ === CSTParser.Generator && is_block(cst[3][1])
-        t.force_nest = true
+    if is_block(cst[3]) || (cst[3].typ === CSTParser.Generator && is_block(cst[3][1]))
+        t.nest_behavior = AlwaysNest
     end
 
     add_node!(t, pretty(ys, cst[1], s), s, join_lines = true)

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -234,8 +234,10 @@ function p_whereopcall(ys::YASStyle, cst::CSTParser.EXPR, s::State)
         cst[3].typ !== CSTParser.Curly &&
         cst[3].typ !== CSTParser.BracesCat
 
-    brace = FST(CSTParser.PUNCTUATION, t.endline, t.endline, "{")
-    add_braces && add_node!(t, brace, s, join_lines = true)
+    if add_braces
+        brace = FST(CSTParser.PUNCTUATION, -1, t.endline, t.endline, "{")
+        add_node!(t, brace, s, join_lines = true)
+    end
 
     for (i, a) in enumerate(cst.args[3:end])
         n = a.typ === CSTParser.BinaryOpCall ? pretty(ys, a, s, nospace = true) :
@@ -251,8 +253,10 @@ function p_whereopcall(ys::YASStyle, cst::CSTParser.EXPR, s::State)
         end
     end
 
-    brace = FST(CSTParser.PUNCTUATION, t.endline, t.endline, "}")
-    add_braces && add_node!(t, brace, s, join_lines = true)
+    if add_braces
+        brace = FST(CSTParser.PUNCTUATION, -1, t.endline, t.endline, "}")
+        add_node!(t, brace, s, join_lines = true)
+    end
     t
 end
 
@@ -260,8 +264,6 @@ function p_generator(ys::YASStyle, cst::CSTParser.EXPR, s::State)
     t = FST(cst, nspaces(s))
 
     for (i, a) in enumerate(cst)
-        # n = a.typ === CSTParser.BinaryOpCall ? pretty(ys, a, s, nonest = true) :
-        #     pretty(ys, a, s)
         n = pretty(ys, a, s)
         if a.typ === CSTParser.KEYWORD
             incomp = parent_is(

--- a/test/config.jl
+++ b/test/config.jl
@@ -1,4 +1,4 @@
-@testset "configuration" begin
+@testset ".JuliaFormatter.toml config" begin
     config2 = "indent = 2"
     config4 = "indent = 4"
     before = "begin rand() end\n"

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -584,7 +584,7 @@
         str = """
         a, b =
             cond ? e1 : e2"""
-        @test fmt(str_, 4, length(str_)- 1) == str
+        @test fmt(str_, 4, length(str_) - 1) == str
         @test fmt(str_, 4, 18) == str
 
         str = """

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -237,15 +237,15 @@
         end"""
         @test fmt(str_) == str
 
-        str = """
-        for i = 1:30, j = 100:-2:1
-            println(i, j)
-        end"""
         str_ = """
         for i = 1:30, j in 100:-2:1
             println(i, j)
         end"""
-        @test fmt(str) == str
+        str = """
+        for i = 1:30, j = 100:-2:1
+            println(i, j)
+        end"""
+        @test fmt(str_) == str
 
         str_ = "[(i,j) for i=I1,j=I2]"
         str = "[(i, j) for i in I1, j in I2]"
@@ -4208,6 +4208,38 @@ some_function(
         return arg1 ||
                arg2"""
         @test fmt(str_, 4, 1) == str
+    end
+
+    @testset "source file line offset with unicode" begin
+        # These just check to see formatting runs without error
+
+        str = """
+        a = 10
+        # └─ code.jl (before -> after2)
+        v = "test_basic_config"
+        """
+        @test fmt(str) == str
+
+        str = """
+        a = 10
+        unicode_str = "α10′"
+        v = "test_basic_config"
+        """
+        @test fmt(str) == str
+
+        str = """
+        a = 10
+        unicode_op = 5 ⪅ 10.0
+        v = "test_basic_config"
+        """
+        @test fmt(str) == str
+
+        str = """
+        a = 10
+        unicode_identifier′ = 10
+        v = "test_basic_config"
+        """
+        @test fmt(str) == str
     end
 
 end

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -580,16 +580,33 @@
         @test fmt(str_, 2, 1) == str
 
         str_ = """a, b = cond ? e1 : e2"""
+
         str = """
-        a, b = cond ?
-            e1 : e2"""
-        @test fmt(str_, 4, 13) == str
+        a, b =
+            cond ? e1 : e2"""
+        @test fmt(str_, 4, length(str_)- 1) == str
+        @test fmt(str_, 4, 18) == str
+
+        str = """
+        a, b =
+            cond ? e1 :
+            e2"""
+        @test fmt(str_, 4, 17) == str
+        @test fmt(str_, 4, 15) == str
 
         str = """
         a, b =
             cond ?
             e1 : e2"""
-        @test fmt(str_, 4, 12) == str
+        @test fmt(str_, 4, 14) == str
+        @test fmt(str_, 4, 11) == str
+
+        str = """
+        a, b =
+            cond ?
+            e1 :
+            e2"""
+        @test fmt(str_, 4, 10) == str
 
         str = """
         begin
@@ -623,10 +640,12 @@
 
         str = """
         begin
-            variable_name = conditional ?
+            variable_name =
+                conditional ?
                 expression1 : expression2
         end"""
         @test fmt(str, 4, 34) == str
+        @test fmt(str, 4, 33) == str
 
         str = """
         begin
@@ -1694,35 +1713,44 @@
         C"""
         @test fmt(str) == str
 
-        str = """
-        foo() = A ?
-            # comment 1
-
-            B : C"""
-        @test fmt(str) == str
         str_ = """
-        foo() =
-           A ?
-           # comment 1
-
-           B :
-           C"""
-        @test fmt(str, 3, 1) == str_
-
-        str = """
         foo = A ?
             # comment 1
 
             B : C"""
-        @test fmt(str) == str
-        str_ = """
+
+        str = """
+        foo =
+            A ?
+            # comment 1
+
+            B : C"""
+        @test fmt(str_) == str
+
+        str = """
         foo =
            A ?
            # comment 1
 
            B :
            C"""
-        @test fmt(str, 3, 1) == str_
+        @test fmt(str_, 3, 1) == str
+
+        str_ = """
+        foo = A +
+            # comment 1
+
+            B + C"""
+
+        str = """
+        foo =
+           A +
+           # comment 1
+
+           B +
+           C"""
+        @test fmt(str_, 3, 100) == str
+        @test fmt(str_, 3, 1) == str
 
         str = """
         begin

--- a/test/files/Docs.jl
+++ b/test/files/Docs.jl
@@ -557,7 +557,8 @@ function docm(source::LineNumberNode, mod::Module, meta, ex, define::Bool = true
     #   "..."
     #   kw"if", kw"else"
     #
-    doc = isa(x, Base.BaseDocs.Keyword) ? keyworddoc(source, mod, meta, x) :
+    doc =
+        isa(x, Base.BaseDocs.Keyword) ? keyworddoc(source, mod, meta, x) :
 
         # Method / macro definitions and "call" syntax.
         #

--- a/test/files/adjoint.jl
+++ b/test/files/adjoint.jl
@@ -27,7 +27,8 @@ function gradm(ex, mut = false)
     ) || error("Need a function definition")
     kw = length(args) > 1 && isexpr(args[1], :parameters) ? esc(popfirst!(args)) : nothing
     isclosure = isexpr(name, :(::)) && length(name.args) > 1
-    f, T = isexpr(name, :(::)) ?
+    f, T =
+        isexpr(name, :(::)) ?
         (length(name.args) == 1 ? (esc(gensym()), esc(name.args[1])) : esc.(name.args)) :
         (esc(gensym()), :(Core.Typeof($(esc(name)))))
     kT = :(Core.kwftype($T))

--- a/test/files/reverse.jl
+++ b/test/files/reverse.jl
@@ -259,7 +259,8 @@ function adjointcfg(pr::Primal)
         preds = predecessors(b)
         rb = block(ir, b.id)
         for i = 1:length(preds)
-            cond = i == length(preds) ? nothing :
+            cond =
+                i == length(preds) ? nothing :
                 push!(rb, xcall(Base, :(!==), alpha(pr.branches[b.id]), BranchNumber(i)))
             branch!(rb, preds[i].id, unless = cond)
         end
@@ -337,7 +338,7 @@ function adjoint(pr::Primal)
             Δ = push!(
                 rb,
                 pr.varargs == nothing ? xcall(Zygote, :tuple, gs...) :
-                    xcall(Zygote, :tuple_va, Val(pr.varargs), gs...),
+                xcall(Zygote, :tuple_va, Val(pr.varargs), gs...),
             )
             branches(rb)[1].args[1] = Δ
         end

--- a/test/options.jl
+++ b/test/options.jl
@@ -854,14 +854,14 @@
         const var2      = 2
         const var3      = 3
         const var4      = 4"""
-        @test fmt(str_, align_const=true) == str
+        @test fmt(str_, align_const = true) == str
 
         str = """
         const variable1 = 1
         const variable2 = 2
         const var3 = 3
         const var4 = 4"""
-        @test fmt(str, align_const=true) == str
+        @test fmt(str, align_const = true) == str
 
         str_ = """
         module Foo
@@ -909,7 +909,7 @@
 
         end"""
         # @test fmt(str_, align_consts = false) == str
-        @test fmt(str_, align_const=true) == str
+        @test fmt(str_, align_const = true) == str
 
         # the aligned consts will NOT be nestable
         str = """
@@ -936,9 +936,8 @@
             1
 
         end"""
-        @test fmt(str_, 4, 1, align_const=true) == str
+        @test fmt(str_, 4, 1, align_const = true) == str
     end
-
 
     @testset "align conditionals" begin
         str_ = """
@@ -955,7 +954,7 @@
             n,
         )
         """
-        @test fmt(str_, align_conditional=true) == str
+        @test fmt(str_, align_conditional = true) == str
 
         str = """
         index =
@@ -966,8 +965,7 @@
                 n,
             )
         """
-        @test fmt(str_, 4, 1, align_conditional=true) == str
-
+        @test fmt(str_, 4, 1, align_conditional = true) == str
 
         str_ = """
         index = zeros(n <= typemax(Int8)  ? Int8 :   # inline
@@ -989,8 +987,7 @@
                 n,
             )
         """
-        @test fmt(str_, 4, 1, align_conditional=true) == str
-
+        @test fmt(str_, 4, 1, align_conditional = true) == str
 
         str_ = """
         index = zeros(n <= typemax(Int8)  ? Int8  :    # inline
@@ -1005,8 +1002,7 @@
                 n,
             )
         """
-        @test fmt(str_, 4, 1, align_conditional=true) == str
-
+        @test fmt(str_, 4, 1, align_conditional = true) == str
 
         str_ = """
         index =
@@ -1026,7 +1022,7 @@
                 n,
             )
         """
-        @test fmt(str_, 4, 1, align_conditional=true) == str
+        @test fmt(str_, 4, 1, align_conditional = true) == str
 
     end
 end

--- a/test/options.jl
+++ b/test/options.jl
@@ -843,7 +843,7 @@
         @test fmt(str, 4, 1, align_struct_field = true) == str
     end
 
-    @testset "align consts" begin
+    @testset "align assignment" begin
         str_ = """
         const variable1 = 1
         const var2      = 2
@@ -1077,5 +1077,54 @@
         """
         @test fmt(str_, 4, 1, align_conditional = true) == str
 
+    end
+
+    @testset "align pair arrow `=>`" begin
+        str_ = """
+        pages = [
+            "Introduction" => "index.md",
+            "How It Works" => "how_it_works.md",
+            "Code Style"          => "style.md",
+            "Skipping Formatting" => "skipping_formatting.md",
+            "Syntax Transforms" => "transforms.md",
+            "Custom Alignment" => "custom_alignment.md",
+            "Custom Styles" => "custom_styles.md",
+            "YAS Style" => "yas_style.md",
+            "Configuration File" => "config.md",
+            "API Reference" => "api.md",
+        ]
+        """
+        str = """
+        pages = [
+            "Introduction"        => "index.md",
+            "How It Works"        => "how_it_works.md",
+            "Code Style"          => "style.md",
+            "Skipping Formatting" => "skipping_formatting.md",
+            "Syntax Transforms"   => "transforms.md",
+            "Custom Alignment"    => "custom_alignment.md",
+            "Custom Styles"       => "custom_styles.md",
+            "YAS Style"           => "yas_style.md",
+            "Configuration File"  => "config.md",
+            "API Reference"       => "api.md",
+        ]
+        """
+        @test fmt(str_, 4, 100, align_pair_arrow = true) == str
+
+        str = """
+        pages =
+            [
+                "Introduction"        => "index.md",
+                "How It Works"        => "how_it_works.md",
+                "Code Style"          => "style.md",
+                "Skipping Formatting" => "skipping_formatting.md",
+                "Syntax Transforms"   => "transforms.md",
+                "Custom Alignment"    => "custom_alignment.md",
+                "Custom Styles"       => "custom_styles.md",
+                "YAS Style"           => "yas_style.md",
+                "Configuration File"  => "config.md",
+                "API Reference"       => "api.md",
+            ]
+        """
+        @test fmt(str_, 4, 1, align_pair_arrow = true) == str
     end
 end

--- a/test/options.jl
+++ b/test/options.jl
@@ -854,14 +854,14 @@
         const var2      = 2
         const var3      = 3
         const var4      = 4"""
-        @test fmt(str_, align_const = true) == str
+        @test fmt(str_, align_assignment = true) == str
 
         str = """
         const variable1 = 1
         const variable2 = 2
         const var3 = 3
         const var4 = 4"""
-        @test fmt(str, align_const = true) == str
+        @test fmt(str, align_assignment = true) == str
 
         str_ = """
         module Foo
@@ -908,8 +908,8 @@
         const FOO = 1
 
         end"""
-        # @test fmt(str_, align_consts = false) == str
-        @test fmt(str_, align_const = true) == str
+        # @test fmt(str_, align_assignment = false) == str
+        @test fmt(str_, align_assignment = true) == str
 
         # the aligned consts will NOT be nestable
         str = """
@@ -936,7 +936,24 @@
             1
 
         end"""
-        @test fmt(str_, 4, 1, align_const = true) == str
+        @test fmt(str_, 4, 1, align_assignment = true) == str
+
+        str = """
+        a  = 1
+        bc = 2
+
+        long_variable = 1
+        other_var     = 2
+        """
+        @test fmt(str, 4, 1, align_assignment = true) == str
+
+        str = """
+        vcat(X::T...) where {T}         = T[X[i] for i = 1:length(X)]
+        vcat(X::T...) where {T<:Number} = T[X[i] for i = 1:length(X)]
+        hcat(X::T...) where {T}         = T[X[j] for i = 1:1, j = 1:length(X)]
+        hcat(X::T...) where {T<:Number} = T[X[j] for i = 1:1, j = 1:length(X)]
+        """
+        @test fmt(str, 4, 1, align_assignment = true) == str
     end
 
     @testset "align conditionals" begin

--- a/test/options.jl
+++ b/test/options.jl
@@ -1006,5 +1006,27 @@
             )
         """
         @test fmt(str_, 4, 1, align_conditional=true) == str
+
+
+        str_ = """
+        index =
+            zeros(
+                n <= typemax(Int8)     ? Int8  :
+                n <= typemax(Int16A) ? Int16  :
+                n <= typemax(Int32)  ? Int322 : Int64,
+                n,
+            )
+        """
+        str = """
+        index =
+            zeros(
+                n <= typemax(Int8)   ? Int8   :
+                n <= typemax(Int16A) ? Int16  :
+                n <= typemax(Int32)  ? Int322 : Int64,
+                n,
+            )
+        """
+        @test fmt(str_, 4, 1, align_conditional=true) == str
+
     end
 end

--- a/test/options.jl
+++ b/test/options.jl
@@ -938,4 +938,73 @@
         end"""
         @test fmt(str_, 4, 1, align_const=true) == str
     end
+
+
+    @testset "align conditionals" begin
+        str_ = """
+        index = zeros(n <= typemax(Int8)  ? Int8  :
+                      n <= typemax(Int16) ? Int16 :
+                      n <= typemax(Int32) ? Int32 : Int64, n)
+        """
+
+        str = """
+        index = zeros(
+            n <= typemax(Int8)  ? Int8  :
+            n <= typemax(Int16) ? Int16 :
+            n <= typemax(Int32) ? Int32 : Int64,
+            n,
+        )
+        """
+        @test fmt(str_, align_conditional=true) == str
+
+        str = """
+        index =
+            zeros(
+                n <= typemax(Int8)  ? Int8  :
+                n <= typemax(Int16) ? Int16 :
+                n <= typemax(Int32) ? Int32 : Int64,
+                n,
+            )
+        """
+        @test fmt(str_, 4, 1, align_conditional=true) == str
+
+
+        str_ = """
+        index = zeros(n <= typemax(Int8)  ? Int8 :   # inline
+                        #comment 1
+                      n <= typemax(Int16) ? Int16 :   # inline 2
+                              # comment 2
+                      n <= typemax(Int32) ? Int32 : # inline 3
+                      Int64, n)
+        """
+        str = """
+        index =
+            zeros(
+                n <= typemax(Int8)  ? Int8 :   # inline
+                #comment 1
+                n <= typemax(Int16) ? Int16 :   # inline 2
+                # comment 2
+                n <= typemax(Int32) ? Int32 : # inline 3
+                Int64,
+                n,
+            )
+        """
+        @test fmt(str_, 4, 1, align_conditional=true) == str
+
+
+        str_ = """
+        index = zeros(n <= typemax(Int8)  ? Int8  :    # inline
+                      n <= typemax(Int16) ? Int16 : n <= typemax(Int32) ? Int32 : Int64, n)
+        """
+
+        str = """
+        index =
+            zeros(
+                n <= typemax(Int8)  ? Int8  :    # inline
+                n <= typemax(Int16) ? Int16 : n <= typemax(Int32) ? Int32 : Int64,
+                n,
+            )
+        """
+        @test fmt(str_, 4, 1, align_conditional=true) == str
+    end
 end

--- a/test/options.jl
+++ b/test/options.jl
@@ -954,6 +954,16 @@
         hcat(X::T...) where {T<:Number} = T[X[j] for i = 1:1, j = 1:length(X)]
         """
         @test fmt(str, 4, 1, align_assignment = true) == str
+
+        # Unicode symbols count as extra characters in Tokenize.jl
+        # which leads to misinterpretation of the operator line offset,
+        # so this will be aligned when it shouldn't.
+        str = """
+        μs, ns = divrem(ns, 1000)
+        ms, μs = divrem(μs, 1000)
+        s, ms = divrem(ms, 1000)
+        """
+        @test_broken fmt(str, 4, 100, align_assignment = true) == str
     end
 
     @testset "align conditionals" begin

--- a/test/options.jl
+++ b/test/options.jl
@@ -955,15 +955,12 @@
         """
         @test fmt(str, 4, 1, align_assignment = true) == str
 
-        # Unicode symbols count as extra characters in Tokenize.jl
-        # which leads to misinterpretation of the operator line offset,
-        # so this will be aligned when it shouldn't.
         str = """
         μs, ns = divrem(ns, 1000)
         ms, μs = divrem(μs, 1000)
         s, ms = divrem(ms, 1000)
         """
-        @test_broken fmt(str, 4, 100, align_assignment = true) == str
+        @test fmt(str, 4, 100, align_assignment = true) == str
     end
 
     @testset "align conditionals" begin

--- a/test/options.jl
+++ b/test/options.jl
@@ -719,4 +719,56 @@
         """
         @test fmt(short, format_docstrings = true) == short_formatted
     end
+
+    @testset "align struct fields" begin
+        str_ = """
+        struct Foo
+            a::T
+            longfieldname::B
+        end"""
+        str = """
+        struct Foo
+            a             :: T
+            longfieldname :: B
+        end"""
+        @test fmt(str_, align_struct_fields = true) == str
+        @test fmt(str, align_struct_fields = false) == str_
+
+        str_ = """
+        Base.@kwdef struct Options
+            indent_size::Int = 4
+            max_margin::Int = 92
+            always_for_in::Bool = false
+            whitespace_typedefs::Bool = false
+            whitespace_ops_in_indices::Bool = false
+            remove_extra_newlines::Bool = false
+            import_to_using::Bool = false
+            pipe_to_function_call::Bool = false
+            short_to_long_function_def::Bool = false
+            always_use_return::Bool = false
+            whitespace_in_kwargs::Bool = true
+            annotate_untyped_fields_with_any::Bool = true
+            format_docstrings::Bool = false
+            align_struct_fields::Bool = false
+        end"""
+        str = """
+        Base.@kwdef struct Options
+            indent_size::Int                       = 4
+            max_margin::Int                        = 92
+            always_for_in::Bool                    = false
+            whitespace_typedefs::Bool              = false
+            whitespace_ops_in_indices::Bool        = false
+            remove_extra_newlines::Bool            = false
+            import_to_using::Bool                  = false
+            pipe_to_function_call::Bool            = false
+            short_to_long_function_def::Bool       = false
+            always_use_return::Bool                = false
+            whitespace_in_kwargs::Bool             = true
+            annotate_untyped_fields_with_any::Bool = true
+            format_docstrings::Bool                = false
+            align_struct_fields::Bool              = false
+        end"""
+        @test fmt(str_, align_struct_fields = true) == str
+        @test fmt(str, align_struct_fields = false) == str_
+    end
 end

--- a/test/options.jl
+++ b/test/options.jl
@@ -729,42 +729,42 @@
         struct Foo
             a::T
         end"""
-        @test fmt(str_, align_struct_fields = true) == str
+        @test fmt(str_, align_struct_field = true) == str
 
-        str_ = """
-        struct Foo
-            a::T
-            longfieldname::B
-        end"""
         str = """
         struct Foo
             a             :: T
             longfieldname :: B
         end"""
-        @test fmt(str_, align_struct_fields = true) == str
-        @test fmt(str, align_struct_fields = false) == str_
+        str_ = """
+        struct Foo
+            a::T
+            longfieldname::B
+        end"""
+        @test fmt(str, align_struct_field = true) == str
+        @test fmt(str, align_struct_field = false) == str_
 
         str_ = """
         Base.@kwdef struct Options
-            indent_size::Int = 4
-            max_margin::Int = 92
-            always_for_in::Bool = false
-            whitespace_typedefs::Bool = false
-            whitespace_ops_in_indices::Bool = false
-            remove_extra_newlines::Bool = false
-            import_to_using::Bool = false
-            pipe_to_function_call::Bool = false
-            short_to_long_function_def::Bool = false
-            always_use_return::Bool = false
-            whitespace_in_kwargs::Bool = true
+            indent_size::Int                       = 4
+            max_margin::Int                        = 92
+            always_for_in::Bool                 = false
+            whitespace_typedefs::Bool          = false
+            whitespace_ops_in_indices::Bool        = false
+            remove_extra_newlines::Bool            = false
+            import_to_using::Bool                  = false
+            pipe_to_function_call::Bool            = false
+            short_to_long_function_def::Bool      = false
+            always_use_return::Bool           = false
+            whitespace_in_kwargs::Bool          = true
             annotate_untyped_fields_with_any::Bool = true
-            format_docstrings::Bool = false
-            align_struct_fields::Bool = false
-
-            Options() = new()
+            format_docstrings::Bool             = false
+            align_struct_fields::Bool           = false
 
             another_field1::BlahBlahBlah = 10
-            field2::Foo = 10
+            field2::Foo                          = 10
+
+            Options() = new()
         end"""
         str = """
         Base.@kwdef struct Options
@@ -783,12 +783,159 @@
             format_docstrings::Bool                = false
             align_struct_fields::Bool              = false
 
+            another_field1::BlahBlahBlah = 10
+            field2::Foo = 10
+
             Options() = new()
+        end"""
+        @test fmt(str_, align_struct_field = true) == str
+
+        str_ = """
+        Base.@kwdef struct Options
+            indent_size::Int = 4
+            max_margin::Int = 92
+            always_for_in::Bool = false
+            whitespace_typedefs::Bool = false
+            whitespace_ops_in_indices::Bool = false
+            remove_extra_newlines::Bool = false
+            import_to_using::Bool = false
+            pipe_to_function_call::Bool = false
+            short_to_long_function_def::Bool = false
+            always_use_return::Bool = false
+            whitespace_in_kwargs::Bool = true
+            annotate_untyped_fields_with_any::Bool = true
+            format_docstrings::Bool = false
+            align_struct_fields::Bool = false
 
             another_field1::BlahBlahBlah = 10
-            field2::Foo                  = 10
+            field2::Foo = 10
+
+            Options() = new()
         end"""
-        @test fmt(str_, align_struct_fields = true) == str
-        @test fmt(str, align_struct_fields = false) == str_
+        @test fmt(str, align_struct_field = true) == str
+        @test fmt(str, align_struct_field = false) == str_
+
+        str = """
+        Base.@kwdef struct Options
+            indent_size::Int                       = 4
+            max_margin::Int                        = 92
+            always_for_in::Bool                    = false
+            whitespace_typedefs::Bool              = false
+            whitespace_ops_in_indices::Bool        = false
+            remove_extra_newlines::Bool            = false
+            import_to_using::Bool                  = false
+            pipe_to_function_call::Bool            = false
+            short_to_long_function_def::Bool       = false
+            always_use_return::Bool                = false
+            whitespace_in_kwargs::Bool             = true
+            annotate_untyped_fields_with_any::Bool = true
+            format_docstrings::Bool                = false
+            align_struct_fields::Bool              = false
+
+            another_field1::BlahBlahBlah =
+                10
+            field2::Foo =
+                10
+
+            Options() =
+                new()
+        end"""
+        @test fmt(str, 4, 1, align_struct_field = true) == str
+    end
+
+    @testset "align consts" begin
+        str_ = """
+        const variable1 = 1
+        const var2      = 2
+        const var3 = 3
+        const var4 = 4"""
+        str = """
+        const variable1 = 1
+        const var2      = 2
+        const var3      = 3
+        const var4      = 4"""
+        @test fmt(str_, align_const=true) == str
+
+        str = """
+        const variable1 = 1
+        const variable2 = 2
+        const var3 = 3
+        const var4 = 4"""
+        @test fmt(str, align_const=true) == str
+
+        str_ = """
+        module Foo
+
+        const UTF8PROC_STABLE    = (1<<1)
+        const UTF8PROC_COMPAT    = (1<<2)
+        const UTF8PROC_COMPOSE   = (1<<3)
+        const UTF8PROC_DECOMPOSE = (1<<4)
+        const UTF8PROC_IGNORE    = (1<<5)
+        const UTF8PROC_REJECTNA  = (1<<6)
+        const UTF8PROC_NLF2LS    = (1<<7)
+        const UTF8PROC_NLF2PS    = (1<<8)
+        const UTF8PROC_NLF2LF    = (UTF8PROC_NLF2LS | UTF8PROC_NLF2PS)
+        const UTF8PROC_STRIPCC   = (1<<9)
+        const UTF8PROC_CASEFOLD  = (1<<10)
+        const UTF8PROC_CHARBOUND = (1<<11)
+        const UTF8PROC_LUMP=(1<<12)
+        const UTF8PROC_STRIP         = (1<<13) # align this
+
+        const FOOBAR = 0
+        const FOO = 1
+
+        end"""
+
+        str = """
+        module Foo
+
+        const UTF8PROC_STABLE    = (1 << 1)
+        const UTF8PROC_COMPAT    = (1 << 2)
+        const UTF8PROC_COMPOSE   = (1 << 3)
+        const UTF8PROC_DECOMPOSE = (1 << 4)
+        const UTF8PROC_IGNORE    = (1 << 5)
+        const UTF8PROC_REJECTNA  = (1 << 6)
+        const UTF8PROC_NLF2LS    = (1 << 7)
+        const UTF8PROC_NLF2PS    = (1 << 8)
+        const UTF8PROC_NLF2LF    = (UTF8PROC_NLF2LS | UTF8PROC_NLF2PS)
+        const UTF8PROC_STRIPCC   = (1 << 9)
+        const UTF8PROC_CASEFOLD  = (1 << 10)
+        const UTF8PROC_CHARBOUND = (1 << 11)
+        const UTF8PROC_LUMP      = (1 << 12)
+        const UTF8PROC_STRIP     = (1 << 13) # align this
+
+        const FOOBAR = 0
+        const FOO = 1
+
+        end"""
+        # @test fmt(str_, align_consts = false) == str
+        @test fmt(str_, align_const=true) == str
+
+        # the aligned consts will NOT be nestable
+        str = """
+        module Foo
+
+        const UTF8PROC_STABLE    = (1 << 1)
+        const UTF8PROC_COMPAT    = (1 << 2)
+        const UTF8PROC_COMPOSE   = (1 << 3)
+        const UTF8PROC_DECOMPOSE = (1 << 4)
+        const UTF8PROC_IGNORE    = (1 << 5)
+        const UTF8PROC_REJECTNA  = (1 << 6)
+        const UTF8PROC_NLF2LS    = (1 << 7)
+        const UTF8PROC_NLF2PS    = (1 << 8)
+        const UTF8PROC_NLF2LF    = (UTF8PROC_NLF2LS | UTF8PROC_NLF2PS)
+        const UTF8PROC_STRIPCC   = (1 << 9)
+        const UTF8PROC_CASEFOLD  = (1 << 10)
+        const UTF8PROC_CHARBOUND = (1 << 11)
+        const UTF8PROC_LUMP      = (1 << 12)
+        const UTF8PROC_STRIP     = (1 << 13) # align this
+
+        const FOOBAR =
+            0
+        const FOO =
+            1
+
+        end"""
+        @test fmt(str_, 4, 1, align_const=true) == str
     end
 end

--- a/test/options.jl
+++ b/test/options.jl
@@ -1,4 +1,4 @@
-@testset "Format Options" begin
+@testset "Formatting Options" begin
     @testset "whitespace in typedefs" begin
         str_ = "Foo{A,B,C}"
         str = "Foo{A, B, C}"

--- a/test/options.jl
+++ b/test/options.jl
@@ -1041,5 +1041,31 @@
         """
         @test fmt(str_, 4, 1, align_conditional = true) == str
 
+        str_ = """
+        val = cst.kind === Tokens.ABSTRACT ? "abstract" :
+            cst.kind === Tokens.BAREMODULE ? "baremodule" : ""
+        """
+        str = """
+        val = cst.kind === Tokens.ABSTRACT ? "abstract" : cst.kind === Tokens.BAREMODULE ? "baremodule" : ""
+        """
+        @test fmt(str_, 4, 100, align_conditional = true) == str
+
+        str_ = """
+        val = cst.kind === Tokens.ABSTRACT ? "abstract" :
+            cst.kind === Tokens.BAREMODUL  ? "baremodule" : ""
+        """
+        str = """
+        val = cst.kind === Tokens.ABSTRACT  ? "abstract" :
+              cst.kind === Tokens.BAREMODUL ? "baremodule" : ""
+        """
+        @test fmt(str_, 4, 100, align_conditional = true) == str
+
+        str = """
+        val =
+            cst.kind === Tokens.ABSTRACT  ? "abstract" :
+            cst.kind === Tokens.BAREMODUL ? "baremodule" : ""
+        """
+        @test fmt(str_, 4, 1, align_conditional = true) == str
+
     end
 end

--- a/test/options.jl
+++ b/test/options.jl
@@ -762,6 +762,9 @@
             align_struct_fields::Bool = false
 
             Options() = new()
+
+            another_field1::BlahBlahBlah = 10
+            field2::Foo = 10
         end"""
         str = """
         Base.@kwdef struct Options
@@ -781,6 +784,9 @@
             align_struct_fields::Bool              = false
 
             Options() = new()
+
+            another_field1::BlahBlahBlah = 10
+            field2::Foo                  = 10
         end"""
         @test fmt(str_, align_struct_fields = true) == str
         @test fmt(str, align_struct_fields = false) == str_

--- a/test/options.jl
+++ b/test/options.jl
@@ -724,6 +724,16 @@
         str_ = """
         struct Foo
             a::T
+        end"""
+        str = """
+        struct Foo
+            a::T
+        end"""
+        @test fmt(str_, align_struct_fields = true) == str
+
+        str_ = """
+        struct Foo
+            a::T
             longfieldname::B
         end"""
         str = """
@@ -750,6 +760,8 @@
             annotate_untyped_fields_with_any::Bool = true
             format_docstrings::Bool = false
             align_struct_fields::Bool = false
+
+            Options() = new()
         end"""
         str = """
         Base.@kwdef struct Options
@@ -767,6 +779,8 @@
             annotate_untyped_fields_with_any::Bool = true
             format_docstrings::Bool                = false
             align_struct_fields::Bool              = false
+
+            Options() = new()
         end"""
         @test fmt(str_, align_struct_fields = true) == str
         @test fmt(str, align_struct_fields = false) == str_

--- a/test/yas_style.jl
+++ b/test/yas_style.jl
@@ -1,4 +1,4 @@
-@testset "YAS style" begin
+@testset "YAS Style" begin
     @testset "basic" begin
         str_ = "foo(; k =v)"
         str = "foo(; k = v)"


### PR DESCRIPTION
This closes #179

- [x] struct fields
- [x] consts
- [x] conditionals
- [x] short function definitions
- [x] general assignments
- [x] documentation

Extra

- [ ] matrices
- [x] `=>`

The main feature of this PR is custom alignment, which is explained below. Another change of this PR is conditionals and chain operator calls are only unnested if the entire expression fits on the line.

In other words the following no longer occurs

```julia
var = cond ?
    e1 : e2
```

This change was made in part to reduce the complexity of aligning conditionals but also because it's not a particularly good use case of unnesting and generally makes the code harder to follow.

# Custom Alignment

Custom alignment is determined by a whitespace heuristic:

A token (typically an operator, i.e. `=, ?, ::, etc`) is custom aligned if there are 
`> 1` whitespaces from the previous expression since the formatter only outputs 
0 or 1 whitespaces for separation. If custom alignment is determined then all
expressions in the code block will be aligned to the furthest aligned token.

> NOTE: alignment overrides nesting behavior, meaning it ignores the allowed maximum margin

### Example

Suppose the source text is as follows

```julia
const variable1 = 1
const var2      = 2
const var3 = 3
const var4 = 4
const var5          = 5
```

If the `align_assignment` option is enabled the formatter will detect that `var2`
is aligned to `variable1` AND `var2` has several whitespaces (>1) prior to
`=`. Since `var3`,`var4`, and `var5` are part of the same code block (no comments
or newlines separating code) they will also be aligned.

So the output would be

```julia
const variable1 = 1
const var2      = 2
const var3      = 3
const var4      = 4
const var5      = 5
```

Notice how the `=` operator for `var5` is correctly positioned
despite it being located further to the right than other `=` operators.

However, if the source code is

```julia
const variable1 = 1
const variable2 = 2
const var3 = 3
const var4 = 4
const var5 = 5
```

It's now ambiguous whether this is meant to be aligned and so the formatter will
proceed with normal behavior.

## Alignment Options


In order for alignment to occur the option must be set to `true`. Available options:

- `align_assignment`
- `align_struct_field`
- `align_conditional`
- `align_pair_arrow`

> **Caveat: Since nesting is disabled when alignment occurs be careful when adding comments to the RHS expression. This will be fixed in a future release**

For example:

```julia
const variable1 = 1
const var2      = foo(10,
    # comment,
    20)
```

This will be formatted to

```julia
const variable1 = 1
const var2      = foo(10, # comment, 20)
```

which causes a parsing error.

### `align_assignment`

Align to `=`-like operators. This covers variable assignments and short definition functions.


```julia
const UTF8PROC_STABLE    = (1 << 1)
const UTF8PROC_COMPAT    = (1 << 2)
const UTF8PROC_COMPOSE   = (1 << 3)
const UTF8PROC_DECOMPOSE = (1 << 4)
const UTF8PROC_IGNORE    = (1 << 5)
const UTF8PROC_REJECTNA  = (1 << 6)
const UTF8PROC_NLF2LS    = (1 << 7)
const UTF8PROC_NLF2PS    = (1 << 8)
const UTF8PROC_NLF2LF    = (UTF8PROC_NLF2LS | UTF8PROC_NLF2PS)
const UTF8PROC_STRIPCC   = (1 << 9)
const UTF8PROC_CASEFOLD  = (1 << 10)
const UTF8PROC_CHARBOUND = (1 << 11)
const UTF8PROC_LUMP      = (1 << 12)
const UTF8PROC_STRIP     = (1 << 13)


vcat(X::T...) where {T}         = T[X[i] for i = 1:length(X)]
vcat(X::T...) where {T<:Number} = T[X[i] for i = 1:length(X)]
hcat(X::T...) where {T}         = T[X[j] for i = 1:1, j = 1:length(X)]
hcat(X::T...) where {T<:Number} = T[X[j] for i = 1:1, j = 1:length(X)]

a  = 1
bc = 2

long_variable = 1
other_var     = 2
```

### `align_struct_field`

Align struct field definitions to `::` or `=` - whichever has higher precedence.

```julia
Base.@kwdef struct Options
    indent_size::Int                       = 4
    max_margin::Int                        = 92
    always_for_in::Bool                    = false
    whitespace_typedefs::Bool              = false
    whitespace_ops_in_indices::Bool        = false
    remove_extra_newlines::Bool            = false
    import_to_using::Bool                  = false
    pipe_to_function_call::Bool            = false
    short_to_long_function_def::Bool       = false
    always_use_return::Bool                = false
    whitespace_in_kwargs::Bool             = true
    annotate_untyped_fields_with_any::Bool = true
    format_docstrings::Bool                = false
    align_struct_fields::Bool              = false

    # no custom whitespace so this block is not aligned
    another_field1::BlahBlahBlah = 10
    field2::Foo = 10

    # no custom whitespace but single line blocks are not aligned
    # either way
    Options() = new()
end


mutable struct Foo
    a             :: T
    longfieldname :: T
end
```

### `align_conditional`

Align conditional expressions to either `?`, `:`, or both.

```julia
# This will remain like this if using YASStyle
index = zeros(n <= typemax(Int8)  ? Int8  :
              n <= typemax(Int16) ? Int16 :
              n <= typemax(Int32) ? Int32 : Int64, n)

# Using DefaultStyle
index = zeros(
    n <= typemax(Int8)  ? Int8  :
    n <= typemax(Int16) ? Int16 :
    n <= typemax(Int32) ? Int32 : Int64,
    n,
)

# Note even if the maximum margin is set to 1, the alignment remains intact
index = 
    zeros(
        n <= typemax(Int8)  ? Int8  :
        n <= typemax(Int16) ? Int16 :
        n <= typemax(Int32) ? Int32 : Int64,
        n,
    )

```

### `align_pair_arrow`

Align pair arrows (`=>`).

```julia
pages = [
    "Introduction"        => "index.md",
    "How It Works"        => "how_it_works.md",
    "Code Style"          => "style.md",
    "Skipping Formatting" => "skipping_formatting.md",
    "Syntax Transforms"   => "transforms.md",
    "Custom Alignment"    => "custom_alignment.md",
    "Custom Styles"       => "custom_styles.md",
    "YAS Style"           => "yas_style.md",
    "Configuration File"  => "config.md",
    "API Reference"       => "api.md",
]
```


