### PR TITLE
Allow `Style`s to set defaults for all settings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -58,12 +58,16 @@ version = "0.21.0"
 
 [[JuliaFormatter]]
 deps = ["CSTParser", "CommonMark", "DataStructures", "Documenter", "Pkg", "Test", "Tokenize"]
-git-tree-sha1 = "bb28d76fe6e2df5ea48f547c0e880eb7e2e5e5aa"
+path = ".."
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "0.7.1"
+version = "0.9.0"
 
 [[LibGit2]]
+deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -87,7 +91,7 @@ uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 version = "1.0.10"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Printf]]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -2,4 +2,5 @@
 
 ```@autodocs
 Modules = [JuliaFormatter]
+Filter = t -> (t != YASStyle && t != BlueStyle)  # on their own pages
 ```

--- a/docs/src/blue_style.md
+++ b/docs/src/blue_style.md
@@ -1,19 +1,8 @@
 # Blue Style
 
-Formatting style based on https://github.com/invenia/BlueStyle
-and https://github.com/domluna/JuliaFormatter.jl/issues/283
-
-Recommended options are:
-
-- `always_use_return` = true
-- `short_to_long_function_def` = true
-- `whitespace_ops_in_indices` = true
-- `remove_extra_newlines` = true
-- `always_for_in` = true
-- `import_to_using` = true
-- `pipe_to_function_call` = true
-- `whitespace_in_kwargs` = false
-- `annotate_untyped_fields_with_any` = false
+```@docs
+BlueStyle
+```
 
 ## Configuration File Example
 
@@ -21,21 +10,23 @@ The `.JuliaFormatter.toml` which represents these settings is
 
 ```toml
 style = "blue"
-always_use_return = true
-short_to_long_function_def = true
-whitespace_ops_in_indices = true
-remove_extra_newlines = true
-always_for_in = true
-import_to_using = true
-pipe_to_function_call = true
-whitespace_in_kwargs = false
-annotate_untyped_fields_with_any = false
 ```
 
+Or to use `BlueStyle` except change one of the settings:
+
+```toml
+style = "yas"
+remove_extra_newlines = false
+```
 
 ## Direct Usage
 
 ```julia
-format("file.jl", style=BlueStyle(), ...)
+format("file.jl", style=BlueStyle())
 ```
 
+Or to use `BlueStyle` except change one of the settings:
+
+```julia
+format("file.jl", style=BlueStyle(), remove_extra_newlines=false)
+```

--- a/docs/src/blue_style.md
+++ b/docs/src/blue_style.md
@@ -22,11 +22,11 @@ remove_extra_newlines = false
 ## Direct Usage
 
 ```julia
-format("file.jl", style=BlueStyle())
+format("file.jl", BlueStyle())
 ```
 
 Or to use `BlueStyle` except change one of the settings:
 
 ```julia
-format("file.jl", style=BlueStyle(), remove_extra_newlines=false)
+format("file.jl", BlueStyle(), remove_extra_newlines=false)
 ```

--- a/docs/src/custom_alignment.md
+++ b/docs/src/custom_alignment.md
@@ -4,8 +4,8 @@
 
 Custom alignment is determined by a whitespace heuristic:
 
-A token (typically an operator, i.e. `=, ?, ::, etc`) is custom aligned if there are 
-`> 1` whitespaces from the previous expression since the formatter only outputs 
+A token (typically an operator, i.e. `=, ?, ::, etc`) is custom aligned if there are
+`> 1` whitespaces from the previous expression since the formatter only outputs
 0 or 1 whitespaces for separation. If custom alignment is determined then all
 expressions in the code block will be aligned to the furthest aligned token.
 
@@ -124,8 +124,8 @@ Align struct field definitions to `::` or `=` - whichever has higher precedence.
 
 ```julia
 Base.@kwdef struct Options
-    indent_size::Int                       = 4
-    max_margin::Int                        = 92
+    indent::Int                            = 4
+    margin::Int                            = 92
     always_for_in::Bool                    = false
     whitespace_typedefs::Bool              = false
     whitespace_ops_in_indices::Bool        = false
@@ -174,7 +174,7 @@ index = zeros(
 )
 
 # Note even if the maximum margin is set to 1, the alignment remains intact
-index = 
+index =
     zeros(
         n <= typemax(Int8)  ? Int8  :
         n <= typemax(Int16) ? Int16 :
@@ -202,4 +202,3 @@ pages = [
     "API Reference"       => "api.md",
 ]
 ```
-

--- a/docs/src/yas_style.md
+++ b/docs/src/yas_style.md
@@ -22,13 +22,13 @@ remove_extra_newlines = false
 ## Direct Usage
 
 ```julia
-format("file.jl", style=YASStyle())
+format("file.jl", YASStyle())
 ```
 
 Or to use `YASStyle` except change one of the settings:
 
 ```julia
-format("file.jl", style=YASStyle(), remove_extra_newlines=false)
+format("file.jl", YASStyle(), remove_extra_newlines=false)
 ```
 
 ## Differences from `DefaultStyle`

--- a/docs/src/yas_style.md
+++ b/docs/src/yas_style.md
@@ -1,18 +1,8 @@
 # YAS Style
 
