### PR TITLE
Resolve issue #317 which edge case that causes infinite recursion when using BlueStyle

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.10.2"
+version = "0.10.3"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -79,9 +79,11 @@ function nest!(ds::DefaultStyle, fst::FST, s::State)
            fst.ref !== nothing &&
            CSTParser.defines_function(fst.ref[])
             short_to_long_function_def!(fst, s)
-            nest!(style, fst, s)
-        else
+        end
+        if fst.typ === CSTParser.BinaryOpCall
             n_binaryopcall!(style, fst, s)
+        else
+            nest!(style, fst, s)
         end
     elseif fst.typ === CSTParser.Curly
         n_curly!(style, fst, s)

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -604,4 +604,12 @@
         """
         @test fmt(str_, 4, 1) == str
     end
+
+    @testset "issue 317 - infinite recursion" begin
+        str = raw"""
+        SUITE["manifolds"][name]["tv = 2 * tv1 + 3 * tv2"] = @benchmarkable $tv =
+            2 * $tv1 + 3 * $tv2
+        """
+        @test format_text(str, BlueStyle()) == str
+    end
 end


### PR DESCRIPTION
Since styles are interleaved for formatting binary op calls with `BlueStyle` this causes infinite recursion if the type of the `FST` remains `BinaryOpCall` after `short_to_long_function_def!` is called on it.

To resolve this `n_binaryopcall!` is used if it remains a `BinaryOpCall` else call `nest!`

fixes #317 