### PR TITLE
Stop double printing inline comments after keyword arguments in `YASStyle`

### DIFF
--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1795,6 +1795,7 @@ p_typedcomprehension(style::S, cst::CSTParser.EXPR, s::State) where {S<:Abstract
 function p_parameters(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
     style = getstyle(ds)
     t = FST(cst, nspaces(s))
+
     for (i, a) in enumerate(cst)
         n = pretty(style, a, s)
         if i == length(cst) && CSTParser.is_comma(a)

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -228,24 +228,6 @@ function p_macrocall(ys::YASStyle, cst::CSTParser.EXPR, s::State)
     return fst
 end
 
-function p_parameters(ys::YASStyle, cst::CSTParser.EXPR, s::State)
-    style = getstyle(ys)
-    t = FST(cst, nspaces(s))
-
-    for (i, a) in enumerate(cst)
-        n = pretty(style, a, s)
-        if i == length(cst) && CSTParser.is_comma(a)
-            # do nothing
-        elseif CSTParser.is_comma(a) && i < length(cst) && !is_punc(cst[i+1])
-            add_node!(t, n, s, join_lines = true)
-            add_node!(t, Placeholder(1), s)
-        else
-            add_node!(t, n, s, join_lines = true)
-        end
-    end
-    t
-end
-
 function p_whereopcall(ys::YASStyle, cst::CSTParser.EXPR, s::State)
     style = getstyle(ys)
     t = FST(cst, nspaces(s))

--- a/test/files/blowup/.JuliaFormatter.toml
+++ b/test/files/blowup/.JuliaFormatter.toml
@@ -1,0 +1,11 @@
+always_for_in = true
+always_use_return = true
+import_to_using = true
+margin = 110
+pipe_to_function_call = true
+remove_extra_newlines = true
+short_to_long_function_def = true
+style = "yas"
+whitespace_in_kwargs = false
+whitespace_ops_in_indices = true
+whitespace_typedefs = false

--- a/test/files/blowup/axis.jl
+++ b/test/files/blowup/axis.jl
@@ -1,0 +1,533 @@
+function ticks_and_labels end
+
+module Formatters
+using Showoff
+
+function scientific(ticks::AbstractVector)
+    return Showoff.showoff(ticks, :scientific)
+end
+
+function plain(ticks::AbstractVector)
+    try
+        Showoff.showoff(ticks, :plain)
+    catch e
+        Base.showerror(stderr, e)
+        println("with ticks: ", ticks)
+        String["-Inf", "Inf"]
+    end
+end
+
+end
+using .Formatters
+
+"""
+    $(SIGNATURES)
+
+Plots a 2-dimensional axis.
+
+## Attributes
+$(ATTRIBUTES)
+"""
+@recipe(Axis2D) do scene
+    return Attributes(visible=true, showgrid=true, showticks=true, showtickmarks=true, padding=0.0,
+                      ticks=Attributes(ranges_labels=(automatic, automatic), formatter=Formatters.plain,
+                                       gap=1, title_gap=3, linewidth=(1, 1),
+                                       linecolor=((:black, 0.4), (:black, 0.4)), linestyle=(nothing, nothing),
+                                       textcolor=(:black, :black), textsize=(5, 5), rotation=(0.0, 0.0),
+                                       align=((:center, :top), (:right, :center)),
+                                       font=lift(dim2, theme(scene, :font))),
+                      tickmarks=Attributes(length=(1.0, 1.0), linewidth=(1, 1),
+                                           linecolor=((:black, 0.4), (:black, 0.2)),
+                                           linestyle=(nothing, nothing)),
+                      grid=Attributes(linewidth=(0.5, 0.5), linecolor=((:black, 0.3), (:black, 0.3)),
+                                      linestyle=(nothing, nothing)),
+                      frame=Attributes(linewidth=1.0, linecolor=:black, linestyle=nothing,
+                                       axis_position=nothing, axis_arrow=false, arrow_size=2.5,
+                                       frames=((false, false), (false, false))),
+                      names=Attributes(axisnames=("x", "y"), title=nothing, textcolor=(:black, :black),
+                                       textsize=(6, 6), rotation=(0.0, -1.5pi),
+                                       align=((:center, :top), (:center, :bottom)),
+                                       font=lift(dim2, theme(scene, :font))))
+end
+
+"""
+    $(SIGNATURES)
+
+Plots a 3-dimensional Axis.
+
+## Attributes
+$(ATTRIBUTES)
+"""
+@recipe(Axis3D) do scene
+    q1 = qrotation(Vec3f0(1, 0, 0), -0.5f0 * pi)
+    q2 = qrotation(Vec3f0(0, 0, 1), 1.0f0 * pi)
+    tickrotations3d = (qrotation(Vec3f0(0, 0, 1), -1.5pi), q2, qrotation(Vec3f0(1, 0, 0), -0.5pi) * q2)
+    axisnames_rotation3d = tickrotations3d
+    tickalign3d = ((:left, :center), # x axis
+                   (:right, :center), # y axis
+                   (:right, :center))
+    axisnames_align3d = tickalign3d
+    tick_color = RGBAf0(0.5, 0.5, 0.5, 0.6)
+    grid_color = RGBAf0(0.5, 0.5, 0.5, 0.4)
+    grid_thickness = 1
+    gridthickness = ntuple(x -> 1.0f0, Val(3))
+    tsize = 5 # in percent
+    return Attributes(visible=true, showticks=(true, true, true), showaxis=(true, true, true),
+                      showgrid=(true, true, true), scale=Vec3f0(1), padding=0.1,
+                      names=Attributes(axisnames=("x", "y", "z"), textcolor=(:black, :black, :black),
+                                       rotation=axisnames_rotation3d, textsize=(6.0, 6.0, 6.0),
+                                       align=axisnames_align3d, font=lift(dim3, theme(scene, :font)), gap=3),
+                      ticks=Attributes(ranges_labels=(automatic, automatic), formatter=Formatters.plain,
+                                       textcolor=(tick_color, tick_color, tick_color),
+                                       rotation=tickrotations3d, textsize=(tsize, tsize, tsize),
+                                       align=tickalign3d, gap=3, font=lift(dim3, theme(scene, :font))),
+                      frame=Attributes(linecolor=(grid_color, grid_color, grid_color),
+                                       linewidth=(grid_thickness, grid_thickness, grid_thickness),
+                                       axiscolor=(:black, :black, :black)))
+end
+
+isaxis(x) = false
+isaxis(x::Union{Axis2D,Axis3D}) = true
+
+const Limits{N} = NTuple{N,Tuple{Number,Number}}
+
+function default_ticks(limits::Limits, ticks, scale_func::Function)
+    return default_ticks.(limits, (ticks,), scale_func)
+end
+
+# function default_ticks(limits::Limits, ticks::Tuple, scale_func::Function)
+#     default_ticks.(limits, ticks, scale_func)
+# end
+function default_ticks(limits::Tuple{Number,Number}, ticks, scale_func::Function)
+    return default_ticks(limits..., ticks, scale_func)
+end
+
+function default_ticks(lmin::Number, lmax::Number, ticks::AbstractVector{<:Number}, scale_func::Function)
+    return scale_func.((filter(t -> lmin <= t <= lmax, ticks)))
+end
+function default_ticks(lmin::Number, lmax::Number, ::Automatic, scale_func::Function)
+    # scale the limits
+    scaled_ticks, mini, maxi = optimize_ticks(scale_func(lmin), scale_func(lmax); k_min=4, # minimum number of ticks # minimum number of ticks
+                                              k_max=8)
+    length(scaled_ticks) == 1 && isnan(scaled_ticks[1]) && return [-Inf, Inf]
+    return scaled_ticks
+end
+
+function default_ticks(lmin::Number, lmax::Number, ticks::Integer, scale_func=identity)
+    scaled_ticks, mini, maxi = optimize_ticks(scale_func(lmin), scale_func(lmax); k_min=ticks, # minimum number of ticks # minimum number of ticks
+                                              k_max=ticks, # maximum number of ticks # maximum number of ticks
+                                              k_ideal=ticks,
+                                              # `strict_span = false` rewards cases where the span of the
+                                              # chosen  ticks is not too much bigger than amin - amax:
+                                              strict_span=false)
+    return scaled_ticks
+end
+
+function default_ticks(x::Automatic, limits::Tuple, n)
+    return default_ticks(limits, n, identity)
+end
+
+function default_ticks(ticks::Tuple, limits::Tuple, n::Tuple)
+    return default_ticks.(ticks, (limits,), n)
+end
+
+default_ticks(ticks::Tuple, limits::Limits, n) = default_ticks.(ticks, limits, (n,))
+
+default_ticks(ticks::Tuple, limits::Limits, n::Tuple) = default_ticks.(ticks, limits, n)
+
+default_ticks(ticks::AbstractVector{<:Number}, limits, n) = ticks
+
+function default_labels(x::NTuple{N,Any}, formatter::Function) where {N}
+    return default_labels.(x, formatter)
+end
+
+function default_labels(x::AbstractVector, y::AbstractVector, formatter::Function=Formatters.plain)
+    return default_labels.((x, y), formatter)
+end
+
+function default_labels(ticks::AbstractVector, formatter::Function=Formatters.plain)
+    if applicable(formatter, ticks)
+        return formatter(ticks) # takes the whole array
+    elseif applicable(formatter, first(ticks))
+        return formatter.(ticks)
+    else
+        error("Formatting function $(formatter) is neither applicable to $(typeof(ticks)) nor $(eltype(ticks)).")
+    end
+end
+
+default_labels(x::Automatic, ranges, formatter) = default_labels(ranges, formatter)
+default_labels(x::Tuple, ranges::Tuple, formatter) = default_labels.(x, ranges, (formatter,))
+default_labels(x::Tuple, ranges, formatter) = default_labels.(x, (ranges,), (formatter,))
+default_labels(x::AbstractVector{<:AbstractString}, ranges, formatter::Function) = x
+default_labels(x::AbstractVector{<:AbstractString}, ranges::AbstractVector, formatter::Function) = x
+
+function convert_arguments(::Type{<:Axis2D}, limits::Rect)
+    e = extrema(limits)
+    return (((e[1][1], e[2][1]), (e[1][2], e[2][2])),)
+end
+
+function convert_arguments(::Type{<:Axis3D}, limits::Rect)
+    e = (minimum(limits), maximum(limits))
+    return (((e[1][1], e[2][1]), (e[1][2], e[2][2]), (e[1][3], e[2][3])),)
+end
+
+a_length(x::AbstractVector) = length(x)
+a_length(x::Automatic) = x
+
+function calculated_attributes!(::Type{<:Union{Axis2D,Axis3D}}, plot)
+    ticks = plot.ticks
+    args = (plot.padding, plot[1], ticks.ranges, ticks.labels, ticks.formatter)
+    ticks[:ranges_labels] = lift(args...) do pad, lims, ranges, labels, formatter
+        limit_widths = map(x -> x[2] - x[1], lims)
+        pad = (limit_widths .* pad)
+        # pad the drawn limits and use them as the ranges
+        lim_pad = map((lim, p) -> (lim[1] - p, lim[2] + p), lims, pad)
+        num_ticks = labels === automatic ? automatic : a_length.(labels)
+        ranges = default_ticks(ranges, lim_pad, num_ticks)
+        labels = default_labels(labels, ranges, formatter)
+        return (ranges, labels)
+    end
+    return
+end
+
+function draw_ticks(textbuffer, dim, origin, ticks, linewidth, linecolor, linestyle, textcolor, textsize,
+                    rotation, align, font)
+    for (tick, str) in ticks
+        pos = ntuple(i -> i != dim ? origin[i] : tick, Val(2))
+        push!(textbuffer, str, Point(pos), rotation=rotation[dim], textsize=textsize[dim], align=align[dim],
+              color=textcolor[dim], font=font[dim])
+    end
+end
+
+function draw_tickmarks(linebuffer, dim, origin, ticks, dir::NTuple{N}, linewidth, linecolor, linestyle,
+                        textcolor, textsize, rotation, align, font) where {N}
+    for (tick, str) in ticks
+        pos = ntuple(i -> i != dim ? origin[i] : tick, Val(2))
+        posf0 = Point2f0(pos)
+        dirf0 = Pointf0{N}(dir)
+        append!(linebuffer, [posf0, posf0 .+ dirf0], color=linecolor[dim], linewidth=linewidth[dim])
+    end
+end
+
+function draw_grid(linebuffer, dim, origin, ticks, dir::NTuple{N}, linewidth, linecolor, linestyle) where {N}
+    dirf0 = Pointf0{N}(dir)
+    for (tick, str) in ticks
+        tup = ntuple(i -> i != dim ? origin[i] : tick, Val(N))
+        posf0 = Pointf0{N}(tup)
+        append!(linebuffer, [posf0, posf0 .+ dirf0], color=linecolor[dim], linewidth=linewidth[dim])
+    end
+end
+
+function draw_frame(linebuffer, limits::NTuple{N,Any}, linewidth, linecolor, linestyle, axis_position,
+                    axis_arrow, arrow_size, frames) where {N}
+    mini = minimum.(limits)
+    maxi = maximum.(limits)
+    rect = Rect(Vec(mini), Vec(maxi .- mini))
+    origin = Vec{N}(0.0)
+    if (origin in rect) && axis_position == :origin
+        for i in 1:N
+            start = unit(Point{N,Float32}, i) * Float32(mini[i])
+            to = unit(Point{N,Float32}, i) * Float32(maxi[i])
+            if false #axis_arrow
+                arrows(scene, [start, to], linewidth=linewidth, linecolor=linecolor, linestyle=linestyle,
+                       arrowsize=arrow_size)
+            else
+                append!(linebuffer, [start, to], linewidth=linewidth, color=linecolor)
+            end
+        end
+    end
+    limit_widths = maxi .- mini
+    frames = convert_attribute(frames, key"frames"())
+    for side in 1:2
+        from = Point{N,Float32}(getindex.(limits, side))
+        # if axis is drawn at origin, and we draw frame from origin,
+        # we already did this
+        if !(from == origin && axis_position == :origin)
+            for otherside in 1:2
+                for dim in 1:N
+                    if frames[N - dim + 1][3 - otherside]
+                        p = ntuple(i -> i == dim ? limits[i][otherside] : limits[i][side], Val(N))
+                        to = Point{N,Float32}(p)
+                        append!(linebuffer, [from, to], linewidth=linewidth, color=linecolor)
+                    end
+                end
+            end
+        end
+    end
+end
+
+function draw_titles(textbuffer, xticks, yticks, origin, limit_widths, tickfont, tick_size, tick_gap,
+                     tick_title_gap, axis_labels, textcolor, textsize, rotation, align, font, title)
+    tickspace_x = maximum(map(yticks) do tick
+                              str = last(tick)
+                              tick_bb = text_bb(str, to_font(tickfont[2]), tick_size[2])
+                              return widths(tick_bb)[1]
+                          end)
+
+    tickspace_y = widths(text_bb(last(first(xticks)), to_font(tickfont[1]), tick_size[1]))[2]
+
+    model_inv = inv(transformationmatrix(textbuffer)[])
+
+    tickspace = transform(model_inv, (tickspace_x, tickspace_y))
+    title_start = origin .- (tick_gap .+ tickspace .+ tick_title_gap)
+    half_width = origin .+ (limit_widths ./ 2.0)
+
+    posx = (half_width[1], title_start[2])
+    posy = (title_start[1], half_width[2])
+    positions = (posx, posy)
+    for i in 1:2
+        if !isempty(axis_labels[i])
+            push!(textbuffer, axis_labels[i], positions[i], textsize=textsize[i], align=align[i],
+                  rotation=rotation[i], color=textcolor[i], font=font[i])
+        end
+    end
+    if title !== nothing
+        # TODO give title own text attributes
+        push!(textbuffer, title, (half_width[1], (origin .+ (limit_widths))[2]), textsize=textsize[1],
+              align=(:center, :top), rotation=rotation[1], color=textcolor[1], font=font[1])
+    end
+end
+
+function ticks_and_labels(x)
+    st, s = extrema(x)
+    r = LinRange(st, s, 4)
+    return zip(r, string.(round.(r, 4)))
+end
+
+function transform(model::Mat4, x::T) where {T}
+    x4d = to_ndim(Vec4f0, x, 0.0)
+    return to_ndim(T, model * x4d, 0.0)
+end
+un_transform(model::Mat4, x) = transform(inv(model), x)
+
+to2tuple(x) = ntuple(i -> x, Val(2))
+to2tuple(x::Tuple{<:Any,<:Any}) = x
+
+function draw_axis2d(textbuffer, frame_linebuffer, grid_linebuffer, tickmarks_linebuffer, m, padding, limits,
+                     xyrange_labels, showgrid, showticks, showtickmarks,
+                     # grid attributes
+                     g_linewidth, g_linecolor, g_linestyle,
+
+                     # tick attributes
+                     t_linewidth, t_linecolor, t_linestyle, t_textcolor, t_textsize, t_rotation, t_align,
+                     t_font, t_gap, t_title_gap,
+
+                     #tickmark attribures
+                     tm_linewidth, tm_linecolor, tm_linestyle, tm_length,
+
+                     # frame attributes
+                     f_linewidth, f_linecolor, f_linestyle, f_axis_position, f_axis_arrow, f_arrow_size,
+                     f_frames,
+
+                     # title / axis name attributes
+                     ti_labels, ti_textcolor, ti_textsize, ti_rotation, ti_align, ti_font, ti_title)
+    xyrange, labels = xyrange_labels
+    start!(textbuffer)
+    start!(frame_linebuffer)
+    foreach(start!, grid_linebuffer)
+    foreach(start!, tickmarks_linebuffer)
+    # limits = limits Vec2f0(padding)
+    # limits ((xmin, xmax), (ymin, ymax))
+    limit_widths = map(x -> x[2] - x[1], limits)
+    pad = (limit_widths .* to2tuple(padding))
+    # pad the drawn limits
+    limits = map((lim, p) -> (lim[1] - p, lim[2] + p), limits, pad)
+
+    # recalculate widths
+    limit_widths = map(x -> x[2] - x[1], limits)
+
+    % = mean(limit_widths) / 100 # percentage
+    xyticks = zip.(xyrange, labels)
+    model_inv = inv(transformationmatrix(textbuffer)[])
+
+    ti_textsize = ti_textsize .* %
+    t_textsize = t_textsize .* %
+    t_gap = transform(model_inv, to2tuple(t_gap .* %))
+    tm_length = transform(model_inv, to2tuple(tm_length .* %))
+    t_title_gap = transform(model_inv, to2tuple(t_title_gap .* %))
+
+    origin = first.(limits)
+    dirs = ((0.0, Float64(limit_widths[2])), (Float64(limit_widths[1]), 0.0))
+    foreach(1:2, dirs, xyticks) do dim, dir, ticks
+        if showgrid[dim]
+            draw_grid(grid_linebuffer[dim], dim, origin, ticks, dir, g_linewidth, g_linecolor, g_linestyle)
+        end
+    end
+    tm_offsets = ((0.0, Float64(tm_length[2])), (Float64(tm_length[1]), Float64(0.0)))
+    foreach(1:2, tm_offsets, xyticks) do dim, offset, ticks
+        if showtickmarks[dim]
+            draw_tickmarks(tickmarks_linebuffer[dim], dim, origin .- offset, ticks, offset, t_linewidth,
+                           t_linecolor, t_linestyle, t_textcolor, t_textsize, t_rotation, t_align, t_font)
+        end
+    end
+    t_offsets = ((0.0, Float64(t_gap[2] + tm_length[2])), (Float64(t_gap[1] + tm_length[1]), Float64(0.0)))
+    foreach(1:2, t_offsets, xyticks) do dim, offset, ticks
+        if showticks[dim]
+            draw_ticks(textbuffer, dim, origin .- offset, ticks, t_linewidth, t_linecolor, t_linestyle,
+                       t_textcolor, t_textsize, t_rotation, t_align, t_font)
+        end
+    end
+
+    draw_frame(frame_linebuffer, limits, f_linewidth, f_linecolor, f_linestyle, f_axis_position, f_axis_arrow,
+               f_arrow_size, f_frames)
+
+    draw_titles(textbuffer, xyticks..., origin, limit_widths, t_font, t_textsize, t_gap, t_title_gap,
+                ti_labels, ti_textcolor, ti_textsize, ti_rotation, ti_align, ti_font, ti_title)
+    finish!(textbuffer)
+    finish!(frame_linebuffer)
+    foreach(finish!, grid_linebuffer)
+    foreach(finish!, tickmarks_linebuffer)
+    return
+end
+
+# for axis, we don't want to have plot!(scene, args) called on it, so we need to overload it directly
+function plot!(scene::SceneLike, ::Type{<:Axis2D}, attributes::Attributes, args...)
+    # create "empty" plot type - empty meaning containing no plots, just attributes + arguments
+    cplot = Axis2D(scene, attributes, args)
+    # Disable any non linear transform for the axis plot!
+    cplot.transformation.transform_func[] = identity
+    g_keys = (:linewidth, :linecolor, :linestyle)
+    f_keys = (:linewidth, :linecolor, :linestyle, :axis_position, :axis_arrow, :arrow_size, :frames)
+    t_keys = (:linewidth, :linecolor, :linestyle, :textcolor, :textsize, :rotation, :align, :font, :gap,
+              :title_gap)
+    tm_keys = (:linewidth, :linecolor, :linestyle, :length)
+    ti_keys = (:axisnames, :textcolor, :textsize, :rotation, :align, :font, :title)
+
+    g_args = getindex.(cplot.grid, g_keys)
+    f_args = getindex.(cplot.frame, f_keys)
+    t_args = getindex.(cplot.ticks, t_keys)
+    tm_args = getindex.(cplot.tickmarks, tm_keys)
+    ti_args = getindex.(cplot.names, ti_keys)
+
+    textbuffer = TextBuffer(cplot, Point{2})
+
+    grid_linebuffer = Node((LinesegmentBuffer(cplot, Point{2}, transparency=true,
+                                              linestyle=lift(first, cplot[:grid, :linestyle])),
+                            LinesegmentBuffer(cplot, Point{2}; transparency=true,
+                                              linestyle=lift(last, cplot[:grid, :linestyle]))))
+
+    frame_linebuffer = Node(LinesegmentBuffer(cplot, Point{2}; transparency=true,
+                                              linestyle=cplot.frame.linestyle))
+    tickmarks_linebuffer = Node((LinesegmentBuffer(cplot, Point{2}; transparency=true,
+                                                   linestyle=lift(first, cplot[:tickmarks, :linestyle])),
+                                 LinesegmentBuffer(cplot, Point{2}; transparency=true,
+                                                   linestyle=lift(last, cplot[:tickmarks, :linestyle]))))
+    map_once(draw_axis2d, Node(textbuffer), frame_linebuffer, grid_linebuffer, tickmarks_linebuffer,
+             transformationmatrix(scene), cplot.padding, cplot[1], cplot.ticks.ranges_labels,
+             lift.((dim2,), (cplot.showgrid, cplot.showticks, cplot.showtickmarks))..., g_args..., t_args...,
+             tm_args..., f_args..., ti_args...)
+    push!(scene, cplot)
+    return cplot
+end
+
+function labelposition(ranges, dim, dir, tgap, origin::StaticVector{N}) where {N}
+    a, b = extrema(ranges[dim])
+    whalf = Float32(((b - a) / 2))
+    halfaxis = unit(Point{N,Float32}, dim) .* whalf
+
+    return origin .+ (halfaxis .+ (normalize(dir) * tgap))
+end
+
+_widths(x::Tuple{<:Number,<:Number}) = x[2] - x[1]
+_widths(x) = Float32(maximum(x) - minimum(x))
+
+to3tuple(x::Tuple{Any}) = (x[1], x[1], x[1])
+to3tuple(x::Tuple{Any,Any}) = (x[1], x[2], x[2])
+to3tuple(x::Tuple{Any,Any,Any}) = x
+to3tuple(x) = ntuple(i -> x, Val(3))
+
+function draw_axis3d(textbuffer, linebuffer, limits, ranges_labels, args...)
+    # make sure we extend all args to 3D
+    ranges, ticklabels = ranges_labels
+    args3d = to3tuple.(args)
+    (showaxis, showticks, showgrid, axisnames, axisnames_color, axisnames_size, axisrotation, axisalign, axisnames_font, titlegap, gridcolors, gridthickness, axiscolors, ttextcolor, trotation, ttextsize, talign, tfont, tgap) = args3d # splat to names
+
+    N = 3
+    start!(textbuffer)
+    start!(linebuffer)
+    mini, maxi = first.(limits), last.(limits)
+
+    origin = Point{N,Float32}(min.(mini, first.(ranges)))
+    limit_widths = max.(last.(ranges), maxi) .- origin
+    % = minimum(limit_widths) / 100 # percentage
+    ttextsize = (%) .* ttextsize
+    axisnames_size = (%) .* axisnames_size
+
+    titlegap = (%) .* titlegap
+    tgap = (%) .* tgap
+    for i in 1:N
+        axis_vec = unit(Point{N,Float32}, i)
+        width = Float32(limit_widths[i])
+        stop = origin .+ (width .* axis_vec)
+        if showaxis[i]
+            append!(linebuffer, [origin, stop], color=axiscolors[i], linewidth=1.5f0)
+        end
+        if showticks[i]
+            range = ranges[i]
+            j = mod1(i + 1, N)
+            tickdir = unit(Point{N,Float32}, j)
+            tickdir, offset2 = if i != 2
+                tickdir = unit(Vec{N,Float32}, j)
+                tickdir, Float32(limit_widths[j] + tgap[i]) * tickdir
+            else
+                tickdir = unit(Vec{N,Float32}, 1)
+                tickdir, Float32(limit_widths[1] + tgap[i]) * tickdir
+            end
+            for (j, tick) in enumerate(range)
+                labels = ticklabels[i]
+                if length(labels) >= j
+                    str = labels[j]
+                    if !isempty(str)
+                        startpos = (origin .+ ((Float32(tick - origin[i]) * axis_vec)) .+ offset2)
+                        push!(textbuffer, str, startpos, color=ttextcolor[i], rotation=trotation[i],
+                              textsize=ttextsize[i], align=talign[i], font=tfont[i])
+                    end
+                end
+            end
+            if !isempty(axisnames[i])
+                tick_widths = if length(ticklabels[i]) >= 3
+                    widths(text_bb(ticklabels[i][end - 1], to_font(tfont[i]), ttextsize[i]))[1]
+                else
+                    0.0f0
+                end
+                pos = (labelposition(ranges, i, tickdir, titlegap[i] + tick_widths, origin) .+ offset2)
+                push!(textbuffer, to_latex(axisnames[i]), pos, textsize=axisnames_size[i],
+                      color=axisnames_color[i], rotation=axisrotation[i], align=axisalign[i],
+                      font=axisnames_font[i])
+            end
+        end
+        if showgrid[i]
+            c = gridcolors[i]
+            thickness = gridthickness[i]
+            for _j in (i + 1):(i + N - 1)
+                j = mod1(_j, N)
+                dir = unit(Point{N,Float32}, j)
+                range = ranges[j]
+                for tick in range
+                    offset = Float32(tick - origin[j]) * dir
+                    append!(linebuffer, [origin .+ offset, stop .+ offset], color=c, linewidth=thickness)
+                end
+            end
+        end
+        finish!(textbuffer)
+        finish!(linebuffer)
+    end
+    return
+end
+
+function plot!(scene::SceneLike, ::Type{<:Axis3D}, attributes::Attributes, args...)
+    axis = Axis3D(scene, attributes, args)
+    # Disable any non linear transform for the axis plot!
+    axis.transformation.transform_func[] = identity
+    textbuffer = TextBuffer(axis, Point{3}, transparency=true)
+    linebuffer = LinesegmentBuffer(axis, Point{3}, transparency=true)
+
+    tstyle, ticks, frame = to_value.(getindex.(axis, (:names, :ticks, :frame)))
+    titlevals = getindex.(tstyle, (:axisnames, :textcolor, :textsize, :rotation, :align, :font, :gap))
+    framevals = getindex.(frame, (:linecolor, :linewidth, :axiscolor))
+    tvals = getindex.(ticks, (:textcolor, :rotation, :textsize, :align, :font, :gap))
+    args = (getindex.(axis, (:showaxis, :showticks, :showgrid))..., titlevals..., framevals..., tvals...)
+    map_once(draw_axis3d, Node(textbuffer), Node(linebuffer), axis[1], axis.ticks.ranges_labels, args...)
+    push!(scene, axis)
+    return axis
+end

--- a/test/files/blowup/interfaces.jl
+++ b/test/files/blowup/interfaces.jl
@@ -1,0 +1,710 @@
+function not_implemented_for(x)
+    return error("Not implemented for $(x). You might want to put:  `using Makie` into your code!")
+end
+
+Attributes(x::AbstractPlot) = x.attributes
+
+default_theme(scene, T) = Attributes()
+
+function default_theme(scene)
+    return Attributes(color=theme(scene, :color), linewidth=1, transformation=automatic, model=automatic,
+                      visible=true, transparency=false, overdraw=false, ambient=Vec3f0(0.55),
+                      diffuse=Vec3f0(0.4), specular=Vec3f0(0.2), shininess=32.0f0, lightposition=:eyeposition,
+                      nan_color=RGBAf0(0, 0, 0, 0), ssao=false)
+end
+
+"""
+    `calculated_attributes!(trait::Type{<: AbstractPlot}, plot)`
+trait version of calculated_attributes
+"""
+calculated_attributes!(trait, plot) = nothing
+
+"""
+    `calculated_attributes!(plot::AbstractPlot)`
+Fill in values that can only be calculated when we have all other attributes filled
+"""
+calculated_attributes!(plot::T) where {T} = calculated_attributes!(T, plot)
+
+"""
+    image(x, y, image)
+    image(image)
+
+Plots an image on range `x, y` (defaults to dimensions).
+
+## Attributes
+$(ATTRIBUTES)
+"""
+@recipe(Image, x, y, image) do scene
+    return Attributes(; default_theme(scene)..., colormap=[:black, :white], interpolate=true, fxaa=false,
+                      lowclip=nothing, highclip=nothing)
+end
+
+# could be implemented via image, but might be optimized specifically by the backend
+"""
+    heatmap(x, y, values)
+    heatmap(values)
+
+Plots a heatmap as an image on `x, y` (defaults to interpretation as dimensions).
+
+## Attributes
+$(ATTRIBUTES)
+"""
+@recipe(Heatmap, x, y, values) do scene
+    return Attributes(; default_theme(scene)..., colormap=:viridis, linewidth=0.0, interpolate=false,
+                      levels=1, fxaa=true, lowclip=nothing, highclip=nothing)
+end
+
+"""
+    volume(volume_data)
+
+Plots a volume. Available algorithms are:
+* `:iso` => IsoValue
+* `:absorption` => Absorption
+* `:mip` => MaximumIntensityProjection
+* `:absorptionrgba` => AbsorptionRGBA
+* `:additive` => AdditiveRGBA
+* `:indexedabsorption` => IndexedAbsorptionRGBA
+
+## Attributes
+$(ATTRIBUTES)
+"""
+@recipe(Volume, x, y, z, volume) do scene
+    return Attributes(; default_theme(scene)..., algorithm=:mip, isovalue=0.5, isorange=0.05, color=nothing,
+                      colormap=:viridis, colorrange=(0, 1), fxaa=true)
+end
+
+"""
+    surface(x, y, z)
+
+Plots a surface, where `(x, y)`  define a grid whose heights are the entries in `z`.
+`x` and `y` may be `Vectors` which define a regular grid, **or** `Matrices` which define an irregular grid.
+
+## Attributes
+$(ATTRIBUTES)
+"""
+@recipe(Surface, x, y, z) do scene
+    return Attributes(; default_theme(scene)..., color=nothing, colormap=:viridis, shading=true, fxaa=true,
+                      lowclip=nothing, highclip=nothing)
+end
+
+"""
+    lines(positions)
+    lines(x, y)
+    lines(x, y, z)
+
+Creates a connected line plot for each element in `(x, y, z)`, `(x, y)` or `positions`.
+
+!!! tip
+    You can separate segments by inserting `NaN`s.
+
+## Attributes
+$(ATTRIBUTES)
+"""
+@recipe(Lines, positions) do scene
+    return Attributes(; default_theme(scene)..., linewidth=1.0, color=:black, colormap=:viridis,
+                      linestyle=nothing, fxaa=false)
+end
+
+"""
+    linesegments(positions)
+    linesegments(x, y)
+    linesegments(x, y, z)
+
+Plots a line for each pair of points in `(x, y, z)`, `(x, y)`, or `positions`.
+
+## Attributes
+$(ATTRIBUTES)
+"""
+@recipe(LineSegments, positions) do scene
+    return default_theme(scene, Lines)
+end
+
+# alternatively, mesh3d? Or having only mesh instead of poly + mesh and figure out 2d/3d via dispatch
+"""
+    mesh(x, y, z)
+    mesh(mesh_object)
+    mesh(x, y, z, faces)
+    mesh(xyz, faces)
+
+Plots a 3D or 2D mesh.
+
+## Attributes
+$(ATTRIBUTES)
+"""
+@recipe(Mesh, mesh) do scene
+    return Attributes(; default_theme(scene)..., color=:black, colormap=:viridis, interpolate=false,
+                      shading=true, fxaa=true)
+end
+
+"""
+    scatter(positions)
+    scatter(x, y)
+    scatter(x, y, z)
+
+Plots a marker for each element in `(x, y, z)`, `(x, y)`, or `positions`.
+
+## Attributes
+$(ATTRIBUTES)
+"""
+@recipe(Scatter, positions) do scene
+    return Attributes(; default_theme(scene)..., color=:gray65, colormap=:viridis, marker=Circle,
+                      markersize=10,
+
+                      strokecolor=:black, strokewidth=1.0, glowcolor=RGBA(0, 0, 0, 0), glowwidth=0.0,
+
+                      rotations=Billboard(), marker_offset=automatic, transform_marker=false, # Applies the plots transformation to marker # Applies the plots transformation to marker
+                      uv_offset_width=Vec4f0(0), distancefield=nothing, markerspace=Pixel, fxaa=false)
+end
+
+"""
+    meshscatter(positions)
+    meshscatter(x, y)
+    meshscatter(x, y, z)
+
+Plots a mesh for each element in `(x, y, z)`, `(x, y)`, or `positions` (similar to `scatter`).
+`markersize` is a scaling applied to the primitive passed as `marker`.
+
+## Attributes
+$(ATTRIBUTES)
+"""
+@recipe(MeshScatter, positions) do scene
+    return Attributes(; default_theme(scene)..., color=:black, colormap=:viridis, colorrange=automatic,
+                      marker=Sphere(Point3f0(0), 1.0f0), markersize=0.1, rotations=Quaternionf0(0, 0, 0, 1),
+                      # markerspace = relative,
+                      shading=true, fxaa=true)
+end
+
+"""
+    text(string)
+
+Plots a text.
+
+## Attributes
+$(ATTRIBUTES)
+"""
+@recipe(Text, text) do scene
+    return Attributes(; default_theme(scene)..., font=theme(scene, :font), strokecolor=(:black, 0.0),
+                      strokewidth=0, align=(:left, :bottom), rotation=0.0, textsize=20, position=Point2f0(0),
+                      justification=0.5, lineheight=1.0)
+end
+
+function color_and_colormap!(plot, intensity=plot[:color])
+    if isa(intensity[], AbstractArray{<:Number})
+        haskey(plot, :colormap) ||
+            error("Plot $(typeof(plot)) needs to have a colormap to allow the attribute color to be an array of numbers")
+
+        replace_automatic!(plot, :colorrange) do
+            return lift(extrema_nan, intensity)
+        end
+        return true
+    else
+        delete!(plot, :colorrange)
+        return false
+    end
+end
+
+function calculated_attributes!(::Type{<:Mesh}, plot)
+    need_cmap = color_and_colormap!(plot)
+    need_cmap || delete!(plot, :colormap)
+    return
+end
+
+function calculated_attributes!(::Type{<:Union{Heatmap,Image}}, plot)
+    plot[:color] = plot[3]
+    return color_and_colormap!(plot)
+end
+
+function calculated_attributes!(::Type{<:Surface}, plot)
+    colors = plot[3]
+    if haskey(plot, :color)
+        color = plot[:color][]
+        if isa(color, AbstractMatrix{<:Number}) && !(color === to_value(colors))
+            colors = plot[:color]
+        end
+    end
+    return color_and_colormap!(plot, colors)
+end
+
+function calculated_attributes!(::Type{<:MeshScatter}, plot)
+    return color_and_colormap!(plot)
+end
+
+function calculated_attributes!(::Type{<:Scatter}, plot)
+    # calculate base case
+    color_and_colormap!(plot)
+
+    replace_automatic!(plot, :marker_offset) do
+        # default to middle
+        return lift(x -> to_2d_scale(x .* (-0.5f0)), plot[:markersize])
+    end
+
+    replace_automatic!(plot, :markerspace) do
+        lift(plot.markersize) do ms
+            if ms isa Pixel || (ms isa AbstractVector && all(x -> ms isa Pixel, ms))
+                return Pixel
+            else
+                return SceneSpace
+            end
+        end
+    end
+end
+
+function calculated_attributes!(::Type{<:Union{Lines,LineSegments}}, plot)
+    color_and_colormap!(plot)
+    pos = plot[1][]
+    # extend one color per linesegment to be one (the same) color per vertex
+    # taken from @edljk  in PR #77
+    if haskey(plot, :color) &&
+       isa(plot[:color][], AbstractVector) &&
+       iseven(length(pos)) &&
+       (length(pos) ÷ 2) == length(plot[:color][])
+        plot[:color] = lift(plot[:color]) do cols
+            return map(i -> cols[(i + 1) ÷ 2], 1:(length(cols) * 2))
+        end
+    end
+end
+
+const atomic_function_symbols = (:text, :meshscatter, :scatter, :mesh, :linesegments, :lines, :surface,
+                                 :volume, :heatmap, :image)
+
+const atomic_functions = getfield.(Ref(AbstractPlotting), atomic_function_symbols)
+const Atomic{Arg} = Union{map(x -> Combined{x,Arg}, atomic_functions)...}
+
+function (PT::Type{<:Combined})(parent, transformation, attributes, input_args, converted)
+    return PT(parent, transformation, attributes, input_args, converted, AbstractPlot[])
+end
+
+plotsym(::Type{<:AbstractPlot{F}}) where {F} = Symbol(typeof(F).name.mt.name)
+
+"""
+    used_attributes(args...) = ()
+
+function used to indicate what keyword args one wants to get passed in `convert_arguments`.
+Usage:
+```example
+    struct MyType end
+    used_attributes(::MyType) = (:attribute,)
+    function convert_arguments(x::MyType; attribute = 1)
+        ...
+    end
+    # attribute will get passed to convert_arguments
+    # without keyword_verload, this wouldn't happen
+    plot(MyType, attribute = 2)
+    #You can also use the convenience macro, to overload convert_arguments in one step:
+    @keywords convert_arguments(x::MyType; attribute = 1)
+        ...
+    end
+```
+"""
+used_attributes(PlotType, args...) = ()
+
+"""
+apply for return type
+    (args...,)
+"""
+function apply_convert!(P, attributes::Attributes, x::Tuple)
+    return (plottype(P, x...), x)
+end
+
+"""
+apply for return type PlotSpec
+"""
+function apply_convert!(P, attributes::Attributes, x::PlotSpec{S}) where {S}
+    args, kwargs = x.args, x.kwargs
+    # Note that kw_args in the plot spec that are not part of the target plot type
+    # will end in the "global plot" kw_args (rest)
+    for (k, v) in pairs(kwargs)
+        attributes[k] = v
+    end
+    return (plottype(P, S), args)
+end
+
+function seperate_tuple(args::Node{<:NTuple{N,Any}}) where {N}
+    ntuple(N) do i
+        lift(args) do x
+            if i <= length(x)
+                x[i]
+            else
+                error("You changed the number of arguments. This isn't allowed!")
+            end
+        end
+    end
+end
+
+function (PlotType::Type{<:AbstractPlot{Typ}})(scene::SceneLike, attributes::Attributes, args) where {Typ}
+    input = convert.(Node, args)
+    argnodes = lift(input...) do args...
+        return convert_arguments(PlotType, args...)
+    end
+    return PlotType(scene, attributes, input, argnodes)
+end
+
+function plot(scene::Scene, plot::AbstractPlot)
+    # plot object contains local theme (default values), and user given values (from constructor)
+    # fill_theme now goes through all values that are missing from the user, and looks if the scene
+    # contains any theming values for them (via e.g. css rules). If nothing founds, the values will
+    # be taken from local theme! This will connect any values in the scene's theme
+    # with the plot values and track those connection, so that we can separate them
+    # when doing delete!(scene, plot)!
+    complete_theme!(scene, plot)
+    # we just return the plot... whoever calls plot (our pipeline usually)
+    # will need to push!(scene, plot) etc!
+    return plot
+end
+
+function (PlotType::Type{<:AbstractPlot{Typ}})(scene::SceneLike, attributes::Attributes, input,
+                                               args) where {Typ}
+    # The argument type of the final plot object is the assumened to stay constant after
+    # argument conversion. This might not always hold, but it simplifies
+    # things quite a bit
+    ArgTyp = typeof(to_value(args))
+    # construct the fully qualified plot type, from the possible incomplete (abstract)
+    # PlotType
+    FinalType = Combined{Typ,ArgTyp}
+    plot_attributes = merged_get!(() -> default_theme(scene, FinalType), plotsym(FinalType), scene,
+                                  attributes)
+
+    # Transformation is a field of the plot type, but can be given as an attribute
+    trans = get(plot_attributes, :transformation, automatic)
+    transformation = if to_value(trans) == automatic
+        Transformation(scene)
+    elseif isa(to_value(trans), Transformation)
+        to_value(trans)
+    else
+        t = Transformation(scene)
+        transform!(t, to_value(trans))
+        t
+    end
+    replace_automatic!(plot_attributes, :model) do
+        return transformation.model
+    end
+    # create the plot, with the full attributes, the input signals, and the final signal nodes.
+    plot_obj = FinalType(scene, transformation, plot_attributes, input, seperate_tuple(args))
+    transformation.parent[] = plot_obj
+    calculated_attributes!(plot_obj)
+    return plot_obj
+end
+
+"""
+    `plottype(plot_args...)`
+
+Any custom argument combination that has a preferred way to be plotted should overload this.
+e.g.:
+```example
+    # make plot(rand(5, 5, 5)) plot as a volume
+    plottype(x::Array{<: AbstractFloat, 3}) = Volume
+```
+"""
+plottype(plot_args...) = Combined{Any,Tuple{typeof.(to_value.(plot_args))...}} # default to dispatch to type recipes!
+
+## generic definitions
+# If the Combined has no plot func, calculate them
+plottype(::Type{<:Combined{Any}}, argvalues...) = plottype(argvalues...)
+plottype(::Type{Any}, argvalues...) = plottype(argvalues...)
+# If it has something more concrete than Any, use it directly
+plottype(P::Type{<:Combined{T}}, argvalues...) where {T} = P
+
+## specialized definitions for types
+plottype(::AbstractVector, ::AbstractVector) = Scatter
+plottype(::AbstractVector) = Scatter
+plottype(::AbstractMatrix{<:Real}) = Heatmap
+plottype(::Array{<:AbstractFloat,3}) = Volume
+plottype(::AbstractString) = Text
+
+plottype(::LineString) = Lines
+plottype(::AbstractVector{<:LineString}) = Lines
+plottype(::MultiLineString) = Lines
+
+plottype(::Polygon) = Poly
+plottype(::GeometryBasics.AbstractPolygon) = Poly
+plottype(::AbstractVector{<:GeometryBasics.AbstractPolygon}) = Poly
+plottype(::MultiPolygon) = Lines
+
+"""
+    plottype(P1::Type{<: Combined{T1}}, P2::Type{<: Combined{T2}})
+
+Chooses the more concrete plot type
+```example
+function convert_arguments(P::PlotFunc, args...)
+    ptype = plottype(P, Lines)
+    ...
+end
+"""
+plottype(P1::Type{<:Combined{Any}}, P2::Type{<:Combined{T}}) where {T} = P2
+plottype(P1::Type{<:Combined{T}}, P2::Type{<:Combined}) where {T} = P1
+
+"""
+Returns the Combined type that represents the signature of `args`.
+"""
+function Plot(args::Vararg{Any,N}) where {N}
+    return Combined{Any,<:Tuple{args...}}
+end
+Base.@pure function Plot(::Type{T}) where {T}
+    return Combined{Any,<:Tuple{T}}
+end
+Base.@pure function Plot(::Type{T1}, ::Type{T2}) where {T1,T2}
+    return Combined{Any,<:Tuple{T1,T2}}
+end
+
+# all the plotting functions that get a plot type
+const PlotFunc = Union{Type{Any},Type{<:AbstractPlot}}
+
+######################################################################
+# In this section, the plotting functions have P as the first argument
+# These are called from type recipes
+
+# non-mutating, without positional attributes
+
+function plot(P::PlotFunc, args...; kw_attributes...)
+    attributes = Attributes(kw_attributes)
+    return plot(P, attributes, args...)
+end
+
+# with positional attributes
+
+function plot(P::PlotFunc, attrs::Attributes, args...; kw_attributes...)
+    attributes = merge!(Attributes(kw_attributes), attrs)
+    scene_attributes = extract_scene_attributes!(attributes)
+    scene = Scene(; scene_attributes...)
+    return plot!(scene, P, attributes, args...)
+end
+
+# mutating, without positional attributes
+
+function plot!(P::PlotFunc, scene::SceneLike, args...; kw_attributes...)
+    attributes = Attributes(kw_attributes)
+    return plot!(scene, P, attributes, args...)
+end
+
+# without scenelike, use current scene
+
+function plot!(P::PlotFunc, args...; kw_attributes...)
+    return plot!(P, current_scene(), args...; kw_attributes...)
+end
+
+# with positional attributes
+
+function plot!(P::PlotFunc, scene::SceneLike, attrs::Attributes, args...; kw_attributes...)
+    attributes = merge!(Attributes(kw_attributes), attrs)
+    return plot!(scene, P, attributes, args...)
+end
+######################################################################
+
+# Register plot / plot! using the Any type as PlotType.
+# This is done so that plot(args...) / plot!(args...) can by default go
+# through a pipeline where the appropriate PlotType is determined
+# from the input arguments themselves.
+eval(default_plot_signatures(:plot, :plot!, :Any))
+
+# plots to scene
+
+plotfunc(::Combined{F}) where {F} = F
+
+"""
+Main plotting signatures that plot/plot! route to if no Plot Type is given
+"""
+function plot!(scene::SceneLike, P::PlotFunc, attributes::Attributes, args...; kw_attributes...)
+    attributes = merge!(Attributes(kw_attributes), attributes)
+    argvalues = to_value.(args)
+    PreType = plottype(P, argvalues...)
+    # plottype will lose the argument types, so we just extract the plot func
+    # type and recreate the type with the argument type
+    PreType = Combined{plotfunc(PreType),typeof(argvalues)}
+    convert_keys = intersect(used_attributes(PreType, argvalues...), keys(attributes))
+    kw_signal = if isempty(convert_keys) # lift(f) isn't supported so we need to catch the empty case
+        Node(())
+    else
+        lift((args...) -> Pair.(convert_keys, args), getindex.(attributes, convert_keys)...) # make them one tuple to easier pass through
+    end
+    # call convert_arguments for a first time to get things started
+    converted = convert_arguments(PreType, argvalues...; kw_signal[]...)
+    # convert_arguments can return different things depending on the recipe type
+    # apply_conversion deals with that!
+
+    FinalType, argsconverted = apply_convert!(PreType, attributes, converted)
+    converted_node = Node(argsconverted)
+    input_nodes = convert.(Node, args)
+    onany(kw_signal, lift(tuple, input_nodes...)) do kwargs, args
+        # do the argument conversion inside a lift
+        result = convert_arguments(FinalType, args...; kwargs...)
+        finaltype, argsconverted = apply_convert!(FinalType, attributes, result)
+        if finaltype != FinalType
+            error("Plot type changed from $FinalType to $finaltype after conversion.
+                Changing the plot type based on values in convert_arguments is not allowed")
+        end
+        return converted_node[] = argsconverted
+    end
+    return plot!(scene, FinalType, attributes, input_nodes, converted_node)
+end
+
+plot!(p::Combined) = _plot!(p)
+
+_plot!(p::Atomic{T}) where {T} = p
+
+function _plot!(p::Combined{Any,T}) where {T}
+    args = (T.parameters...,)
+    typed_args = join(string.("::", args), ", ")
+    return error("Plotting for the arguments ($typed_args) not defined. If you want to support those arguments, overload plot!(plot::Plot$((args...,)))")
+end
+function _plot!(p::Combined{X,T}) where {X,T}
+    args = (T.parameters...,)
+    typed_args = join(string.("::", args), ", ")
+    return error("Plotting for the arguments ($typed_args) not defined for $X. If you want to support those arguments, overload plot!(plot::$X{ <: $T})")
+end
+
+function show_attributes(attributes)
+    for (k, v) in attributes
+        println("    ", k, ": ", v[] == nothing ? "nothing" : v[])
+    end
+end
+
+"""
+    extract_scene_attributes!(attributes)
+
+removes all scene attributes from `attributes` and returns them in a new
+Attribute dict.
+"""
+function extract_scene_attributes!(attributes)
+    scene_attributes = (:backgroundcolor, :resolution, :show_axis, :show_legend, :scale_plot, :center, :axis,
+                        :axis2d, :axis3d, :legend, :camera, :limits, :padding, :raw, :SSAO)
+    result = Attributes()
+    for k in scene_attributes
+        haskey(attributes, k) && (result[k] = pop!(attributes, k))
+    end
+    return result
+end
+
+function plot!(scene::SceneLike, P::PlotFunc, attributes::Attributes, input::NTuple{N,Node},
+               args::Node) where {N}
+    # create "empty" plot type - empty meaning containing no plots, just attributes + arguments
+    scene_attributes = extract_scene_attributes!(attributes)
+    plot_object = P(scene, copy(attributes), input, args)
+    # transfer the merged attributes from theme and user defined to the scene
+    for (k, v) in scene_attributes
+        scene.attributes[k] = v
+    end
+    # We allow certain scene attributes to be part of the plot theme
+    for k in (:camera, :raw)
+        if haskey(plot_object, k)
+            scene.attributes[k] = plot_object[k]
+        end
+    end
+
+    # call user defined recipe overload to fill the plot type
+    plot!(plot_object)
+
+    push!(scene, plot_object)
+
+    if !scene.raw[] || scene[:camera][] !== automatic
+        # if no camera controls yet, setup camera
+        setup_camera!(scene)
+    end
+    if !scene.raw[]
+        add_axis!(scene, scene.attributes)
+    end
+    # ! ∘ isaxis --> (x)-> !isaxis(x)
+    # move axis to front, so that scene[end] gives back the last plot and not the axis!
+    if !isempty(scene.plots) && isaxis(last(scene.plots))
+        axis = pop!(scene.plots)
+        pushfirst!(scene.plots, axis)
+    end
+    return scene
+end
+
+function plot!(scene::Combined, P::PlotFunc, attributes::Attributes, args...)
+    # create "empty" plot type - empty meaning containing no plots, just attributes + arguments
+    plot_object = P(scene, attributes, args)
+    # call user defined recipe overload to fill the plot type
+    plot!(plot_object)
+    push!(scene.plots, plot_object)
+    return scene
+end
+function plot!(scene::Combined, P::PlotFunc, attributes::Attributes, input::NTuple{N,Node},
+               args::Node) where {N}
+    # create "empty" plot type - empty meaning containing no plots, just attributes + arguments
+    plot_object = P(scene, attributes, input, args)
+    # call user defined recipe overload to fill the plot type
+    plot!(plot_object)
+    push!(scene.plots, plot_object)
+    return scene
+end
+
+function apply_camera!(scene::Scene, cam_func)
+    if cam_func in (cam2d!, cam3d!, campixel!, cam3d_cad!)
+        cam_func(scene)
+    else
+        error("Unrecognized `camera` attribute type: $(typeof(cam_func)). Use automatic, cam2d! or cam3d!, campixel!, cam3d_cad!")
+    end
+end
+
+function setup_camera!(scene::Scene)
+    theme_cam = scene[:camera][]
+    if theme_cam == automatic
+        cam = cameracontrols(scene)
+        # only automatically add camera when cameracontrols are empty (not set)
+        if cam == EmptyCamera()
+            if is2d(scene)
+                cam2d!(scene)
+            else
+                cam3d!(scene)
+            end
+        end
+    else
+        apply_camera!(scene, theme_cam)
+    end
+    return scene
+end
+
+function find_in_plots(scene::Scene, key::Symbol)
+    # TODO findfirst is a bit flaky... maybe merge multiple ranges + tick labels?!
+    idx = findfirst(scene.plots) do plot
+        return !isaxis(plot) && haskey(plot, key) && plot[key][] !== automatic
+    end
+    if idx !== nothing
+        scene.plots[idx][key]
+    else
+        automatic
+    end
+end
+
+function add_axis!(scene::Scene, attributes=Attributes())
+    show_axis = scene.show_axis[]
+    show_axis isa Bool || error("show_axis needs to be a bool")
+    axistype = if scene.axis_type[] == automatic
+        is2d(scene) ? axis2d! : axis3d!
+    elseif scene.axis_type[] in (axis2d!, axis3d!)
+        scene.axis_type[]
+    else
+        error("Unrecogniced `axis_type` attribute type: $(typeof(scene[:axis_type][])). Use automatic, axis2d! or axis3d!")
+    end
+
+    if show_axis && scene[Axis] === nothing
+        axis_attributes = Attributes()
+        for key in (:axis, :axis2d, :axis3d)
+            if haskey(scene, key) && !isempty(scene[key])
+                axis_attributes = scene[key]
+                break
+            end
+        end
+        ranges = get(attributes, :tickranges) do
+            return find_in_plots(scene, :tickranges)
+        end
+        labels = get(attributes, :ticklabels) do
+            return find_in_plots(scene, :ticklabels)
+        end
+        lims = lift(scene.limits, scene.data_limits) do sl, dl
+            sl === automatic && return dl
+            return sl
+        end
+        axistype(scene, axis_attributes, lims, ticks=(ranges=ranges, labels=labels))
+    end
+    return scene
+end
+
+function add_labels!(scene::Scene)
+    if plot_attributes.show_legend[] && haskey(p.attributes, :colormap)
+        legend_attributes = plot_attributes[:legend][]
+        colorlegend(scene, p.attributes[:colormap], p.attributes[:colorrange], legend_attributes)
+    end
+    return scene
+end

--- a/test/files/blowup/interfaces.jl
+++ b/test/files/blowup/interfaces.jl
@@ -152,7 +152,7 @@ $(ATTRIBUTES)
 
                       strokecolor=:black, strokewidth=1.0, glowcolor=RGBA(0, 0, 0, 0), glowwidth=0.0,
 
-                      rotations=Billboard(), marker_offset=automatic, transform_marker=false, # Applies the plots transformation to marker # Applies the plots transformation to marker
+                      rotations=Billboard(), marker_offset=automatic, transform_marker=false, # Applies the plots transformation to marker
                       uv_offset_width=Vec4f0(0), distancefield=nothing, markerspace=Pixel, fxaa=false)
 end
 

--- a/test/files/blowup/interfaces.jl
+++ b/test/files/blowup/interfaces.jl
@@ -148,11 +148,8 @@ $(ATTRIBUTES)
 """
 @recipe(Scatter, positions) do scene
     return Attributes(; default_theme(scene)..., color=:gray65, colormap=:viridis, marker=Circle,
-                      markersize=10,
-
-                      strokecolor=:black, strokewidth=1.0, glowcolor=RGBA(0, 0, 0, 0), glowwidth=0.0,
-
-                      rotations=Billboard(), marker_offset=automatic, transform_marker=false, # Applies the plots transformation to marker
+                      markersize=10, strokecolor=:black, strokewidth=1.0, glowcolor=RGBA(0, 0, 0, 0),
+                      glowwidth=0.0, rotations=Billboard(), marker_offset=automatic, transform_marker=false, # Applies the plots transformation to marker
                       uv_offset_width=Vec4f0(0), distancefield=nothing, markerspace=Pixel, fxaa=false)
 end
 

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -617,7 +617,6 @@
         str = """
         scaled_ticks, mini, maxi = optimize_ticks(scale_func(lmin), scale_func(lmax); k_min=4, # minimum number of ticks
                                                   k_max=8)"""
-        @test yasfmt(str, 4, 92, whitespace_in_kwargs=false) == str
-
+        @test yasfmt(str, 4, 92, whitespace_in_kwargs = false) == str
     end
 end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -612,5 +612,4 @@
         """
         @test format_text(str, BlueStyle()) == str
     end
-
 end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -613,10 +613,4 @@
         @test format_text(str, BlueStyle()) == str
     end
 
-    @testset "issue 321 - exponential inline comments !!!" begin
-        str = """
-        scaled_ticks, mini, maxi = optimize_ticks(scale_func(lmin), scale_func(lmax); k_min=4, # minimum number of ticks
-                                                  k_max=8)"""
-        @test yasfmt(str, 4, 92, whitespace_in_kwargs = false) == str
-    end
 end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -612,4 +612,12 @@
         """
         @test format_text(str, BlueStyle()) == str
     end
+
+    @testset "issue 321 - exponential inline comments !!!" begin
+        str = """
+        scaled_ticks, mini, maxi = optimize_ticks(scale_func(lmin), scale_func(lmax); k_min=4, # minimum number of ticks
+                                                  k_max=8)"""
+        @test yasfmt(str, 4, 92, whitespace_in_kwargs=false) == str
+
+    end
 end

--- a/test/yas_style.jl
+++ b/test/yas_style.jl
@@ -441,4 +441,5 @@
         str = "[x[i] for i in 1:length(x)]"
         @test yasfmt(str_, 4, 92, always_for_in = true) == str
     end
+
 end

--- a/test/yas_style.jl
+++ b/test/yas_style.jl
@@ -441,5 +441,4 @@
         str = "[x[i] for i in 1:length(x)]"
         @test yasfmt(str_, 4, 92, always_for_in = true) == str
     end
-
 end

--- a/test/yas_style.jl
+++ b/test/yas_style.jl
@@ -441,4 +441,11 @@
         str = "[x[i] for i in 1:length(x)]"
         @test yasfmt(str_, 4, 92, always_for_in = true) == str
     end
+
+    @testset "issue 321 - exponential inline comments !!!" begin
+        str = """
+        scaled_ticks, mini, maxi = optimize_ticks(scale_func(lmin), scale_func(lmax); k_min=4, # minimum number of ticks
+                                                  k_max=8)"""
+        @test yasfmt(str, 4, 92, whitespace_in_kwargs = false) == str
+    end
 end


### PR DESCRIPTION
fixes #321 

This would lead to exponential blowup in the comment size and a file a few GB in size yikes!!!

Also adds some test files from AbstractPlotting.jl