### PR TITLE
Keep whitespace around kwargs if the RHS is an opcall such as `>=(1)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.13.0"
+version = "0.13.1"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Tokenize = "0796e94c-ce3b-5d07-9a54-7f471281c624"
 
 [compat]
 CSTParser = "^2.2"
-CommonMark = "0.5, 0.6"
+CommonMark = "0.5, 0.6, 0.7"
 DataStructures = "0.17, 0.18"
 Documenter = "0.24, 0.25, 0.26"
 Tokenize = "^0.5.7"

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1318,16 +1318,53 @@ function p_kw(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
     t = FST(cst, nspaces(s))
 
     exclamation = cst[1].typ === CSTParser.IDENTIFIER && endswith(cst[1].val, "!")
+    opcall = (cst[3].typ === CSTParser.Call && cst[3][1].typ === CSTParser.OPERATOR)
 
-    add_node!(t, pretty(style, cst[1], s), s, join_lines = true)
-    if s.opts.whitespace_in_kwargs || exclamation
+    if !s.opts.whitespace_in_kwargs && exclamation
+        n = pretty(style, cst[1], s)
+        add_node!(
+            t,
+            FST(CSTParser.PUNCTUATION, -1, n.startline, n.startline, "("),
+            s,
+            join_lines = true,
+        )
+        add_node!(t, n, s, join_lines = true)
+        add_node!(
+            t,
+            FST(CSTParser.PUNCTUATION, -1, n.startline, n.startline, ")"),
+            s,
+            join_lines = true,
+        )
+    else
+        add_node!(t, pretty(style, cst[1], s), s, join_lines = true)
+    end
+
+    if s.opts.whitespace_in_kwargs
         add_node!(t, Whitespace(1), s)
         add_node!(t, pretty(style, cst[2], s), s, join_lines = true)
         add_node!(t, Whitespace(1), s)
     else
         add_node!(t, pretty(style, cst[2], s), s, join_lines = true)
     end
-    add_node!(t, pretty(style, cst[3], s), s, join_lines = true)
+
+    if !s.opts.whitespace_in_kwargs && opcall
+        n = pretty(style, cst[3], s)
+        add_node!(
+            t,
+            FST(CSTParser.PUNCTUATION, -1, n.startline, n.startline, "("),
+            s,
+            join_lines = true,
+        )
+        add_node!(t, n, s, join_lines = true)
+        add_node!(
+            t,
+            FST(CSTParser.PUNCTUATION, -1, n.startline, n.startline, ")"),
+            s,
+            join_lines = true,
+        )
+    else
+        add_node!(t, pretty(style, cst[3], s), s, join_lines = true)
+    end
 
     t
 end

--- a/test/options.jl
+++ b/test/options.jl
@@ -364,11 +364,11 @@
 
         # issue 242
         str_ = "f(a, b! = 1; c! = 2, d = 3, e! = 4)"
-        str = "f(a, b! = 1; c! = 2, d=3, e! = 4)"
+        str = "f(a, (b!)=1; (c!)=2, d=3, (e!)=4)"
         @test fmt(str_, 4, 92, whitespace_in_kwargs = false) == str
 
         str_ = "( k1 =v1,  k2! = v2)"
-        str = "(k1=v1, k2! = v2)"
+        str = "(k1=v1, (k2!)=v2)"
         @test fmt(str_, 4, 80, style = YASStyle(), whitespace_in_kwargs = false) == str
         @test fmt(str_, 4, 80, style = DefaultStyle(), whitespace_in_kwargs = false) == str
 
@@ -376,6 +376,14 @@
         str = "(k1 = v1, k2! = v2)"
         @test fmt(str_, 4, 80, style = YASStyle(), whitespace_in_kwargs = true) == str
         @test fmt(str_, 4, 80, style = DefaultStyle(), whitespace_in_kwargs = true) == str
+
+        str_ = "f(; a = b)"
+        str = "f(; a=b)"
+        @test fmt(str_, 4, 92, whitespace_in_kwargs = false) == str
+
+        str_ = "(; g = >=(1))"
+        str = "(; g=(>=(1)))"
+        @test fmt(str_, 4, 92, whitespace_in_kwargs = false) == str
     end
 
     @testset "annotate untyped fields with `Any`" begin

--- a/test/options.jl
+++ b/test/options.jl
@@ -377,10 +377,6 @@
         @test fmt(str_, 4, 80, style = YASStyle(), whitespace_in_kwargs = true) == str
         @test fmt(str_, 4, 80, style = DefaultStyle(), whitespace_in_kwargs = true) == str
 
-        str_ = "f(; a = b)"
-        str = "f(; a=b)"
-        @test fmt(str_, 4, 92, whitespace_in_kwargs = false) == str
-
         str_ = "(; g = >=(1))"
         str = "(; g=(>=(1)))"
         @test fmt(str_, 4, 92, whitespace_in_kwargs = false) == str


### PR DESCRIPTION
Fix #360



Also behaviour with ! identifiers has changed. Previously whitespace
would be kept if the LHS identifier ended with a !, now the identifier
is wrapped in parenthesis

```
(; a! = 1)

->

(; (a!)=1)
```