### PR TITLE
Solve #316 - Add option to replace `in` used in `always_for_in`

### DIFF
--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -317,6 +317,20 @@ end
 
 One of `"unix"` (normalize all `\r\n` to `\n`), `"windows"` (normalize all `\n` to `\r\n`), `"auto"` (automatically
 choose based on which line ending is more common in the file).
+
+### `for_in_replacement`
+
+Can be used when `always_for_in` is `true` to replace `in` with ∈ (\\in), or `=` instead:
+
+```julia
+for a = 1:10
+end
+
+# formatted with always_for_in = true, for_in_replacement = "∈"
+for a ∈ 1:10
+end
+```
+
 """
 function format_text(text::AbstractString; style::AbstractStyle = DefaultStyle(), kwargs...)
     return format_text(text, style; kwargs...)

--- a/src/options.jl
+++ b/src/options.jl
@@ -18,10 +18,10 @@ Base.@kwdef struct Options
     align_pair_arrow::Bool = false
     conditional_to_if::Bool = false
     normalize_line_endings::String = "auto"
-    in_replacement::String = "in"
+    for_in_replacement::String = "in"
 end
 
-function valid_in_op(s::String)
+function valid_for_in_op(s::String)
     s == "in" && return true
     s == "=" && return true
     s == "∈" && return true

--- a/src/options.jl
+++ b/src/options.jl
@@ -20,3 +20,10 @@ Base.@kwdef struct Options
     normalize_line_endings::String = "auto"
     in_replacement::String = "in"
 end
+
+function valid_in_op(s::String)
+    s == "in" && return true
+    s == "=" && return true
+    s == "∈" && return true
+    return false
+end

--- a/src/options.jl
+++ b/src/options.jl
@@ -18,4 +18,5 @@ Base.@kwdef struct Options
     align_pair_arrow::Bool = false
     conditional_to_if::Bool = false
     normalize_line_endings::String = "auto"
+    in_replacement::String = "in"
 end

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1007,14 +1007,14 @@ p_let(style::S, cst::CSTParser.EXPR, s::State) where {S<:AbstractStyle} =
 # for i = 1:10 body end
 #
 # https://github.com/domluna/JuliaFormatter.jl/issues/34
-function eq_to_in_normalization!(fst::FST, always_for_in::Bool, in_replacement::String)
+function eq_to_in_normalization!(fst::FST, always_for_in::Bool, for_in_replacement::String)
     if fst.typ === CSTParser.BinaryOpCall
         idx = findfirst(n -> n.typ === CSTParser.OPERATOR, fst.nodes)
         idx === nothing && return
         op = fst[idx]
 
-        if always_for_in && valid_in_op(op.val)
-            op.val = in_replacement
+        if always_for_in && valid_for_in_op(op.val)
+            op.val = for_in_replacement
             op.len = length(op.val)
             return
         end
@@ -1028,7 +1028,7 @@ function eq_to_in_normalization!(fst::FST, always_for_in::Bool, in_replacement::
         end
     elseif !is_leaf(fst)
         for n in fst.nodes
-            eq_to_in_normalization!(n, always_for_in, in_replacement)
+            eq_to_in_normalization!(n, always_for_in, for_in_replacement)
         end
     end
 end
@@ -1049,7 +1049,7 @@ function p_for(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
         pretty(style, cst[2], s)
     end
 
-    cst[1].kind === Tokens.FOR && eq_to_in_normalization!(n, s.opts.always_for_in, s.opts.in_replacement)
+    cst[1].kind === Tokens.FOR && eq_to_in_normalization!(n, s.opts.always_for_in, s.opts.for_in_replacement)
     add_node!(t, n, s, join_lines = true)
 
     idx = length(t.nodes)
@@ -2029,7 +2029,7 @@ function p_generator(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
             add_node!(t, n, s, join_lines = true)
         end
 
-        has_for_kw && eq_to_in_normalization!(n, s.opts.always_for_in, s.opts.in_replacement)
+        has_for_kw && eq_to_in_normalization!(n, s.opts.always_for_in, s.opts.for_in_replacement)
     end
     t
 end

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1049,7 +1049,8 @@ function p_for(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
         pretty(style, cst[2], s)
     end
 
-    cst[1].kind === Tokens.FOR && eq_to_in_normalization!(n, s.opts.always_for_in, s.opts.for_in_replacement)
+    cst[1].kind === Tokens.FOR &&
+        eq_to_in_normalization!(n, s.opts.always_for_in, s.opts.for_in_replacement)
     add_node!(t, n, s, join_lines = true)
 
     idx = length(t.nodes)
@@ -2029,7 +2030,8 @@ function p_generator(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
             add_node!(t, n, s, join_lines = true)
         end
 
-        has_for_kw && eq_to_in_normalization!(n, s.opts.always_for_in, s.opts.for_in_replacement)
+        has_for_kw &&
+            eq_to_in_normalization!(n, s.opts.always_for_in, s.opts.for_in_replacement)
     end
     t
 end

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1013,7 +1013,7 @@ function eq_to_in_normalization!(fst::FST, always_for_in::Bool, in_replacement::
         idx === nothing && return
         op = fst[idx]
 
-        if always_for_in
+        if always_for_in && valid_in_op(op.val)
             op.val = in_replacement
             op.len = length(op.val)
             return
@@ -1026,7 +1026,7 @@ function eq_to_in_normalization!(fst::FST, always_for_in::Bool, in_replacement::
             op.val = "="
             op.len = length(op.val)
         end
-    elseif fst.typ === CSTParser.Block || fst.typ === CSTParser.InvisBrackets
+    elseif !is_leaf(fst)
         for n in fst.nodes
             eq_to_in_normalization!(n, always_for_in, in_replacement)
         end

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1007,14 +1007,14 @@ p_let(style::S, cst::CSTParser.EXPR, s::State) where {S<:AbstractStyle} =
 # for i = 1:10 body end
 #
 # https://github.com/domluna/JuliaFormatter.jl/issues/34
-function eq_to_in_normalization!(fst::FST, always_for_in::Bool)
+function eq_to_in_normalization!(fst::FST, always_for_in::Bool, in_replacement::String)
     if fst.typ === CSTParser.BinaryOpCall
         idx = findfirst(n -> n.typ === CSTParser.OPERATOR, fst.nodes)
         idx === nothing && return
         op = fst[idx]
 
         if always_for_in
-            op.val = "in"
+            op.val = in_replacement
             op.len = length(op.val)
             return
         end
@@ -1028,7 +1028,7 @@ function eq_to_in_normalization!(fst::FST, always_for_in::Bool)
         end
     elseif fst.typ === CSTParser.Block || fst.typ === CSTParser.InvisBrackets
         for n in fst.nodes
-            eq_to_in_normalization!(n, always_for_in)
+            eq_to_in_normalization!(n, always_for_in, in_replacement)
         end
     end
 end
@@ -1049,7 +1049,7 @@ function p_for(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
         pretty(style, cst[2], s)
     end
 
-    cst[1].kind === Tokens.FOR && eq_to_in_normalization!(n, s.opts.always_for_in)
+    cst[1].kind === Tokens.FOR && eq_to_in_normalization!(n, s.opts.always_for_in, s.opts.in_replacement)
     add_node!(t, n, s, join_lines = true)
 
     idx = length(t.nodes)
@@ -2029,7 +2029,7 @@ function p_generator(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
             add_node!(t, n, s, join_lines = true)
         end
 
-        has_for_kw && eq_to_in_normalization!(n, s.opts.always_for_in)
+        has_for_kw && eq_to_in_normalization!(n, s.opts.always_for_in, s.opts.in_replacement)
     end
     t
 end

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -329,12 +329,8 @@ function p_generator(ys::YASStyle, cst::CSTParser.EXPR, s::State)
 
             if !is_gen(cst.args[i+1])
                 tup = p_tupleh(style, cst.args[i+1:length(cst)], s)
+                has_for_kw && eq_to_in_normalization!(tup, s.opts.always_for_in, s.opts.in_replacement)
                 add_node!(t, tup, s, join_lines = true)
-                if has_for_kw
-                    for nn in tup.nodes
-                        eq_to_in_normalization!(nn, s.opts.always_for_in, s.opts.in_replacement)
-                    end
-                end
                 break
             end
         elseif CSTParser.is_comma(a) && i < length(cst) && !is_punc(cst[i+1])

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -329,7 +329,7 @@ function p_generator(ys::YASStyle, cst::CSTParser.EXPR, s::State)
 
             if !is_gen(cst.args[i+1])
                 tup = p_tupleh(style, cst.args[i+1:length(cst)], s)
-                has_for_kw && eq_to_in_normalization!(tup, s.opts.always_for_in, s.opts.in_replacement)
+                has_for_kw && eq_to_in_normalization!(tup, s.opts.always_for_in, s.opts.for_in_replacement)
                 add_node!(t, tup, s, join_lines = true)
                 break
             end
@@ -340,7 +340,7 @@ function p_generator(ys::YASStyle, cst::CSTParser.EXPR, s::State)
             add_node!(t, n, s, join_lines = true)
         end
 
-        has_for_kw && eq_to_in_normalization!(n, s.opts.always_for_in, s.opts.in_replacement)
+        has_for_kw && eq_to_in_normalization!(n, s.opts.always_for_in, s.opts.for_in_replacement)
     end
 
     t

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -332,7 +332,7 @@ function p_generator(ys::YASStyle, cst::CSTParser.EXPR, s::State)
                 add_node!(t, tup, s, join_lines = true)
                 if has_for_kw
                     for nn in tup.nodes
-                        eq_to_in_normalization!(nn, s.opts.always_for_in)
+                        eq_to_in_normalization!(nn, s.opts.always_for_in, s.opts.in_replacement)
                     end
                 end
                 break
@@ -344,7 +344,7 @@ function p_generator(ys::YASStyle, cst::CSTParser.EXPR, s::State)
             add_node!(t, n, s, join_lines = true)
         end
 
-        has_for_kw && eq_to_in_normalization!(n, s.opts.always_for_in)
+        has_for_kw && eq_to_in_normalization!(n, s.opts.always_for_in, s.opts.in_replacement)
     end
 
     t

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -329,7 +329,11 @@ function p_generator(ys::YASStyle, cst::CSTParser.EXPR, s::State)
 
             if !is_gen(cst.args[i+1])
                 tup = p_tupleh(style, cst.args[i+1:length(cst)], s)
-                has_for_kw && eq_to_in_normalization!(tup, s.opts.always_for_in, s.opts.for_in_replacement)
+                has_for_kw && eq_to_in_normalization!(
+                    tup,
+                    s.opts.always_for_in,
+                    s.opts.for_in_replacement,
+                )
                 add_node!(t, tup, s, join_lines = true)
                 break
             end
@@ -340,7 +344,8 @@ function p_generator(ys::YASStyle, cst::CSTParser.EXPR, s::State)
             add_node!(t, n, s, join_lines = true)
         end
 
-        has_for_kw && eq_to_in_normalization!(n, s.opts.always_for_in, s.opts.for_in_replacement)
+        has_for_kw &&
+            eq_to_in_normalization!(n, s.opts.always_for_in, s.opts.for_in_replacement)
     end
 
     t

--- a/test/options.jl
+++ b/test/options.jl
@@ -1379,7 +1379,7 @@
         @test fmt(mixed_unix_str, normalize_line_endings = "windows") == windows_str
     end
 
-    @testset "always_for_∈" begin
+    @testset "for_in_replacement" begin
         str_ = """
         for a = b
         end

