### PR TITLE
Add function to format a package dir

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -33,6 +33,9 @@ julia> format_file("foo.jl")
 
 # Formats a string (contents of a Julia file)
 julia> format_text(str)
+
+# Formats all files in the package directory of a `Module`
+julia> format(FooPackage)
 ```
 
 ## Usage

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -537,6 +537,11 @@ format(path::AbstractString; options...) = format((path,); options...)
 """
 format(path, style::AbstractStyle; options...) = format(path; style = style, options...)
 
+"""
+    format(mod::Module, args...; options...)
+"""
+format(mod::Module, args...; options...) = format(pkgdir(mod), args...; options...)
+
 function kwargs(dict)
     ns = (Symbol.(keys(dict))...,)
     vs = (collect(values(dict))...,)


### PR DESCRIPTION
Just a tiny alias `format(mod::Module) = format(pkgdir(mod))`. Useful (or at least mildly convenient) for things like adding a 
```julia
@test format(ThisModule; overwrite=false)
# cf.
@test format(pkgdir(ThisModule); overwrite=false)
```
to package tests.