-Formatting style based on [YASGuide](https://github.com/jrevels/YASGuide) and https://github.com/domluna/JuliaFormatter.jl/issues/198.
-
-Recommended options for confirming with the above guide are:
-
-  - `always_for_in` = true
-  - `whitespace_ops_in_indices` = true
-  - `whitespace_typedefs` = false
-  - `remove_extra_newlines` = true
-  - `import_to_using` = true
-  - `pipe_to_function_call` = true
-  - `short_to_long_function_def` = true
-  - `always_use_return` = true
-  - `whitespace_in_kwargs` = false
+```@docs
+YASStyle
+```
 
 ## Configuration File Example
 
@@ -20,20 +10,25 @@ The `.JuliaFormatter.toml` which represents these settings is
 
 ```toml
 style = "yas"
-always_for_in = true
-whitespace_ops_in_indices = true
-whitespace_typedefs = false
-remove_extra_newlines = true
-import_to_using = true
-pipe_to_function_call = true
-short_to_long_function_def = true
-always_use_return = true
+```
+
+Or to use `YASStyle` except change one of the settings:
+
+```toml
+style = "yas"
+remove_extra_newlines = false
 ```
 
 ## Direct Usage
 
 ```julia
-format("file.jl", style=YASStyle(), ...)
+format("file.jl", style=YASStyle())
+```
+
+Or to use `YASStyle` except change one of the settings:
+
+```julia
+format("file.jl", style=YASStyle(), remove_extra_newlines=false)
 ```
 
 ## Differences from `DefaultStyle`

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -26,8 +26,10 @@ abstract type AbstractStyle end
 """
     DefaultStyle
 
-The default formatting style. See the style section of the documentation
+The default formatting style. See the [Style](@ref) section of the documentation
 for more details.
+
+See also: [`BlueStyle`](@ref), [`YASStyle`](@ref)
 """
 struct DefaultStyle <: AbstractStyle
     innerstyle::Union{Nothing,AbstractStyle}
@@ -446,7 +448,7 @@ See [`format_file`](@ref) and [`format_text`](@ref) for a description of the opt
 This function will look for `.JuliaFormatter.toml` in the location of the file being
 formatted, and searching *up* the file tree until a config file is (or isn't) found.
 When found, the configurations in the file will overwrite the given `options`.
-See ["Configuration File"](@id) for more details.
+See [Configuration File](@ref) for more details.
 
 ### Output
 

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -396,7 +396,7 @@ end
     format_file(filename::AbstractString, style::AbstractStyle; kwargs...)::Bool
 """
 function format_file(filename::AbstractString, style::AbstractStyle; kwargs...)
-    return format_file(filename; style=style, kwargs...)
+    return format_file(filename; style = style, kwargs...)
 end
 
 if VERSION < v"1.1.0"
@@ -517,7 +517,7 @@ format(path::AbstractString; options...) = format((path,); options...)
 """
     format(path, style::AbstractStyle; options...)::Bool
 """
-format(path, style::AbstractStyle; options...) = format(path; style=style, options...)
+format(path, style::AbstractStyle; options...) = format(path; style = style, options...)
 
 function kwargs(dict)
     ns = (Symbol.(keys(dict))...,)

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -392,6 +392,13 @@ function format_file(
     return formatted_str == str
 end
 
+"""
+    format_file(filename::AbstractString, style::AbstractStyle; kwargs...)::Bool
+"""
+function format_file(filename::AbstractString, style::AbstractStyle; kwargs...)
+    return format_file(filename; style=style, kwargs...)
+end
+
 if VERSION < v"1.1.0"
     # We define `splitpath` here, copying the definition from base/path.jl
     # because it was only added in Julia 1.1.
@@ -506,6 +513,11 @@ function format(paths; options...)::Bool
     return already_formatted
 end
 format(path::AbstractString; options...) = format((path,); options...)
+
+"""
+    format(path, style::AbstractStyle; options...)::Bool
+"""
+format(path, style::AbstractStyle; options...) = format(path; style=style, options...)
 
 function kwargs(dict)
     ns = (Symbol.(keys(dict))...,)

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -33,6 +33,7 @@ end
 DefaultStyle() = DefaultStyle(nothing)
 
 @inline getstyle(s::DefaultStyle) = s.innerstyle === nothing ? s : s.innerstyle
+@inline options(s::DefaultStyle) = NamedTuple()
 
 include("document.jl")
 include("options.jl")
@@ -59,9 +60,9 @@ normalize_line_ending(s::AbstractString) = replace(s, "\r\n" => "\n")
 """
     format_text(
         text::AbstractString;
+        style::AbstractStyle = DefaultStyle(),
         indent::Int = 4,
         margin::Int = 92,
-        style::AbstractStyle = DefaultStyle(),
         always_for_in::Bool = false,
         whitespace_typedefs::Bool = false,
         whitespace_ops_in_indices::Bool = false,
@@ -242,47 +243,13 @@ Markdown is formatted with [`CommonMark`](https://github.com/MichaelHatherly/Com
 
 See `Custom Alignment` documentation.
 """
-function format_text(
-    text::AbstractString;
-    indent::Int = 4,
-    margin::Int = 92,
-    style::AbstractStyle = DefaultStyle(),
-    always_for_in::Bool = false,
-    whitespace_typedefs::Bool = false,
-    whitespace_ops_in_indices::Bool = false,
-    remove_extra_newlines::Bool = false,
-    import_to_using::Bool = false,
-    pipe_to_function_call::Bool = false,
-    short_to_long_function_def::Bool = false,
-    always_use_return::Bool = false,
-    whitespace_in_kwargs::Bool = true,
-    annotate_untyped_fields_with_any::Bool = true,
-    format_docstrings::Bool = false,
-    align_struct_field::Bool = false,
-    align_conditional::Bool = false,
-    align_assignment::Bool = false,
-    align_pair_arrow::Bool = false,
-)
+function format_text(text::AbstractString; style::AbstractStyle=DefaultStyle(), kwargs...)
+    return format_text(text, style; kwargs...)
+end
+
+function format_text(text::AbstractString, style::AbstractStyle; kwargs...)
     isempty(text) && return text
-    opts = Options(
-        indent_size = indent,
-        max_margin = margin,
-        always_for_in = always_for_in,
-        whitespace_typedefs = whitespace_typedefs,
-        whitespace_ops_in_indices = whitespace_ops_in_indices,
-        remove_extra_newlines = remove_extra_newlines,
-        import_to_using = import_to_using,
-        pipe_to_function_call = pipe_to_function_call,
-        short_to_long_function_def = short_to_long_function_def,
-        always_use_return = always_use_return,
-        whitespace_in_kwargs = whitespace_in_kwargs,
-        annotate_untyped_fields_with_any = annotate_untyped_fields_with_any,
-        format_docstrings = format_docstrings,
-        align_struct_field = align_struct_field,
-        align_conditional = align_conditional,
-        align_assignment = align_assignment,
-        align_pair_arrow = align_pair_arrow,
-    )
+    opts = Options(; merge(options(style), kwargs)...)
     return format_text(text, style, opts)
 end
 

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -21,6 +21,8 @@ export format, format_text, format_file, format_md, DefaultStyle, YASStyle, Blue
 
 abstract type AbstractStyle end
 
+@inline options(s::AbstractStyle) = NamedTuple()
+
 """
     DefaultStyle
 
@@ -33,7 +35,27 @@ end
 DefaultStyle() = DefaultStyle(nothing)
 
 @inline getstyle(s::DefaultStyle) = s.innerstyle === nothing ? s : s.innerstyle
-@inline options(s::DefaultStyle) = NamedTuple()
+function options(s::DefaultStyle)
+    return (;
+        indent = 4,
+        margin = 92,
+        always_for_in = false,
+        whitespace_typedefs = false,
+        whitespace_ops_in_indices = false,
+        remove_extra_newlines = false,
+        import_to_using = false,
+        pipe_to_function_call = false,
+        short_to_long_function_def = false,
+        always_use_return = false,
+        whitespace_in_kwargs = true,
+        annotate_untyped_fields_with_any = true,
+        format_docstrings = false,
+        align_struct_field = false,
+        align_assignment = false,
+        align_conditional = false,
+        align_pair_arrow = false,
+    )
+end
 
 include("document.jl")
 include("options.jl")

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -265,7 +265,7 @@ Markdown is formatted with [`CommonMark`](https://github.com/MichaelHatherly/Com
 
 See `Custom Alignment` documentation.
 """
-function format_text(text::AbstractString; style::AbstractStyle=DefaultStyle(), kwargs...)
+function format_text(text::AbstractString; style::AbstractStyle = DefaultStyle(), kwargs...)
     return format_text(text, style; kwargs...)
 end
 

--- a/src/markdown.jl
+++ b/src/markdown.jl
@@ -73,5 +73,5 @@ end
     format_md(text::AbstractString, style::AbstractStyle; options...)::String
 """
 function format_md(text::AbstractString, style::AbstractStyle; options...)
-    return format_md(text; style=style, options...)
+    return format_md(text; style = style, options...)
 end

--- a/src/markdown.jl
+++ b/src/markdown.jl
@@ -68,3 +68,10 @@ function format_md(
     ))
     return formatted
 end
+
+"""
+    format_md(text::AbstractString, style::AbstractStyle; options...)::String
+"""
+function format_md(text::AbstractString, style::AbstractStyle; options...)
+    return format_md(text; style=style, options...)
+end

--- a/src/markdown.jl
+++ b/src/markdown.jl
@@ -40,8 +40,8 @@ function format_md(
 )
     isempty(text) && return text
     opts = Options(
-        indent_size = indent,
-        max_margin = margin,
+        indent = indent,
+        margin = margin,
         always_for_in = always_for_in,
         whitespace_typedefs = whitespace_typedefs,
         whitespace_ops_in_indices = whitespace_ops_in_indices,

--- a/src/nest_utils.jl
+++ b/src/nest_utils.jl
@@ -75,7 +75,7 @@ function dedent!(fst::FST, s::State)
     if is_leaf(fst)
         s.line_offset += length(fst)
         if is_closer(fst) || fst.typ === NOTCODE
-            fst.indent -= s.opts.indent_size
+            fst.indent -= s.opts.indent
         end
         return
     elseif fst.typ === CSTParser.StringH
@@ -83,7 +83,7 @@ function dedent!(fst::FST, s::State)
     end
 
     # dedent
-    fst.indent -= s.opts.indent_size
+    fst.indent -= s.opts.indent
 
     # only unnest if it's allowed
     can_nest(fst) || return
@@ -91,7 +91,7 @@ function dedent!(fst::FST, s::State)
     nl_inds = findall(n -> n.typ === NEWLINE && can_nest(n), fst.nodes)
     length(nl_inds) > 0 || return
     margin = s.line_offset + fst.extra_margin + length(fst)
-    margin <= s.opts.max_margin || return
+    margin <= s.opts.margin || return
     unnest!(fst, nl_inds)
 end
 
@@ -125,7 +125,7 @@ function nest_if_over_margin!(
         margin += sum(length.(fst[idx:stop_idx-1]))
     end
 
-    if margin > s.opts.max_margin || is_comment(fst[idx+1]) || is_comment(fst[idx-1])
+    if margin > s.opts.margin || is_comment(fst[idx+1]) || is_comment(fst[idx-1])
         fst[idx] = Newline(length = fst[idx].len)
         s.line_offset = fst.indent
     else

--- a/src/options.jl
+++ b/src/options.jl
@@ -1,6 +1,6 @@
 Base.@kwdef struct Options
-    indent_size::Int = 4
-    max_margin::Int = 92
+    indent::Int = 4
+    margin::Int = 92
     always_for_in::Bool = false
     whitespace_typedefs::Bool = false
     whitespace_ops_in_indices::Bool = false

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -235,8 +235,8 @@ function short_to_long_function_def!(fst::FST, s::State)
 
         # body
         s.opts.always_use_return && prepend_return!(fst[end], s)
-        add_node!(funcdef, fst[end], s, max_padding = s.opts.indent_size)
-        add_indent!(funcdef[end], s, s.opts.indent_size)
+        add_node!(funcdef, fst[end], s, max_padding = s.opts.indent)
+        add_indent!(funcdef[end], s, s.opts.indent)
 
         # end
         kw = FST(CSTParser.KEYWORD, -1, fst[end].startline, fst[end].endline, "end")
@@ -264,8 +264,8 @@ function short_to_long_function_def!(fst::FST, s::State)
 
         # body
         s.opts.always_use_return && prepend_return!(fst[end], s)
-        add_node!(funcdef, fst[end], s, max_padding = s.opts.indent_size)
-        add_indent!(funcdef[end], s, s.opts.indent_size)
+        add_node!(funcdef, fst[end], s, max_padding = s.opts.indent)
+        add_indent!(funcdef[end], s, s.opts.indent)
 
         # end
         kw = FST(CSTParser.KEYWORD, -1, fst[end].startline, fst[end].endline, "end")

--- a/src/print.jl
+++ b/src/print.jl
@@ -25,7 +25,7 @@ function format_check(io::IOBuffer, fst::FST, s::State)
         deleteat!(s.doc.format_skips, 1)
         s.on = true
         # change the startline, otherwise lines
-        # prior to in the NOTCODE node prior to 
+        # prior to in the NOTCODE node prior to
         # "format: on" will be reprinted
         fst.startline = skip[2]
         print_notcode(io, fst, s, fmttag = true)
@@ -69,7 +69,7 @@ function print_tree(
             if notcode_indent > -1
                 n.indent = notcode_indent
             elseif i + 1 < length(nodes) && is_end(nodes[i+2])
-                n.indent += s.opts.indent_size
+                n.indent += s.opts.indent
             elseif i + 1 < length(nodes) && (
                 nodes[i+2].typ === CSTParser.Block || nodes[i+2].typ === CSTParser.Begin
             )

--- a/src/styles/blue/nest.jl
+++ b/src/styles/blue/nest.jl
@@ -4,23 +4,23 @@ function n_tupleh!(bs::BlueStyle, fst::FST, s::State)
     fidx = findfirst(n -> n.typ === PLACEHOLDER, fst.nodes)
     opener = findfirst(is_opener, fst.nodes) !== nothing
 
-    if lidx !== nothing && (line_margin > s.opts.max_margin || must_nest(fst))
+    if lidx !== nothing && (line_margin > s.opts.margin || must_nest(fst))
         fidx = findfirst(n -> n.typ === PLACEHOLDER, fst.nodes)
         args_range = fidx+1:lidx-1
         args_margin = sum(length.(fst[args_range]))
 
         nest_to_oneline =
-            (fst.indent + s.opts.indent_size + args_margin <= s.opts.max_margin) &&
+            (fst.indent + s.opts.indent + args_margin <= s.opts.margin) &&
             !contains_comment(fst.nodes[args_range])
 
-        # @info "" nest_to_oneline fst.indent fst.indent + s.opts.indent_size + args_margin args_margin
+        # @info "" nest_to_oneline fst.indent fst.indent + s.opts.indent + args_margin args_margin
 
         line_offset = s.line_offset
         if opener
             fst[end].indent = fst.indent
         end
         if fst.typ !== CSTParser.TupleH || opener
-            fst.indent += s.opts.indent_size
+            fst.indent += s.opts.indent
         end
 
         for (i, n) in enumerate(fst.nodes)

--- a/src/styles/blue/pretty.jl
+++ b/src/styles/blue/pretty.jl
@@ -6,8 +6,7 @@
 Formatting style based on https://github.com/invenia/BlueStyle
 and https://github.com/domluna/JuliaFormatter.jl/issues/283
 
-Recommended options are:
-
+Configurable options with different defaults to [`DefaultStyle`](@ref) are:
 - `always_use_return` = true
 - `short_to_long_function_def` = true
 - `whitespace_ops_in_indices` = true
@@ -20,6 +19,20 @@ Recommended options are:
 """
 struct BlueStyle <: AbstractStyle end
 @inline getstyle(s::BlueStyle) = s
+
+function options(style::BlueStyle)
+    return (;
+        always_use_return = true,
+        short_to_long_function_def = true,
+        whitespace_ops_in_indices = true,
+        remove_extra_newlines = true,
+        always_for_in = true,
+        import_to_using = true,
+        pipe_to_function_call = true,
+        whitespace_in_kwargs = false,
+        annotate_untyped_fields_with_any = false,
+    )
+end
 
 function nestable(::BlueStyle, cst::CSTParser.EXPR)
     is_assignment(cst) && is_iterable(cst[end]) && return false

--- a/src/styles/blue/pretty.jl
+++ b/src/styles/blue/pretty.jl
@@ -1,10 +1,12 @@
 """
     BlueStyle()
 
-> This style is a WIP/Experimental
+Formatting style based on [BlueStyle](https://github.com/invenia/BlueStyle)
+and [JuliaFormatter#283](https://github.com/domluna/JuliaFormatter.jl/issues/283).
 
-Formatting style based on https://github.com/invenia/BlueStyle
-and https://github.com/domluna/JuliaFormatter.jl/issues/283
+!!! note
+    This style is still work-in-progress, and does not yet implement all of the
+    BlueStyle guide.
 
 Configurable options with different defaults to [`DefaultStyle`](@ref) are:
 - `always_use_return` = true

--- a/src/styles/blue/pretty.jl
+++ b/src/styles/blue/pretty.jl
@@ -49,10 +49,10 @@ function p_do(style::BlueStyle, cst::CSTParser.EXPR, s::State)
         add_node!(t, pretty(style, cst[3], s), s, join_lines = true)
     end
     if cst[4].typ === CSTParser.Block
-        s.indent += s.opts.indent_size
+        s.indent += s.opts.indent
         n = pretty(style, cst[4], s, ignore_single_line = true)
-        add_node!(t, n, s, max_padding = s.opts.indent_size)
-        s.indent -= s.opts.indent_size
+        add_node!(t, n, s, max_padding = s.opts.indent)
+        s.indent -= s.opts.indent
     end
     add_node!(t, pretty(style, cst.args[end], s), s)
     t
@@ -187,7 +187,7 @@ function p_binaryopcall(
     end
 
     if nest
-        # for indent, will be converted to `indent_size` if needed
+        # for indent, will be converted to `indent` if needed
         insert!(t.nodes, length(t.nodes), Placeholder(0))
     end
 

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -394,8 +394,7 @@ function n_whereopcall!(ds::DefaultStyle, fst::FST, s::State)
             fst[end].indent = fst.indent
         end
 
-        over =
-            (s.line_offset + Blen + fst.extra_margin > s.opts.margin) || must_nest(fst)
+        over = (s.line_offset + Blen + fst.extra_margin > s.opts.margin) || must_nest(fst)
         fst.indent += s.opts.indent
         for (i, n) in enumerate(fst[2:end])
             if n.typ === NEWLINE

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -736,11 +736,11 @@ function p_functiondef(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
             add_node!(t, Whitespace(1), s)
             add_node!(t, pretty(style, cst[4], s), s, join_lines = true)
         else
-            s.indent += s.opts.indent_size
+            s.indent += s.opts.indent
             n = pretty(style, cst[3], s, ignore_single_line = true)
             s.opts.always_use_return && prepend_return!(n, s)
-            add_node!(t, n, s, max_padding = s.opts.indent_size)
-            s.indent -= s.opts.indent_size
+            add_node!(t, n, s, max_padding = s.opts.indent)
+            s.indent -= s.opts.indent
             add_node!(t, pretty(style, cst[4], s), s)
         end
     else
@@ -769,13 +769,13 @@ function p_struct(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
         add_node!(t, Whitespace(1), s)
         add_node!(t, pretty(style, cst[4], s), s, join_lines = true)
     else
-        s.indent += s.opts.indent_size
+        s.indent += s.opts.indent
         n = pretty(style, cst[3], s, ignore_single_line = true)
         if s.opts.annotate_untyped_fields_with_any
             annotate_typefields_with_any!(n, s)
         end
-        add_node!(t, n, s, max_padding = s.opts.indent_size)
-        s.indent -= s.opts.indent_size
+        add_node!(t, n, s, max_padding = s.opts.indent)
+        s.indent -= s.opts.indent
         add_node!(t, pretty(style, cst[4], s), s)
     end
     t
@@ -796,13 +796,13 @@ function p_mutable(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
         add_node!(t, Whitespace(1), s)
         add_node!(t, pretty(style, cst[5], s), s, join_lines = true)
     else
-        s.indent += s.opts.indent_size
+        s.indent += s.opts.indent
         n = pretty(style, cst[4], s, ignore_single_line = true)
         if s.opts.annotate_untyped_fields_with_any
             annotate_typefields_with_any!(n, s)
         end
-        add_node!(t, n, s, max_padding = s.opts.indent_size)
-        s.indent -= s.opts.indent_size
+        add_node!(t, n, s, max_padding = s.opts.indent)
+        s.indent -= s.opts.indent
         add_node!(t, pretty(style, cst[5], s), s)
     end
     t
@@ -875,7 +875,7 @@ function p_toplevel(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
             s.offset += a.fullspan
             continue
         end
-        add_node!(t, pretty(style, a, s), s, max_padding = s.opts.indent_size)
+        add_node!(t, pretty(style, a, s), s, max_padding = s.opts.indent)
         add_node!(t, Semicolon(), s)
     end
     t
@@ -892,14 +892,14 @@ function p_begin(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
         add_node!(t, Whitespace(1), s)
         add_node!(t, pretty(style, cst[3], s), s, join_lines = true)
     else
-        s.indent += s.opts.indent_size
+        s.indent += s.opts.indent
         add_node!(
             t,
             pretty(style, cst[2], s, ignore_single_line = true),
             s,
-            max_padding = s.opts.indent_size,
+            max_padding = s.opts.indent,
         )
-        s.indent -= s.opts.indent_size
+        s.indent -= s.opts.indent
         add_node!(t, pretty(style, cst[3], s), s)
     end
     t
@@ -917,14 +917,14 @@ function p_quote(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
             add_node!(t, Whitespace(1), s)
             add_node!(t, pretty(style, cst[3], s), s, join_lines = true)
         else
-            s.indent += s.opts.indent_size
+            s.indent += s.opts.indent
             add_node!(
                 t,
                 pretty(style, cst[2], s, ignore_single_line = true),
                 s,
-                max_padding = s.opts.indent_size,
+                max_padding = s.opts.indent,
             )
-            s.indent -= s.opts.indent_size
+            s.indent -= s.opts.indent
             add_node!(t, pretty(style, cst[3], s), s)
         end
     else
@@ -954,23 +954,23 @@ function p_let(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
     add_node!(t, pretty(style, cst[1], s), s)
     if length(cst.args) > 3
         add_node!(t, Whitespace(1), s)
-        s.indent += s.opts.indent_size
+        s.indent += s.opts.indent
         if cst[2].typ === CSTParser.Block
             add_node!(t, pretty(style, cst[2], s, join_body = true), s, join_lines = true)
         else
             add_node!(t, pretty(style, cst[2], s), s, join_lines = true)
         end
-        s.indent -= s.opts.indent_size
+        s.indent -= s.opts.indent
 
         idx = length(t.nodes)
-        s.indent += s.opts.indent_size
+        s.indent += s.opts.indent
         add_node!(
             t,
             pretty(style, cst[3], s, ignore_single_line = true),
             s,
-            max_padding = s.opts.indent_size,
+            max_padding = s.opts.indent,
         )
-        s.indent -= s.opts.indent_size
+        s.indent -= s.opts.indent
         # Possible newline after args if nested to act as a separator
         # to the block body.
         if cst[2].typ === CSTParser.Block && t.nodes[end-2].typ !== NOTCODE
@@ -978,9 +978,9 @@ function p_let(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
         end
         add_node!(t, pretty(style, cst.args[end], s), s)
     else
-        s.indent += s.opts.indent_size
+        s.indent += s.opts.indent
         add_node!(t, pretty(style, cst[2], s, ignore_single_line = true), s)
-        s.indent -= s.opts.indent_size
+        s.indent -= s.opts.indent
         add_node!(t, pretty(style, cst.args[end], s), s)
     end
     t
@@ -1064,9 +1064,9 @@ function p_for(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
     # end
 
     n = if cst[2].typ === CSTParser.Block
-        s.indent += s.opts.indent_size
+        s.indent += s.opts.indent
         n = pretty(style, cst[2], s, join_body = true)
-        s.indent -= s.opts.indent_size
+        s.indent -= s.opts.indent
         n
     else
         n = pretty(style, cst[2], s)
@@ -1076,14 +1076,14 @@ function p_for(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
     add_node!(t, n, s, join_lines = true)
 
     idx = length(t.nodes)
-    s.indent += s.opts.indent_size
+    s.indent += s.opts.indent
     add_node!(
         t,
         pretty(style, cst[3], s, ignore_single_line = true),
         s,
-        max_padding = s.opts.indent_size,
+        max_padding = s.opts.indent,
     )
-    s.indent -= s.opts.indent_size
+    s.indent -= s.opts.indent
 
     # Possible newline after args if nested to act as a separator
     # to the block body.
@@ -1112,11 +1112,11 @@ function p_do(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
         add_node!(t, pretty(style, cst[3], s), s, join_lines = true)
     end
     if cst[4].typ === CSTParser.Block
-        s.indent += s.opts.indent_size
+        s.indent += s.opts.indent
         n = pretty(style, cst[4], s, ignore_single_line = true)
         s.opts.always_use_return && prepend_return!(n, s)
-        add_node!(t, n, s, max_padding = s.opts.indent_size)
-        s.indent -= s.opts.indent_size
+        add_node!(t, n, s, max_padding = s.opts.indent)
+        s.indent -= s.opts.indent
     end
     add_node!(t, pretty(style, cst.args[end], s), s)
     t
@@ -1133,14 +1133,14 @@ function p_try(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
         elseif a.typ === CSTParser.KEYWORD
             add_node!(t, pretty(style, a, s), s, max_padding = 0)
         elseif a.typ === CSTParser.Block
-            s.indent += s.opts.indent_size
+            s.indent += s.opts.indent
             add_node!(
                 t,
                 pretty(style, a, s, ignore_single_line = true),
                 s,
-                max_padding = s.opts.indent_size,
+                max_padding = s.opts.indent,
             )
-            s.indent -= s.opts.indent_size
+            s.indent -= s.opts.indent
         else
             len = length(t)
             add_node!(t, Whitespace(1), s)
@@ -1163,14 +1163,14 @@ function p_if(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
         add_node!(t, pretty(style, cst[1], s), s)
         add_node!(t, Whitespace(1), s)
         add_node!(t, pretty(style, cst[2], s), s, join_lines = true)
-        s.indent += s.opts.indent_size
+        s.indent += s.opts.indent
         add_node!(
             t,
             pretty(style, cst[3], s, ignore_single_line = true),
             s,
-            max_padding = s.opts.indent_size,
+            max_padding = s.opts.indent,
         )
-        s.indent -= s.opts.indent_size
+        s.indent -= s.opts.indent
 
         len = length(t)
         if length(cst.args) > 4
@@ -1183,14 +1183,14 @@ function p_if(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
                 t.len = max(len, length(n))
             else
                 # ELSE KEYWORD
-                s.indent += s.opts.indent_size
+                s.indent += s.opts.indent
                 add_node!(
                     t,
                     pretty(style, cst[5], s, ignore_single_line = true),
                     s,
-                    max_padding = s.opts.indent_size,
+                    max_padding = s.opts.indent,
                 )
-                s.indent -= s.opts.indent_size
+                s.indent -= s.opts.indent
             end
         end
         # END KEYWORD
@@ -1200,14 +1200,14 @@ function p_if(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
         t.len += 7
         add_node!(t, pretty(style, cst[1], s), s)
 
-        s.indent += s.opts.indent_size
+        s.indent += s.opts.indent
         add_node!(
             t,
             pretty(style, cst[2], s, ignore_single_line = true),
             s,
-            max_padding = s.opts.indent_size,
+            max_padding = s.opts.indent,
         )
-        s.indent -= s.opts.indent_size
+        s.indent -= s.opts.indent
 
         len = length(t)
         if length(cst.args) > 2
@@ -1221,14 +1221,14 @@ function p_if(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
                 # "elseif n"
                 t.len = max(len, length(n))
             else
-                s.indent += s.opts.indent_size
+                s.indent += s.opts.indent
                 add_node!(
                     t,
                     pretty(style, cst[4], s, ignore_single_line = true),
                     s,
-                    max_padding = s.opts.indent_size,
+                    max_padding = s.opts.indent,
                 )
-                s.indent -= s.opts.indent_size
+                s.indent -= s.opts.indent
             end
         end
     end
@@ -1449,7 +1449,7 @@ function p_binaryopcall(
     end
 
     if nest
-        # for indent, will be converted to `indent_size` if needed
+        # for indent, will be converted to `indent` if needed
         insert!(t.nodes, length(t.nodes), Placeholder(0))
     end
 
@@ -1491,12 +1491,12 @@ function p_whereopcall(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
         if is_opener(a) && nest
             add_node!(t, pretty(style, a, s), s, join_lines = true)
             add_node!(t, Placeholder(0), s)
-            s.indent += s.opts.indent_size
+            s.indent += s.opts.indent
         elseif is_closer(a) && nest
             add_node!(t, TrailingComma(), s)
             add_node!(t, Placeholder(0), s)
             add_node!(t, pretty(style, a, s), s, join_lines = true)
-            s.indent -= s.opts.indent_size
+            s.indent -= s.opts.indent
         elseif CSTParser.is_comma(a) && !is_punc(cst[i+3])
             add_node!(t, pretty(style, a, s), s, join_lines = true)
             add_node!(t, Placeholder(nws), s)

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -1,8 +1,8 @@
 """
     YASStyle()
 
-gormatting style based on https://github.com/jrevels/YASGuide
-and https://github.com/domluna/JuliaFormatter.jl/issues/198.
+Formatting style based on [YASGuide](https://github.com/jrevels/YASGuide)
+and [JuliaFormatter#198](https://github.com/domluna/JuliaFormatter.jl/issues/198).
 
 Configurable options with different defaults to [`DefaultStyle`](@ref) are:
 - `always_for_in` = true

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -1,23 +1,34 @@
 """
     YASStyle()
 
-Formatting style based on https://github.com/jrevels/YASGuide
+gormatting style based on https://github.com/jrevels/YASGuide
 and https://github.com/domluna/JuliaFormatter.jl/issues/198.
 
-Recommended options are:
-
-  - `always_for_in` = true
-  - `whitespace_ops_in_indices` = true
-  - `whitespace_typedefs` = false
-  - `remove_extra_newlines` = true
-  - `import_to_using` = true
-  - `pipe_to_function_call` = true
-  - `short_to_long_function_def` = true
-  - `always_use_return` = true
-  - `whitespace_in_kwargs` = false
+Configurable options with different defaults to [`DefaultStyle`](@ref) are:
+- `always_for_in` = true
+- `whitespace_ops_in_indices` = true
+- `remove_extra_newlines` = true
+- `import_to_using` = true
+- `pipe_to_function_call` = true
+- `short_to_long_function_def` = true
+- `always_use_return` = true
+- `whitespace_in_kwargs` = false
 """
 struct YASStyle <: AbstractStyle end
 @inline getstyle(s::YASStyle) = s
+
+function options(style::YASStyle)
+    return (;
+        always_for_in = true,
+        whitespace_ops_in_indices = true,
+        remove_extra_newlines = true,
+        import_to_using = true,
+        pipe_to_function_call = true,
+        short_to_long_function_def = true,
+        always_use_return = true,
+        whitespace_in_kwargs = false,
+    )
+end
 
 function nestable(::YASStyle, cst::CSTParser.EXPR)
     (CSTParser.defines_function(cst) || nest_assignment(cst)) && return false

--- a/test/blue_style.jl
+++ b/test/blue_style.jl
@@ -151,11 +151,11 @@
 
     @testset "separate kw args with semicolon" begin
         str_ = "xy = f(x, y=3)"
-        str = "xy = f(x; y=3)"
+        str = "xy = f(x; y = 3)"
         @test fmt(str_, style = BlueStyle()) == str
 
         str_ = "xy = f(x=1, y=2)"
-        str = "xy = f(; x=1, y=2)"
+        str = "xy = f(; x = 1, y = 2)"
         @test fmt1(str_, style = BlueStyle()) == str
         @test fmt(str_, style = BlueStyle()) == str
         @test fmt(str, style = BlueStyle()) == str
@@ -165,14 +165,14 @@
         @test fmt(str_, style = BlueStyle()) == str
 
         str = """
-        function g(x, y=1)
+        function g(x, y = 1)
             return x + y
         end
-        macro h(x, y=1)
-            return nothing
+        macro h(x, y = 1)
+            nothing
         end
-        shortdef1(MatrixT, VectorT=nothing) = nothing
-        shortdef2(MatrixT, VectorT=nothing) where {T} = nothing
+        shortdef1(MatrixT, VectorT = nothing) = nothing
+        shortdef2(MatrixT, VectorT = nothing) where {T} = nothing
         """
         @test fmt1(str, style = BlueStyle()) == str
         @test fmt(str, style = BlueStyle()) == str

--- a/test/blue_style.jl
+++ b/test/blue_style.jl
@@ -1,8 +1,8 @@
 @testset "Blue Style" begin
     @testset "ops" begin
         # `//` and `^` are binary ops without whitespace around them
-        @test fmt("1 // 2 + 3 ^ 4", style = BlueStyle()) == "1//2 + 3^4"
-        @test fmt("a.//10", style = BlueStyle()) == "a .// 10"
+        @test bluefmt("1 // 2 + 3 ^ 4") == "1//2 + 3^4"
+        @test bluefmt("a.//10") == "a .// 10"
     end
 
     @testset "nest to one line" begin
@@ -16,7 +16,7 @@
             arg2,
         ]
         """
-        @test fmt(str_, style = BlueStyle()) == str
+        @test bluefmt(str_) == str
 
         str_ = """
         var = (arg1,
@@ -25,7 +25,7 @@
         str = """
         var = (arg1, arg2)
         """
-        @test fmt(str_, 4, 18, style = BlueStyle()) == str
+        @test bluefmt(str_, 4, 18) == str
 
         str_ = """
         var = {arg1,
@@ -36,8 +36,8 @@
             arg1, arg2
         }
         """
-        @test fmt(str_, 4, 17, style = BlueStyle()) == str
-        @test fmt(str_, 4, 14, style = BlueStyle()) == str
+        @test bluefmt(str_, 4, 17) == str
+        @test bluefmt(str_, 4, 14) == str
 
         str_ = """
         var = call(arg1,
@@ -48,7 +48,7 @@
             arg1, arg2
         )
         """
-        @test fmt(str_, 4, 14, style = BlueStyle()) == str
+        @test bluefmt(str_, 4, 14) == str
 
         str = """
         var = call(
@@ -56,7 +56,7 @@
             arg2,
         )
         """
-        @test fmt(str_, 4, 13, style = BlueStyle()) == str
+        @test bluefmt(str_, 4, 13) == str
 
         str_ = """
         var = ref[arg1,
@@ -67,7 +67,7 @@
             arg1, arg2
         ]
         """
-        @test fmt(str_, 4, 14, style = BlueStyle()) == str
+        @test bluefmt(str_, 4, 14) == str
 
         str = """
         var = ref[
@@ -75,7 +75,7 @@
             arg2,
         ]
         """
-        @test fmt(str_, 4, 13, style = BlueStyle()) == str
+        @test bluefmt(str_, 4, 13) == str
 
         str_ = """
         var = ABC{arg1,
@@ -86,7 +86,7 @@
             arg1,arg2
         }
         """
-        @test fmt(str_, 4, 13, style = BlueStyle()) == str
+        @test bluefmt(str_, 4, 13) == str
 
         str = """
         var = ABC{
@@ -94,7 +94,7 @@
             arg2,
         }
         """
-        @test fmt(str_, 4, 12, style = BlueStyle()) == str
+        @test bluefmt(str_, 4, 12) == str
 
         str_ = """
         var = @call(arg1,
@@ -105,7 +105,7 @@
             arg1, arg2
         )
         """
-        @test fmt(str_, 4, 14, style = BlueStyle()) == str
+        @test bluefmt(str_, 4, 14) == str
 
         str = """
         var = @call(
@@ -113,7 +113,7 @@
             arg2
         )
         """
-        @test fmt(str_, 4, 13, style = BlueStyle()) == str
+        @test bluefmt(str_, 4, 13) == str
 
         str_ = """
         function long_name_of_function_because_i_am_writing_an_example(
@@ -122,7 +122,7 @@
             # code
         end
         """
-        @test fmt(str_, 4, 38, style = BlueStyle()) == str_
+        @test bluefmt(str_, 4, 38) == str_
 
         str = """
         function long_name_of_function_because_i_am_writing_an_example(
@@ -136,7 +136,7 @@
             # code
         end
         """
-        @test fmt(str_, 4, 37, style = BlueStyle()) == str
+        @test bluefmt(str_, 4, 37) == str
 
     end
 
@@ -146,23 +146,23 @@
             expr1
             expr2
         end"""
-        @test fmt(str, style = BlueStyle(), always_use_return = true) == str
+        @test bluefmt(str, always_use_return = true) == str
     end
 
     @testset "separate kw args with semicolon" begin
         str_ = "xy = f(x, y=3)"
         str = "xy = f(x; y = 3)"
-        @test fmt(str_, style = BlueStyle()) == str
+        @test bluefmt(str_) == str
 
         str_ = "xy = f(x=1, y=2)"
         str = "xy = f(; x = 1, y = 2)"
-        @test fmt1(str_, style = BlueStyle()) == str
-        @test fmt(str_, style = BlueStyle()) == str
-        @test fmt(str, style = BlueStyle()) == str
+        @test bluefmt1(str_) == str
+        @test bluefmt(str_) == str
+        @test bluefmt(str) == str
 
         str_ = "xy = f(x=1; y=2)"
-        @test fmt1(str_, style = BlueStyle()) == str
-        @test fmt(str_, style = BlueStyle()) == str
+        @test bluefmt1(str_) == str
+        @test bluefmt(str_) == str
 
         str = """
         function g(x, y = 1)
@@ -174,7 +174,7 @@
         shortdef1(MatrixT, VectorT = nothing) = nothing
         shortdef2(MatrixT, VectorT = nothing) where {T} = nothing
         """
-        @test fmt1(str, style = BlueStyle()) == str
-        @test fmt(str, style = BlueStyle()) == str
+        @test bluefmt1(str) == str
+        @test bluefmt(str) == str
     end
 end

--- a/test/blue_style.jl
+++ b/test/blue_style.jl
@@ -151,11 +151,11 @@
 
     @testset "separate kw args with semicolon" begin
         str_ = "xy = f(x, y=3)"
-        str = "xy = f(x; y = 3)"
+        str = "xy = f(x; y=3)"
         @test fmt(str_, style = BlueStyle()) == str
 
         str_ = "xy = f(x=1, y=2)"
-        str = "xy = f(; x = 1, y = 2)"
+        str = "xy = f(; x=1, y=2)"
         @test fmt1(str_, style = BlueStyle()) == str
         @test fmt(str_, style = BlueStyle()) == str
         @test fmt(str, style = BlueStyle()) == str
@@ -165,14 +165,14 @@
         @test fmt(str_, style = BlueStyle()) == str
 
         str = """
-        function g(x, y = 1)
+        function g(x, y=1)
             return x + y
         end
-        macro h(x, y = 1)
-            nothing
+        macro h(x, y=1)
+            return nothing
         end
-        shortdef1(MatrixT, VectorT = nothing) = nothing
-        shortdef2(MatrixT, VectorT = nothing) where {T} = nothing
+        shortdef1(MatrixT, VectorT=nothing) = nothing
+        shortdef2(MatrixT, VectorT=nothing) where {T} = nothing
         """
         @test fmt1(str, style = BlueStyle()) == str
         @test fmt(str, style = BlueStyle()) == str

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1,0 +1,31 @@
+function test_format(fmt, before, after)
+    sandbox_dir = joinpath(@__DIR__, "tmp")
+    mkdir(sandbox_dir)
+    try
+        code_path = joinpath(sandbox_dir, "code.jl")
+        open(io -> write(io, before), code_path, "w")
+
+        @test fmt(code_path) == false
+        @test strip(read(code_path, String)) == after
+    finally
+        rm(sandbox_dir; recursive = true)
+    end
+end
+
+@testset "$f interface" for f in (format, format_file)
+    before = "foo(; k =v)"
+    @testset "style can be positional arg or keyword" begin
+        pos = path -> f(path, BlueStyle())
+        key = path -> f(path; style = BlueStyle())
+        after = "foo(; k=v)"
+        test_format(pos, before, after)
+        test_format(key, before, after)
+    end
+    @testset "other keywords take affect" begin
+        pos = path -> f(path, BlueStyle(); whitespace_in_kwargs = true)
+        key = path -> f(path; style = BlueStyle(), whitespace_in_kwargs = true)
+        after = "foo(; k = v)"
+        test_format(pos, before, after)
+        test_format(key, before, after)
+    end
+end

--- a/test/options.jl
+++ b/test/options.jl
@@ -109,7 +109,7 @@
         using .B: B
         using ...C: C"""
         @test fmt(str_, import_to_using = true) == str
-        t = run_pretty(str_, opts = Options(max_margin = 80, import_to_using = true))
+        t = run_pretty(str_, opts = Options(margin = 80, import_to_using = true))
         @test t.len == 13
 
         # #232
@@ -385,7 +385,7 @@
 
         t = run_pretty(
             str_,
-            opts = Options(max_margin = 80, annotate_untyped_fields_with_any = false),
+            opts = Options(margin = 80, annotate_untyped_fields_with_any = false),
         )
         @test length(t) == 11
 
@@ -414,7 +414,7 @@
 
         t = run_pretty(
             str_,
-            opts = Options(max_margin = 80, annotate_untyped_fields_with_any = false),
+            opts = Options(margin = 80, annotate_untyped_fields_with_any = false),
         )
         @test length(t) == 23
     end
@@ -747,7 +747,7 @@
         str_ = """
         Base.@kwdef struct Options
             indent_size::Int                       = 4
-            max_margin::Int                        = 92
+            margin::Int                            = 92
             always_for_in::Bool                 = false
             whitespace_typedefs::Bool          = false
             whitespace_ops_in_indices::Bool        = false
@@ -769,7 +769,7 @@
         str = """
         Base.@kwdef struct Options
             indent_size::Int                       = 4
-            max_margin::Int                        = 92
+            margin::Int                            = 92
             always_for_in::Bool                    = false
             whitespace_typedefs::Bool              = false
             whitespace_ops_in_indices::Bool        = false
@@ -793,7 +793,7 @@
         str_ = """
         Base.@kwdef struct Options
             indent_size::Int = 4
-            max_margin::Int = 92
+            margin::Int = 92
             always_for_in::Bool = false
             whitespace_typedefs::Bool = false
             whitespace_ops_in_indices::Bool = false
@@ -818,7 +818,7 @@
         str = """
         Base.@kwdef struct Options
             indent_size::Int                       = 4
-            max_margin::Int                        = 92
+            margin::Int                            = 92
             always_for_in::Bool                    = false
             whitespace_typedefs::Bool              = false
             whitespace_ops_in_indices::Bool        = false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,11 +34,15 @@ function run_nest(text::String; opts = Options(), style = DefaultStyle())
 end
 run_nest(text::String, margin::Int) = run_nest(text, opts = Options(margin = margin))
 
-function yasfmt(s, i, m; kwargs...)
+function fmt(str, i, m; kwargs...)
     # use DefaultStyle options to make writing tests easier
     kws = merge(options(DefaultStyle()), kwargs)
-    return fmt(s; kws..., i = i, m = m, style = YASStyle())
+    return fmt(str; kws..., i = i, m = m)
 end
+
+yasfmt(str, i, m; kwargs...) = fmt(str, i, m; style = YASStyle(), kwargs...)
+bluefmt(str, i = 4, m = 80; kwargs...) = fmt(str, i, m; style = BlueStyle(), kwargs...)
+bluefmt1(str) = fmt1(str; style = BlueStyle(), options(DefaultStyle())...)
 
 @testset "JuliaFormatter" begin
     include("default_style.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,10 +39,12 @@ run_nest(text::String, margin::Int) =
 yasfmt1(s, i, m; kwargs...) = fmt1(s; kwargs..., i = i, m = m, style = YASStyle())
 yasfmt(s, i, m; kwargs...) = fmt(s; kwargs..., i = i, m = m, style = YASStyle())
 
-include("default_style.jl")
-include("yas_style.jl")
-include("blue_style.jl")
-include("issues.jl")
-include("options.jl")
-include("config.jl")
-include("document.jl")
+@testset "JuliaFormatter" begin
+    include("default_style.jl")
+    include("yas_style.jl")
+    include("blue_style.jl")
+    include("issues.jl")
+    include("options.jl")
+    include("config.jl")
+    include("document.jl")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,8 +22,7 @@ function run_pretty(text::String; style = DefaultStyle(), opts = Options())
     t = JuliaFormatter.pretty(style, x, s)
     t
 end
-run_pretty(text::String, margin::Int) =
-    run_pretty(text, opts = Options(margin = margin))
+run_pretty(text::String, margin::Int) = run_pretty(text, opts = Options(margin = margin))
 
 function run_nest(text::String; opts = Options(), style = DefaultStyle())
     d = JuliaFormatter.Document(text)
@@ -33,8 +32,7 @@ function run_nest(text::String; opts = Options(), style = DefaultStyle())
     JuliaFormatter.nest!(style, t, s)
     t, s
 end
-run_nest(text::String, margin::Int) =
-    run_nest(text, opts = Options(margin = margin))
+run_nest(text::String, margin::Int) = run_nest(text, opts = Options(margin = margin))
 
 function yasfmt(s, i, m; kwargs...)
     # use DefaultStyle options to make writing tests easier

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,4 +52,5 @@ bluefmt1(str) = fmt1(str; style = BlueStyle(), options(DefaultStyle())...)
     include("options.jl")
     include("config.jl")
     include("document.jl")
+    include("interface.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using JuliaFormatter
-using JuliaFormatter: DefaultStyle, YASStyle, Options, CONFIG_FILE_NAME
+using JuliaFormatter: DefaultStyle, YASStyle, Options, options, CONFIG_FILE_NAME
 using CSTParser
 using Test
 
@@ -36,8 +36,11 @@ end
 run_nest(text::String, margin::Int) =
     run_nest(text, opts = Options(margin = margin))
 
-yasfmt1(s, i, m; kwargs...) = fmt1(s; kwargs..., i = i, m = m, style = YASStyle())
-yasfmt(s, i, m; kwargs...) = fmt(s; kwargs..., i = i, m = m, style = YASStyle())
+function yasfmt(s, i, m; kwargs...)
+    # use DefaultStyle options to make writing tests easier
+    kws = merge(options(DefaultStyle()), kwargs)
+    return fmt(s; kws..., i = i, m = m, style = YASStyle())
+end
 
 @testset "JuliaFormatter" begin
     include("default_style.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,8 +22,8 @@ function run_pretty(text::String; style = DefaultStyle(), opts = Options())
     t = JuliaFormatter.pretty(style, x, s)
     t
 end
-run_pretty(text::String, max_margin::Int) =
-    run_pretty(text, opts = Options(max_margin = max_margin))
+run_pretty(text::String, margin::Int) =
+    run_pretty(text, opts = Options(margin = margin))
 
 function run_nest(text::String; opts = Options(), style = DefaultStyle())
     d = JuliaFormatter.Document(text)
@@ -33,8 +33,8 @@ function run_nest(text::String; opts = Options(), style = DefaultStyle())
     JuliaFormatter.nest!(style, t, s)
     t, s
 end
-run_nest(text::String, max_margin::Int) =
-    run_nest(text, opts = Options(max_margin = max_margin))
+run_nest(text::String, margin::Int) =
+    run_nest(text, opts = Options(margin = margin))
 
 yasfmt1(s, i, m; kwargs...) = fmt1(s; kwargs..., i = i, m = m, style = YASStyle())
 yasfmt(s, i, m; kwargs...) = fmt(s; kwargs..., i = i, m = m, style = YASStyle())


### PR DESCRIPTION
- fixes #296 (implements "option (i)" suggested there)

Behaviour:
- Change the results for running `format(str, style=style)` when `style` is BlueStyle or YASStyle, to use the configurable settings that those styles prefer (so tests are affected).
- This doesn't change the API.  
- Updated docs 

Implementation:
- basically this just adds a `format_text(str, ::Style; kwargs...)` method, where the values for the `kwargs` are different depending on the `Style` -- most of the relevant changes are those in `src/JuliaFormatter.jl`.
- This is implemented via having a `options(::Style)` function that returns a NamedTuple which contains the defaults for the style, and and any `kwargs` passed in is `merge`d into that to overwrite them.  
- To be able to re-use more existing code, i changed the field names in the `Options` type (to match the public-facing keywords, so that we can just splat them into the constructor)... which caused big diffs (sorry)

These changes affect the tests, so i fixed them up:
- For YAS tests, since i don't know how to write in YAS style, and there are lots of tests, for those i just changed the internal `yasfmt` function to use `DefaultStyle` settings (i.e. have the same behaviour it had before this PR). 
- ~For Blue tests, since I know how to write BlueStyle, which the tests are short, i just changed the tests to be written in BlueStyle (except for the format change we're testing).~ Same thing for Blue tests as YAS tests.
- ~i've not added dedicated tests, given this is change is exercised by the existing YAS and Blue tests. Would you like me to do that? Not sure how best to do that tbh...~