--- a/test/options.jl
+++ b/test/options.jl
@@ -236,6 +236,21 @@
         str = "[(i, j) for i in 1:2:10, j in 100:-1:10]"
         @test fmt(str_, always_for_in = true) == str
         @test fmt(str, always_for_in = true) == str
+
+        str_ = "[i for i = 1:10 if i == 2]"
+        str = "[i for i in 1:10 if i == 2]"
+        @test fmt(str_, always_for_in = true) == str
+        @test fmt(str, always_for_in = true) == str
+
+        str_ = "[(i, j) for i = 1:2:10, j = 100:-1:10]"
+        str = "[(i, j) for i in 1:2:10, j in 100:-1:10]"
+        @test yasfmt(str_, always_for_in = true) == str
+        @test yasfmt(str, always_for_in = true) == str
+
+        str_ = "[i for i = 1:10 if i == 2]"
+        str = "[i for i in 1:10 if i == 2]"
+        @test yasfmt(str_, always_for_in = true) == str
+        @test yasfmt(str, always_for_in = true) == str
     end
 
     @testset "rewrite x |> f to f(x)" begin

--- a/test/options.jl
+++ b/test/options.jl
@@ -1378,4 +1378,33 @@
         @test fmt(mixed_windows_str, normalize_line_endings = "windows") == windows_str
         @test fmt(mixed_unix_str, normalize_line_endings = "windows") == windows_str
     end
