### PR TITLE
Add compatibility with Documenter 0.26

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.12.2"
+version = "0.12.3"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
@@ -16,6 +16,6 @@ Tokenize = "0796e94c-ce3b-5d07-9a54-7f471281c624"
 CSTParser = "^2.2"
 CommonMark = "0.5, 0.6"
 DataStructures = "0.17, 0.18"
-Documenter = "0.24, 0.25"
+Documenter = "0.24, 0.25, 0.26"
 Tokenize = "^0.5.7"
 julia = "1"


### PR DESCRIPTION
This PR tries to add compatibility with Documenter 0.26 (there was no CompatHelper PR since the action fails currently, see also https://github.com/domluna/JuliaFormatter.jl/pull/353).