### PR TITLE
Extends `remove_extra_newlines` to remove empty newlines at the start or end of a code block

### DIFF
--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -143,7 +143,7 @@ Example: `arr[(i1 + i2):(i3 + i4)]` instead of `arr[i1+i2:i3+i4]`.
 If true, superflous newlines will be removed. For example:
 
 ```julia
-Module M
+module M
 
 
 
@@ -166,7 +166,7 @@ end
 is rewritten as
 
 ```julia
-Module M
+module M
 
 a = 1
 

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -143,20 +143,44 @@ Example: `arr[(i1 + i2):(i3 + i4)]` instead of `arr[i1+i2:i3+i4]`.
 If true, superflous newlines will be removed. For example:
 
 ```julia
+Module M
+
+
+
 a = 1
 
+function foo()
+
+
+    return nothing
+
+end
 
 
 b = 2
+
+
+end
 ```
 
 is rewritten as
 
 ```julia
+Module M
+
 a = 1
 
+function foo()
+    return nothing
+end
+
 b = 2
+
+end
 ```
+
+Modules are the only type of code block allowed to keep a single newline
+prior to the intial or after the final piece of code.
 
 ### `import_to_using`
 

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -376,8 +376,11 @@ function add_node!(t::FST, n::FST, s::State; join_lines = false, max_padding = -
         if notcode_startline <= notcode_endline
             # If there are comments in between node elements
             # nesting is forced in an effort to preserve them.
-            
-            rm_block_nl = s.opts.remove_extra_newlines && t.typ !== CSTParser.ModuleH && (n.typ === CSTParser.Block || is_end(n))
+
+            rm_block_nl =
+                s.opts.remove_extra_newlines &&
+                t.typ !== CSTParser.ModuleH &&
+                (n.typ === CSTParser.Block || is_end(n))
 
             if remove_empty_notcode(t) || rm_block_nl
                 nest = false

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -376,8 +376,11 @@ function add_node!(t::FST, n::FST, s::State; join_lines = false, max_padding = -
         if notcode_startline <= notcode_endline
             # If there are comments in between node elements
             # nesting is forced in an effort to preserve them.
+            
+            if remove_empty_notcode(t) ||
+                s.opts.remove_extra_newlines && (n.typ === CSTParser.Block ||
+                 is_end(n))
 
-            if remove_empty_notcode(t)
                 nest = false
                 for l = notcode_startline:notcode_endline
                     if hascomment(s.doc, l)
@@ -385,7 +388,10 @@ function add_node!(t::FST, n::FST, s::State; join_lines = false, max_padding = -
                         break
                     end
                 end
-                if !nest
+                if !nest 
+                    if s.opts.remove_extra_newlines && (n.typ === CSTParser.Block || is_end(n))
+                        add_node!(t, Newline(), s)
+                    end
                     @goto add_node_end
                 end
             end

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -377,10 +377,9 @@ function add_node!(t::FST, n::FST, s::State; join_lines = false, max_padding = -
             # If there are comments in between node elements
             # nesting is forced in an effort to preserve them.
             
-            if remove_empty_notcode(t) ||
-                s.opts.remove_extra_newlines && (n.typ === CSTParser.Block ||
-                 is_end(n))
+            rm_block_nl = s.opts.remove_extra_newlines && t.typ !== ModuleH && (n.typ === CSTParser.Block || is_end(n))
 
+            if remove_empty_notcode(t) || rm_block_nl
                 nest = false
                 for l = notcode_startline:notcode_endline
                     if hascomment(s.doc, l)
@@ -388,8 +387,8 @@ function add_node!(t::FST, n::FST, s::State; join_lines = false, max_padding = -
                         break
                     end
                 end
-                if !nest 
-                    if s.opts.remove_extra_newlines && (n.typ === CSTParser.Block || is_end(n))
+                if !nest
+                    if rm_block_nl
                         add_node!(t, Newline(), s)
                     end
                     @goto add_node_end

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -207,11 +207,11 @@ function parent_is(cst::CSTParser.EXPR, valid; ignore = _ -> false)
     valid(p)
 end
 
+contains_comment(nodes::Vector{FST}) = findfirst(is_comment, nodes) !== nothing
 function contains_comment(fst::FST)
     is_leaf(fst) && return false
-    findfirst(is_comment, fst.nodes) !== nothing
+    contains_comment(fst.nodes)
 end
-contains_comment(nodes::Vector{FST}) = findfirst(is_comment, nodes) !== nothing
 
 # TODO: Remove once this is fixed in CSTParser.
 # https://github.com/julia-vscode/CSTParser.jl/issues/108

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -377,7 +377,7 @@ function add_node!(t::FST, n::FST, s::State; join_lines = false, max_padding = -
             # If there are comments in between node elements
             # nesting is forced in an effort to preserve them.
             
-            rm_block_nl = s.opts.remove_extra_newlines && t.typ !== ModuleH && (n.typ === CSTParser.Block || is_end(n))
+            rm_block_nl = s.opts.remove_extra_newlines && t.typ !== CSTParser.ModuleH && (n.typ === CSTParser.Block || is_end(n))
 
             if remove_empty_notcode(t) || rm_block_nl
                 nest = false

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -359,13 +359,8 @@ function add_node!(t::FST, n::FST, s::State; join_lines = false, max_padding = -
         t.len += length(n)
         t.line_offset = n.line_offset
         push!(t.nodes, n)
-        # @info "" t.typ n.typ t.line_offset n.line_offset n.val
         return
     end
-
-    # if t.line_offset <= 0
-    #     t.line_offset = n.line_offset
-    # end
 
     if !is_prev_newline(t.nodes[end])
         current_line = t.endline
@@ -527,7 +522,6 @@ function is_block(x::Union{CSTParser.EXPR,FST})
     x.typ === CSTParser.For && return true
     x.typ === CSTParser.While && return true
     x.typ === CSTParser.Let && return true
-    # (cst.typ === CSTParser.Quote && cst[1].kind === Tokens.QUOTE) && return true
     (x.typ === CSTParser.Quote && x[1].val == "quote") && return true
     return false
 end

--- a/src/styles/blue/pretty.jl
+++ b/src/styles/blue/pretty.jl
@@ -124,7 +124,6 @@ function p_binaryopcall(
        s.opts.whitespace_ops_in_indices &&
        !is_leaf(cst[1]) &&
        !is_iterable(cst[1])
-
         paren = FST(CSTParser.PUNCTUATION, -1, n.startline, n.startline, "(")
         add_node!(t, paren, s)
         add_node!(t, n, s, join_lines = true)

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -78,7 +78,6 @@ function nest!(ds::DefaultStyle, fst::FST, s::State)
            line_margin > s.opts.margin &&
            fst.ref !== nothing &&
            CSTParser.defines_function(fst.ref[])
-
             short_to_long_function_def!(fst, s)
         end
         n_binaryopcall!(style, fst, s)

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1388,7 +1388,6 @@ function p_binaryopcall(
        s.opts.whitespace_ops_in_indices &&
        !is_leaf(cst[1]) &&
        !is_iterable(cst[1])
-
         paren = FST(CSTParser.PUNCTUATION, -1, n.startline, n.startline, "(")
         add_node!(t, paren, s)
         add_node!(t, n, s, join_lines = true)

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -164,7 +164,6 @@ function p_ref(ys::YASStyle, cst::CSTParser.EXPR, s::State)
                a.typ === CSTParser.InvisBrackets ||
                a.typ === CSTParser.ChainOpCall ||
                a.typ === CSTParser.Comparison
-
             n = pretty(ys, a, s, nonest = true, nospace = nospace)
             add_node!(t, n, s, join_lines = true)
         else

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -957,7 +957,6 @@
             )
         end"""
         @test fmt(str, 4, 28) == str
-
     end
 
     @testset "quote" begin
@@ -1013,7 +1012,6 @@
             )
         end"""
         @test fmt(str, 4, 28) == str
-
     end
 
     @testset "do" begin
@@ -1081,7 +1079,6 @@
             body
         end"""
         @test fmt(str_) == str
-
     end
 
     @testset "for" begin
@@ -1132,7 +1129,6 @@
         end"""
         t = run_pretty(str, 80)
         @test length(t) == 20
-
     end
 
     @testset "while" begin
@@ -1354,7 +1350,6 @@
         end"""
         t = run_pretty(str, 80)
         @test length(t) == 11
-
     end
 
     @testset "if" begin
@@ -1391,7 +1386,6 @@
         end"""
         t = run_pretty(str, 80)
         @test length(t) == 14
-
     end
 
     @testset "strings" begin
@@ -2938,7 +2932,6 @@
         @test s.line_offset == 17
         _, s = run_nest(str, 16)
         @test s.line_offset == 7
-
     end
 
     @testset "additional length" begin
@@ -3519,7 +3512,6 @@
             c,
         )"""
         @test fmt("@func(a, b, c,)", 4, 1) == str
-
     end
 
     @testset "comphrehensions types" begin
@@ -4246,5 +4238,4 @@ some_function(
         str = "const FOO = '😢'"
         @test fmt(str) == str
     end
-
 end

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -3794,7 +3794,6 @@ some_function(
         )"""
         @test fmt(str_, remove_extra_newlines = true) == str
 
-
         str_ = """
         var =
 

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -3794,38 +3794,6 @@ some_function(
         )"""
         @test fmt(str_, remove_extra_newlines = true) == str
 
-        str_ = """
-        a = 10
-
-        # foo1
-        # ooo
-
-
-
-        # aooo
-
-
-        # aaaa
-        b = 20
-
-
-
-        # hello
-        """
-        str = """
-        a = 10
-
-        # foo1
-        # ooo
-
-        # aooo
-
-        # aaaa
-        b = 20
-
-        # hello
-        """
-        @test fmt(str, remove_extra_newlines = true) == str
 
         str_ = """
         var =

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -151,7 +151,6 @@
             (4, 5),
         )"""
         @test fmt(str_) == str
-
     end
 
     @testset "issue #150" begin
@@ -240,7 +239,6 @@
         @test fmt(str_) == str
         _, s = run_nest(str_, 100)
         @test s.line_offset == 1
-
     end
 
     @testset "issue #183" begin
@@ -292,7 +290,6 @@
             (b - y) * delta_hat[i] - delta[i] * delta_hat[i] for i = 1:8
         ]"""
         @test fmt(str_) == str
-
     end
 
     @testset "issue #193" begin
@@ -448,7 +445,6 @@
             y_past = get_y(m),
         ) where {C <: Union{T, TGP <: AbstractGP{T}; IsMultiOutput{TGP}}} end"""
         @test fmt(str_, m = 92, whitespace_typedefs = true) == str
-
     end
 
     @testset "issue #218" begin

--- a/test/options.jl
+++ b/test/options.jl
@@ -34,7 +34,6 @@
         @test fmt(str_, remove_extra_newlines = true) == str
         @test fmt(str_, remove_extra_newlines = false) == str_
 
-
         str_ = """
         module M
 

--- a/test/options.jl
+++ b/test/options.jl
@@ -1092,7 +1092,6 @@
             cst.kind === Tokens.BAREMODUL ? "baremodule" : ""
         """
         @test fmt(str_, 4, 1, align_conditional = true) == str
-
     end
 
     @testset "align pair arrow `=>`" begin

--- a/test/options.jl
+++ b/test/options.jl
@@ -1,4 +1,76 @@
 @testset "Formatting Options" begin
+    @testset "remove extra newlines" begin
+        str_ = """
+        a = 10
+
+        # foo1
+        # ooo
+
+
+
+        # aooo
+
+
+        # aaaa
+        b = 20
+
+
+
+        # hello
+        """
+        str = """
+        a = 10
+
+        # foo1
+        # ooo
+
+        # aooo
+
+        # aaaa
+        b = 20
+
+        # hello
+        """
+        @test fmt(str_, remove_extra_newlines = true) == str
+        @test fmt(str_, remove_extra_newlines = false) == str_
+
+
+        str_ = """
+        module M
+
+
+        function foo(bar::Int64, baz::Int64)
+
+
+            return bar + baz
+        end
+
+        function foo(bar::In64, baz::Int64)
+            return bar + baz
+
+
+        end
+
+
+        end
+        """
+        str = """
+        module M
+
+        function foo(bar::Int64, baz::Int64)
+            return bar + baz
+        end
+
+        function foo(bar::In64, baz::Int64)
+            return bar + baz
+        end
+
+        end
+        """
+        @test fmt(str_, remove_extra_newlines = true) == str
+        @test fmt(str_, remove_extra_newlines = false) == str_
+    end
+
     @testset "whitespace in typedefs" begin
         str_ = "Foo{A,B,C}"
         str = "Foo{A, B, C}"
@@ -668,6 +740,7 @@
         function fmt() end"""
         @test fmt(unformatted, format_docstrings = true) == formatted
     end
+
     @testset "format docstrings - Empty line in docstring" begin
         unformatted = """
         \"""

--- a/test/yas_style.jl
+++ b/test/yas_style.jl
@@ -265,7 +265,6 @@
                                                            :avr],
                                           file_extension = Symbol("lpcm.zst"))"""
         @test yasfmt(str_, 4, 1) == str
-
     end
 
     @testset "inline comments with arguments" begin
@@ -378,7 +377,6 @@
                                  body
                              end)"""
         @test yasfmt(str_, 4, 32) == str
-
     end
 
     @testset "inline comments with arguments" begin
@@ -424,7 +422,6 @@
               (b - y) * delta_hat[i] - delta[i] * delta_hat[i]
               for i = 1:8]"""
         @test yasfmt(str_, 2, 60) == str
-
     end
 
     @testset "issue 237" begin
@@ -438,5 +435,4 @@
         end"""
         @test yasfmt(str_, 4, 92) == str
     end
-
 end


### PR DESCRIPTION
**The exemption(s) from this rule are `module` code blocks which are permitted a single newline**

### Example


```julia
module M



a = 1

function foo()


    return nothing

end


b = 2


end
```

is rewritten as

```julia
module M

a = 1

function foo()
    return nothing
end

b = 2

end
```

On master this would currently be

```julia
module M

a = 1

function foo()

    return nothing

end

b = 2

end
```