+
+    @testset "always_for_∈" begin
+        str_ = """
+        for a = b
+        end
+        """
+        str = """
+        for a ∈ b
+        end
+        """
+        @test fmt(str_, always_for_in = true, for_in_replacement = "∈") == str
+
+        # generator
+        str_ = "[(i, j) for i = 1:2:10, j = 100:-1:10]"
+        str = "[(i, j) for i ∈ 1:2:10, j ∈ 100:-1:10]"
+        @test fmt(str_, always_for_in = true, for_in_replacement = "∈") == str
+
+        str_ = "[i for i = 1:10 if i == 2]"
+        str = "[i for i ∈ 1:10 if i == 2]"
+        @test fmt(str_, always_for_in = true, for_in_replacement = "∈") == str
+
+        str_ = "[(i, j) for i = 1:2:10, j = 100:-1:10]"
+        str = "[(i, j) for i ∈ 1:2:10, j ∈ 100:-1:10]"
+        @test yasfmt(str_, always_for_in = true, for_in_replacement = "∈") == str
+
+        str_ = "[i for i = 1:10 if i == 2]"
+        str = "[i for i ∈ 1:10 if i == 2]"
+        @test yasfmt(str_, always_for_in = true, for_in_replacement = "∈") == str
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,12 @@ function fmt(s; i = 4, m = 80, kwargs...)
 end
 fmt(s, i, m; kwargs...) = fmt(s; kwargs..., i = i, m = m)
 
