### PR TITLE
fix #375

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.13.2"
+version = "0.13.3"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/styles/blue/pretty.jl
+++ b/src/styles/blue/pretty.jl
@@ -122,7 +122,6 @@ function p_binaryopcall(
         # Do nothing - represents a binary op with no textual representation.
         # For example: `2a`, which is equivalent to `2 * a`.
     elseif op.kind === Tokens.EX_OR
-        add_node!(t, Whitespace(1), s)
         add_node!(t, pretty(style, op, s), s, join_lines = true)
     elseif (
         is_number(cst[1]) ||

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1419,7 +1419,6 @@ function p_binaryopcall(
         # Do nothing - represents a binary op with no textual representation.
         # For example: `2a`, which is equivalent to `2 * a`.
     elseif op.kind === Tokens.EX_OR
-        add_node!(t, Whitespace(1), s)
         add_node!(t, pretty(style, op, s), s, join_lines = true)
     elseif (is_number(cst[1]) || op.kind === Tokens.CIRCUMFLEX_ACCENT) && op.dot
         add_node!(t, Whitespace(1), s)

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -640,4 +640,12 @@
         """
         @test fmt(str_, 4, 80) == str
     end
+
+    @testset "issue 375" begin
+        s = raw"conflictstatus = @jimport ilog.cp.IloCP$ConflictStatus"
+        @test fmt(s) == s
+
+        s = raw"conflictstatus = @jimport ilog.cp.IloCP$ConflictStatus"
+        @test bluefmt(s) == s
+    end
 end


### PR DESCRIPTION
Remove addition of whitespace when $ is used in the context of
binary op calls. I'm not sure why the whitespace was added previously
since it doesn't break any testing.

Example text:

```julia
conflictstatus = @jimport ilog.cp.IloCP$ConflictStatus
```