### PR TITLE
Resolve #352

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.13.3"
+version = "0.13.4"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -751,7 +751,7 @@ function n_block!(ds::DefaultStyle, fst::FST, s::State; indent = -1)
         nest!(style, fst.nodes, s, fst.indent, extra_margin = fst.extra_margin)
     end
 end
-n_block!(style::S, fst::FST, s::State; indent = 0) where {S<:AbstractStyle} =
+n_block!(style::S, fst::FST, s::State; indent = -1) where {S<:AbstractStyle} =
     n_block!(DefaultStyle(style), fst, s, indent = indent)
 
 @inline n_comparison!(ds::DefaultStyle, fst::FST, s::State) =

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1046,7 +1046,7 @@ function p_for(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
         s.indent -= s.opts.indent
         n
     else
-        n = pretty(style, cst[2], s)
+       pretty(style, cst[2], s)
     end
 
     cst[1].kind === Tokens.FOR && eq_to_in_normalization!(n, s.opts.always_for_in)

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1046,7 +1046,7 @@ function p_for(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
         s.indent -= s.opts.indent
         n
     else
-       pretty(style, cst[2], s)
+        pretty(style, cst[2], s)
     end
 
     cst[1].kind === Tokens.FOR && eq_to_in_normalization!(n, s.opts.always_for_in)

--- a/src/styles/yas/nest.jl
+++ b/src/styles/yas/nest.jl
@@ -181,7 +181,7 @@ function n_for!(ys::YASStyle, fst::FST, s::State)
         else
             n.extra_margin = fst.extra_margin
             if i == 3 && n.typ === CSTParser.Block
-                n_block!(style, n, s, indent=s.line_offset)
+                n_block!(style, n, s, indent = s.line_offset)
             else
                 nest!(style, n, s)
             end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -648,4 +648,38 @@
         s = raw"conflictstatus = @jimport ilog.cp.IloCP$ConflictStatus"
         @test bluefmt(s) == s
     end
+
+    @testset "issue 352" begin
+        str_ = """
+                      @inbounds for f in 1:n_freqs, m in 1:n_channels, l in 1:n_channels, k in 1:length(weighted_evals)
+                         a = f + m + l + k
+                      end"""
+        str = """
+        @inbounds for f in 1:n_freqs,
+                      m in 1:n_channels,
+                      l in 1:n_channels,
+                      k in 1:length(weighted_evals)
+
+            a = f + m + l + k
+        end"""
+        @test yasfmt(str_, always_for_in = true) == str
+
+        str_ = """
+        using Test
+
+        @testset "A long testset name that is rather long" for variable in 100:200, other_var in 1:100
+            @test true
+        end
+        """
+        str = """
+        using Test
+
+        @testset "A long testset name that is rather long" for variable in 100:200,
+            other_var in 1:100
+
+            @test true
+        end
+        """
+        @test bluefmt(str_, always_for_in = true) == str
+    end
 end


### PR DESCRIPTION
For BlueStyle fix it was literally just a typo of 0 instead of -1 in the
dispatch for non-default styles.

For YASStyle we have to copy-pasta the nest! function for Vector{EXPR}
into n_for!(::YASStyle, ...) so that we can set the indent for the
argument block that sometimes occurs in a for/while loop.

In generator expressions, the for loop is not parsed as as a for loop
but rather a vector of expressions that happens to have a `for` keyword
which is why this worked fine for those.