### PR TITLE
Avoid adding spacing to operation calls that are matrix elements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tokenize = "0796e94c-ce3b-5d07-9a54-7f471281c624"
 
 [compat]
-CSTParser = "^2.1"
+CSTParser = "^2.2"
 CommonMark = "0.5, 0.6"
 DataStructures = "0.17, 0.18"
 Documenter = "0.24, 0.25"

--- a/Project.toml
+++ b/Project.toml
@@ -13,9 +13,9 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tokenize = "0796e94c-ce3b-5d07-9a54-7f471281c624"
 
 [compat]
-CSTParser = "1, 2"
+CSTParser = "^2.1"
 CommonMark = "0.5, 0.6"
 DataStructures = "0.17, 0.18"
 Documenter = "0.24, 0.25"
-Tokenize = "^0.5.5"
+Tokenize = "^0.5.7"
 julia = "1"

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1966,7 +1966,12 @@ function p_row(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
 
     for (i, a) in enumerate(cst)
         if is_opcall(a)
-            add_node!(t, pretty(style, a, s, nospace=true, nonest=true), s, join_lines = true)
+            add_node!(
+                t,
+                pretty(style, a, s, nospace = true, nonest = true),
+                s,
+                join_lines = true,
+            )
         else
             add_node!(t, pretty(style, a, s), s, join_lines = true)
         end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -588,4 +588,34 @@
         """
         @test fmt(str_) == str
     end
+
+    @testset "issue 289 - no spaces/nesting for matrix elements" begin
+        str_ = """
+        A =  [0. 1 0 0
+           -k/Jm -c/Jm k/Jm c/Jm
+            0 0 0 1
+            k/Ja c/Ja -k/Ja -c/Ja]
+        """
+
+        str = """
+        A = [
+            0.0 1 0 0
+            -k/Jm -c/Jm k/Jm c/Jm
+            0 0 0 1
+            k/Ja c/Ja -k/Ja -c/Ja
+        ]
+        """
+        @test fmt(str_) == str
+
+        str = """
+        A =
+            [
+                0.0 1 0 0
+                -k/Jm -c/Jm k/Jm c/Jm
+                0 0 0 1
+                k/Ja c/Ja -k/Ja -c/Ja
+            ]
+        """
+        @test fmt(str_, 4, 1) == str
+    end
 end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -594,18 +594,8 @@
         A =  [0. 1 0 0
            -k/Jm -c/Jm k/Jm c/Jm
             0 0 0 1
-            k/Ja c/Ja -k/Ja -c/Ja]
+            f(1,2) c/Ja -k/Ja -c/Ja]
         """
-
-        str = """
-        A = [
-            0.0 1 0 0
-            -k/Jm -c/Jm k/Jm c/Jm
-            0 0 0 1
-            k/Ja c/Ja -k/Ja -c/Ja
-        ]
-        """
-        @test fmt(str_) == str
 
         str = """
         A =
@@ -613,7 +603,7 @@
                 0.0 1 0 0
                 -k/Jm -c/Jm k/Jm c/Jm
                 0 0 0 1
-                k/Ja c/Ja -k/Ja -c/Ja
+                f(1, 2) c/Ja -k/Ja -c/Ja
             ]
         """
         @test fmt(str_, 4, 1) == str


### PR DESCRIPTION
Additionally 

1. never nest elements of a matrix
2. bump minimum dependencies so we can remove some hacks

fixes #289 