+yasfmt1(str) = fmt1(str; style = YASStyle(), options(DefaultStyle())...)
+yasfmt(str, i = 4, m = 80; kwargs...) = fmt(str, i, m; style = YASStyle(), kwargs...)
+
+bluefmt1(str) = fmt1(str; style = BlueStyle(), options(DefaultStyle())...)
+bluefmt(str, i = 4, m = 80; kwargs...) = fmt(str, i, m; style = BlueStyle(), kwargs...)
+
 function run_pretty(text::String; style = DefaultStyle(), opts = Options())
     d = JuliaFormatter.Document(text)
     s = JuliaFormatter.State(d, opts)
@@ -35,11 +41,6 @@ function run_nest(text::String; opts = Options(), style = DefaultStyle())
 end
 run_nest(text::String, margin::Int) = run_nest(text, opts = Options(margin = margin))
 
-yasfmt1(str) = fmt1(str; style = YASStyle(), options(DefaultStyle())...)
-yasfmt(str, i = 4, m = 80; kwargs...) = fmt(str, i, m; style = YASStyle(), kwargs...)
-
-bluefmt1(str) = fmt1(str; style = BlueStyle(), options(DefaultStyle())...)
-bluefmt(str, i = 4, m = 80; kwargs...) = fmt(str, i, m; style = BlueStyle(), kwargs...)
 
 @testset "JuliaFormatter" begin
     include("default_style.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,7 +41,6 @@ function run_nest(text::String; opts = Options(), style = DefaultStyle())
 end
 run_nest(text::String, margin::Int) = run_nest(text, opts = Options(margin = margin))
 
-
 @testset "JuliaFormatter" begin
     include("default_style.jl")
     include("yas_style.jl")


### PR DESCRIPTION
Add an option `for_in_replacement`, that works alongside `always_for_in` whereby you can specify an alternative to `in`.

Can be used when `always_for_in` is `true` to replace `in` with ∈ (\\in), or `=` instead:
```julia
for a = 1:10
end
# formatted with always_for_in = true, for_in_replacement = "∈"
for a ∈ 1:10
end
```
