### PR TITLE
fix #387

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.13.8"
+version = "0.13.9"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/styles/yas/nest.jl
+++ b/src/styles/yas/nest.jl
@@ -1,10 +1,17 @@
 function n_call!(ys::YASStyle, fst::FST, s::State)
     style = getstyle(ys)
-    fst.indent = s.line_offset + sum(length.(fst[1:2]))
 
     f = n -> n.typ === PLACEHOLDER || n.typ === NEWLINE
 
     for (i, n) in enumerate(fst.nodes)
+        if i == 3
+            # The indent is set here to handle the edge
+            # case where the first argument of Call is
+            # nestable.
+            # ref https://github.com/domluna/JuliaFormatter.jl/issues/387
+            fst.indent = s.line_offset
+        end
+
         if n.typ === NEWLINE
             s.line_offset = fst.indent
         elseif n.typ === PLACEHOLDER

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -682,4 +682,13 @@
         """
         @test bluefmt(str_, always_for_in = true) == str
     end
+
+    @testset "issue 387" begin
+        str_ = """new{T1,T2}(arg1,arg2)"""
+        str = """
+        new{T1,
+            T2}(arg1,
+                arg2)"""
+        @test yasfmt(str_, 4, 1) == str
+    end
 end


### PR DESCRIPTION
Handles the edge case where the first argument of a Call node
is nestable. For example:

```
new{T1,T2}(arg1,arg2)
```

In this case if the indent is set to the offset of the first argument after
`(` and `new{T1,T2}` is nested, the indentation will be incorrect.

before (aligned to after the initial position of `(`):

```
new{T1,
    T2}(arg1,
           arg2)
```

after (aligned to after new position of `(`):

```
new{T1,
    T2}(arg1,
        arg2)
```