### PR TITLE
Fix #336

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.12.0"
+version = "0.12.1"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -569,7 +569,10 @@ function n_binaryopcall!(ds::DefaultStyle, fst::FST, s::State)
             cst = rhs.ref[]
             line_margin = s.line_offset
 
-            if (rhs.typ === CSTParser.BinaryOpCall && !(op_kind(cst) === Tokens.IN || op_kind(rhs) === Tokens.DECLARATION)) ||
+            if (
+                   rhs.typ === CSTParser.BinaryOpCall &&
+                   !(op_kind(cst) === Tokens.IN || op_kind(rhs) === Tokens.DECLARATION)
+               ) ||
                rhs.typ === CSTParser.UnaryOpCall ||
                rhs.typ === CSTParser.ChainOpCall ||
                rhs.typ === CSTParser.Comparison ||

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -569,7 +569,7 @@ function n_binaryopcall!(ds::DefaultStyle, fst::FST, s::State)
             cst = rhs.ref[]
             line_margin = s.line_offset
 
-            if (rhs.typ === CSTParser.BinaryOpCall && cst[2].kind !== Tokens.IN) ||
+            if (rhs.typ === CSTParser.BinaryOpCall && !(op_kind(cst) === Tokens.IN || op_kind(rhs) === Tokens.DECLARATION)) ||
                rhs.typ === CSTParser.UnaryOpCall ||
                rhs.typ === CSTParser.ChainOpCall ||
                rhs.typ === CSTParser.Comparison ||

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -621,4 +621,23 @@
                f("A")"""
         @test format_text(str_) == str
     end
+
+    @testset "issue 336" begin
+        str_ = """
+        nzthis = _hessian_slice(d, ex, x, H, obj_factor, nzcount, recovery_tmp_storage, Val{1})::Int
+        """
+        str = """
+        nzthis = _hessian_slice(
+            d,
+            ex,
+            x,
+            H,
+            obj_factor,
+            nzcount,
+            recovery_tmp_storage,
+            Val{1},
+        )::Int
+        """
+        @test fmt(str_, 4, 80) == str
+    end
 end


### PR DESCRIPTION
```
var =
    funccall(
        ...,
    )::Type
```

Is now lifted up when possible - identical treatment to `funccall` as if `::Type` was not present.

```
var = funccall(
    ...,
)::Type
```