### PR TITLE
Only apply `=` to `in` transform on FST since otherwise the node length is inconsistent and can lead to an offset error

### DIFF
--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -319,7 +319,7 @@ function p_generator(ys::YASStyle, cst::CSTParser.EXPR, s::State)
             if !is_gen(cst.args[i+1])
                 tup = p_tupleh(style, cst.args[i+1:length(cst)], s)
                 add_node!(t, tup, s, join_lines = true)
-                if has_for_kw 
+                if has_for_kw
                     for nn in tup.nodes
                         eq_to_in_normalization!(nn, s.opts.always_for_in)
                     end

--- a/test/yas_style.jl
+++ b/test/yas_style.jl
@@ -439,6 +439,6 @@
     @testset "issue 320" begin
         str_ = "[x[i] for i = 1:length(x)]"
         str = "[x[i] for i in 1:length(x)]"
-        @test yasfmt(str_, 4, 92, always_for_in=true) == str
+        @test yasfmt(str_, 4, 92, always_for_in = true) == str
     end
 end

--- a/test/yas_style.jl
+++ b/test/yas_style.jl
@@ -435,4 +435,10 @@
         end"""
         @test yasfmt(str_, 4, 92) == str
     end
+
+    @testset "issue 320" begin
+        str_ = "[x[i] for i = 1:length(x)]"
+        str = "[x[i] for i in 1:length(x)]"
+        @test yasfmt(str_, 4, 92, always_for_in=true) == str
+    end
 end


### PR DESCRIPTION
fixes #320 