### PR TITLE
More robust alignment of assignment expressions. 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.10.6"
+version = "0.10.7"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/align.jl
+++ b/src/align.jl
@@ -160,7 +160,7 @@ function align_binaryopcalls!(fst::FST, op_idxs::Vector{Int})
             g = AlignGroup()
         end
 
-        binop, nlen, ws = if n.typ === CSTParser.BinaryOpCall || n.typ === CSTParser.Kw 
+        binop, nlen, ws = if n.typ === CSTParser.BinaryOpCall || n.typ === CSTParser.Kw
             nlen = length(n[1])
             n, nlen, (n[3].line_offset - n.line_offset) - nlen
         else

--- a/src/align.jl
+++ b/src/align.jl
@@ -160,10 +160,16 @@ function align_binaryopcalls!(fst::FST, op_idxs::Vector{Int})
             g = AlignGroup()
         end
 
-        binop = n.typ === CSTParser.BinaryOpCall || n.typ === CSTParser.Kw ? n : n[3]
-        nlen = length(binop[1])
+        binop, nlen, ws = if n.typ === CSTParser.BinaryOpCall || n.typ === CSTParser.Kw 
+            nlen = length(n[1])
+            n, nlen, (n[3].line_offset - n.line_offset) - nlen
+        else
+            binop = n[3]
+            nlen = length(binop[1]) + length(fst[i][1]) + length(fst[i][2])
+            binop, nlen, (binop[3].line_offset - n.line_offset) - nlen
+        end
 
-        ws = binop[3].line_offset - (binop.line_offset + nlen)
+        # @info "" binop.typ nlen ws
         push!(g, i, binop[3].line_offset, nlen, ws)
 
         prev_endline = n.endline

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -557,7 +557,8 @@ function is_assignment(x::Union{FST,CSTParser.EXPR})
         x.typ === CSTParser.Const ||
         x.typ === CSTParser.Local ||
         x.typ === CSTParser.Global ||
-        x.typ === CSTParser.Outer
+        x.typ === CSTParser.Outer ||
+        x.typ === MacroBlock
     ) && is_assignment(x[end])
         return true
     end

--- a/test/options.jl
+++ b/test/options.jl
@@ -1081,7 +1081,6 @@
         """
         @test fmt(str_, 4, 100, align_assignment = true) == str
 
-
         str = """
         function stabilize(model)
             s            = model.sys

--- a/test/options.jl
+++ b/test/options.jl
@@ -1052,6 +1052,54 @@
         )
         """
         @test fmt(str, 4, 100, align_assignment = true, whitespace_in_kwargs = false) == str
+
+        str_ = """
+        s           = model.sys
+        @unpack A,K = s
+        C           = s.C
+        poles       = eigvals(A - K * C)
+        """
+        str = """
+        s            = model.sys
+        @unpack A, K = s
+        C            = s.C
+        poles        = eigvals(A - K * C)
+        """
+        @test fmt(str_, 4, 100, align_assignment = true) == str
+
+        str_ = """
+        s             = model.sys
+        @unpack A,K   = s
+        C             = s.C
+        const polesss = eigvals(A - K * C)
+        """
+        str = """
+        s             = model.sys
+        @unpack A, K  = s
+        C             = s.C
+        const polesss = eigvals(A - K * C)
+        """
+        @test fmt(str_, 4, 100, align_assignment = true) == str
+
+
+        str = """
+        function stabilize(model)
+            s            = model.sys
+            @unpack A, K = s
+            C            = s.C
+            poles        = eigvals(A - K * C)
+            newpoles     = map(poles) do p
+                ap = abs(p)
+                ap <= 1 && (return p)
+                p / (ap + sqrt(eps()))
+            end
+            K2           = ControlSystems.acker(A', C', newpoles)' .|> real
+            all(abs(p) <= 1 for p in eigvals(A - K * C)) || @warn("Failed to stabilize predictor")
+            s.K .= K2
+            model
+        end
+        """
+        @test fmt(str, 4, 100, align_assignment = true) == str
     end
 
     @testset "align conditionals" begin


### PR DESCRIPTION
In summary this is now possible:

```julia
const s      = model.sys
@unpack A, K = s
C            = s.C
poles        = eigvals(A - K * C)
newpoles     = map(poles) do p
    ap = abs(p)
    ap <= 1 && (return p)
    p / (ap + sqrt(eps()))
end
K2           = ControlSystems.acker(A', C', newpoles)' .|> real
```

Previously the assignments had to be uniform, meaning `const ... =
...` would only be aligned if the other `... = ...` expressions in the code block were `const`.

Noticed this when formatting https://github.com/baggepinnen/ControlSystemIdentification.jl