### PR TITLE
Remove support for versions earlier than 1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.0'
           - '1.3'
           - '1.4'
           - '1.5'

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ CommonMark = "0.5, 0.6, 0.7"
 DataStructures = "0.17, 0.18"
 Documenter = "0.24, 0.25, 0.26"
 Tokenize = "^0.5.7"
-julia = "1"
+julia = "^1.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -457,46 +457,6 @@ function format_file(filename::AbstractString, style::AbstractStyle; kwargs...)
     return format_file(filename; style = style, kwargs...)
 end
 
-if VERSION < v"1.1.0"
-    # We define `splitpath` here, copying the definition from base/path.jl
-    # because it was only added in Julia 1.1.
-
-    # TODO(odow): remove this definition of splitpath once JuliaFormatter no
-    # longer supports Julia 1.0.
-    _splitdir_nodrive(path::String) = _splitdir_nodrive("", path)
-    function _splitdir_nodrive(a::String, b::String)
-        path_dir_splitter = if Sys.isunix()
-            r"^(.*?)(/+)([^/]*)$"
-        elseif Sys.iswindows()
-            r"^(.*?)([/\\]+)([^/\\]*)$"
-        else
-            error("JuliaFormatter.jl does not work on this OS.")
-        end
-        m = match(path_dir_splitter, b)
-        m === nothing && return (a, b)
-        a = string(a, isempty(m.captures[1]) ? m.captures[2][1] : m.captures[1])
-        a, String(m.captures[3])
-    end
-    splitpath(p::AbstractString) = splitpath(String(p))
-    function splitpath(p::String)
-        drive, p = splitdrive(p)
-        out = String[]
-        isempty(p) && (pushfirst!(out, p))  # "" means the current directory.
-        while !isempty(p)
-            dir, base = _splitdir_nodrive(p)
-            dir == p && (pushfirst!(out, dir); break)  # Reached root node.
-            if !isempty(base)  # Skip trailing '/' in basename
-                pushfirst!(out, base)
-            end
-            p = dir
-        end
-        if !isempty(drive)  # Tack the drive back on to the first element.
-            out[1] = drive * out[1]  # Note that length(out) is always >= 1.
-        end
-        return out
-    end
-end
-
 const CONFIG_FILE_NAME = ".JuliaFormatter.toml"
 
 """


### PR DESCRIPTION
#365 caused tests to fail for versions < 1.3. The CI didn't run for that PR for some reason and I was fooled by the green check mark. So we could try to fix on the earlier versions but I'm not sure there's a great reason to either since they are dated at this point and going forward with CSTParser3 and it mimicking the Julia AST now it may be harder to keep things working on earlier versions. 