### PR TITLE
Give `//` the same binaryop whitespace exception as `^`

### DIFF
--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1364,14 +1364,21 @@ function p_binaryopcall(
     elseif op.kind === Tokens.EX_OR
         add_node!(t, Whitespace(1), s)
         add_node!(t, pretty(style, op, s), s, join_lines = true)
-    elseif (is_number(cst[1]) || op.kind === Tokens.CIRCUMFLEX_ACCENT) && op.dot
+    elseif (is_number(cst[1]) || op.kind === Tokens.FWDFWD_SLASH || op.kind === Tokens.CIRCUMFLEX_ACCENT) && op.dot
         add_node!(t, Whitespace(1), s)
         add_node!(t, pretty(style, op, s), s, join_lines = true)
         nest ? add_node!(t, Placeholder(1), s) : add_node!(t, Whitespace(1), s)
-    elseif (
-        nospace ||
-        (CSTParser.precedence(op) in (8, 13, 14, 16) && op.kind !== Tokens.ANON_FUNC)
-    ) && op.kind !== Tokens.IN
+    elseif op.kind !== Tokens.IN && (
+        nospace || (
+            op.kind !== Tokens.ANON_FUNC && CSTParser.precedence(op) in (
+                CSTParser.ColonOp,
+                CSTParser.RationalOp,
+                CSTParser.PowerOp,
+                CSTParser.DeclarationOp,
+                CSTParser.DotOp,
+            )
+        )
+    )
         add_node!(t, pretty(style, op, s), s, join_lines = true)
     else
         add_node!(t, Whitespace(1), s)

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1364,7 +1364,11 @@ function p_binaryopcall(
     elseif op.kind === Tokens.EX_OR
         add_node!(t, Whitespace(1), s)
         add_node!(t, pretty(style, op, s), s, join_lines = true)
-    elseif (is_number(cst[1]) || op.kind === Tokens.FWDFWD_SLASH || op.kind === Tokens.CIRCUMFLEX_ACCENT) && op.dot
+    elseif (
+        is_number(cst[1]) ||
+        op.kind === Tokens.FWDFWD_SLASH ||
+        op.kind === Tokens.CIRCUMFLEX_ACCENT
+    ) && op.dot
         add_node!(t, Whitespace(1), s)
         add_node!(t, pretty(style, op, s), s, join_lines = true)
         nest ? add_node!(t, Placeholder(1), s) : add_node!(t, Whitespace(1), s)

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -164,6 +164,7 @@
         @test fmt("10.0 .^ a") == "10.0 .^ a"
         @test fmt("a.^b") == "a .^ b"
         @test fmt("a.^10.") == "a .^ 10.0"
+        @test fmt("a.//10") == "a .// 10"
     end
 
     @testset "toplevel" begin
@@ -375,6 +376,9 @@
 
         str = "!(typ <: ArithmeticTypes)"
         @test fmt(str) == str
+
+        # `//` and `^` are binary ops without whitespace around them
+        @test fmt("1 // 2 + 3 ^ 4") == "1//2 + 3^4"
 
         # Function def
 


### PR DESCRIPTION
As mentioned in #283, BlueStyle recommends exempting both `^` and `//` from the rule that binary operators are surrounded by whitespace. `a ^ b` is already formatted as `a^b`. This PR adds the analogous formatting `x // y` -> `x//y`.

Since `x//y` is a single `Rational` number, i think this makes sense as a general rule, so i've added it to the DefaultStyle - does that seem reasonable?

This is my first attempt at making contributions to the code in the package, so please let me know if this approach seems right 😄 Hopefully tests show the intended behaviour