### PR TITLE
Use `op_kind` to determine kind of binary op instead of indexing, some binary ops only have 2 elements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.10.5"
+version = "0.10.6"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/align.jl
+++ b/src/align.jl
@@ -17,13 +17,11 @@ function align_fst!(fst::FST, opts::Options)
             align_fst!(n, opts)
         end
 
-        # gather all assignments within the current code block
-        # they will be aligned at the end
         if is_assignment(n) || n.typ === CSTParser.Kw
+            # Gather all assignments within the current code block
+            # they will be aligned at the end
             push!(assignment_idxs, i)
-        end
-
-        if n.typ === CSTParser.BinaryOpCall && n[3].val == "=>"
+        elseif n.typ === CSTParser.BinaryOpCall && op_kind(n) === Tokens.PAIR_ARROW
             push!(pair_arrow_idxs, i)
         end
     end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -619,6 +619,6 @@
         θ = eigvals(Matrix([0I(n^2) -I(n^2); P0 P1]), -Matrix([I(n^2) 0I(n^2); 0I(n^2) P2]))
         c = maximum(abs.(θ[(imag.(θ).==0).*(real.(θ).>0)]))
         """
-        @test format_text(str, align_assignment=true) == str
+        @test format_text(str, align_assignment = true) == str
     end
 end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -612,4 +612,13 @@
         """
         @test format_text(str, BlueStyle()) == str
     end
+
+    @testset "issue 324 - bounds error when aligning binary op calls" begin
+        # caused by the star operator
+        str = """
+        θ = eigvals(Matrix([0I(n^2) -I(n^2); P0 P1]), -Matrix([I(n^2) 0I(n^2); 0I(n^2) P2]))
+        c = maximum(abs.(θ[(imag.(θ).==0).*(real.(θ).>0)]))
+        """
+        @test format_text(str, align_assignment=true) == str
+    end
 end


### PR DESCRIPTION
fixes #324 