### PR TITLE
Align kwargs

### DIFF
--- a/src/align.jl
+++ b/src/align.jl
@@ -19,7 +19,7 @@ function align_fst!(fst::FST, opts::Options)
 
         # gather all assignments within the current code block
         # they will be aligned at the end
-        if is_assignment(n)
+        if is_assignment(n) || n.typ === CSTParser.Kw
             push!(assignment_idxs, i)
         end
 
@@ -162,7 +162,7 @@ function align_binaryopcalls!(fst::FST, op_idxs::Vector{Int})
             g = AlignGroup()
         end
 
-        binop = n.typ === CSTParser.BinaryOpCall ? n : n[3]
+        binop = n.typ === CSTParser.BinaryOpCall || n.typ === CSTParser.Kw ? n : n[3]
         nlen = length(binop[1])
 
         ws = binop[3].line_offset - (binop.line_offset + nlen)
@@ -179,7 +179,8 @@ function align_binaryopcalls!(fst::FST, op_idxs::Vector{Int})
         for (i, idx) in enumerate(g.node_idxs)
             diff = align_len - g.lens[i] + 1
 
-            if fst[idx].typ === CSTParser.BinaryOpCall
+            typ = fst[idx].typ
+            if typ === CSTParser.BinaryOpCall || typ === CSTParser.Kw
                 align_binaryopcall!(fst[idx], diff)
             else
                 align_binaryopcall!(fst[idx][3], diff)

--- a/test/options.jl
+++ b/test/options.jl
@@ -961,6 +961,26 @@
         s, ms = divrem(ms, 1000)
         """
         @test fmt(str, 4, 100, align_assignment = true) == str
+
+
+        str = """
+        run = wandb.init(
+            name      = name,
+            project   = project,
+            config    = config,
+            notes     = notes,
+            tags      = tags,
+            dir       = dir,
+            job_type  = job_type,
+            entity    = entity,
+            group     = group,
+            id        = id,
+            reinit    = reinit,
+            resume    = resume,
+            anonymous = anonymous ? "allow" : "never",
+        )
+        """
+        @test fmt(str, 4, 100, align_assignment = true) == str
     end
 
     @testset "align conditionals" begin

--- a/test/options.jl
+++ b/test/options.jl
@@ -962,7 +962,6 @@
         """
         @test fmt(str, 4, 100, align_assignment = true) == str
 
-
         str = """
         run = wandb.init(
             name      = name,

--- a/test/options.jl
+++ b/test/options.jl
@@ -979,7 +979,7 @@
             anonymous = anonymous ? "allow" : "never",
         )
         """
-        @test fmt(str, 4, 100, align_assignment = true) == str
+        @test fmt(str, 4, 100, align_assignment = true, whitespace_in_kwargs = false) == str
     end
 
     @testset "align conditionals" begin


### PR DESCRIPTION
Keyword arguments are parsed as `Kw` and not `BinaryOpCall` if appear after a `;`, because of this they were not candidates for alignment. This fixes that.