### PR TITLE
Fix #399

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.13.9"
+version = "0.13.10"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -694,16 +694,7 @@ function n_for!(ds::DefaultStyle, fst::FST, s::State)
     end
     ph_idx = findfirst(n -> n.typ === PLACEHOLDER, fst[block_idx].nodes)
     nest!(style, fst.nodes, s, fst.indent, extra_margin = fst.extra_margin)
-
-    # return if the argument block was nested
-    ph_idx !== nothing && fst[3][ph_idx].typ === NEWLINE && return
-
-    idx = 5
-    n = fst[idx]
-    if n.typ === NOTCODE && n.startline == n.endline
-        res = get(s.doc.comments, n.startline, (0, ""))
-        res == (0, "") && (fst[idx-1] = Whitespace(0))
-    end
+    return
 end
 n_for!(style::S, fst::FST, s::State) where {S<:AbstractStyle} =
     n_for!(DefaultStyle(style), fst, s)

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -3480,12 +3480,14 @@
     @testset "multi-variable `for` and `let`" begin
         str = """
         for a in x, b in y, c in z
+
             body
         end"""
         str_ = """
         for a in x,
             b in y,
             c in z
+
             body
         end"""
         @test fmt(str_) == str
@@ -3505,12 +3507,14 @@
 
         str = """
         let a = x, b = y, c = z
+
             body
         end"""
         str_ = """
         let a = x,
             b = y,
             c = z
+
             body
         end"""
         @test fmt(str_) == str


### PR DESCRIPTION
I'm not sure why this was being done in the first place, it might be an
outdated style decision. Commit 434918df5fb578e4d6bf119c9cfc8bfa5ec3a722
originally introduces `n_for`.

Either way it looks like this is no longer required.


```
julia> s = """
       for line in readlines(path)

           split_ = split(line, 't')

       end"""
"for line in readlines(path)\n    \n    split_ = split(line, 't')\n    \nend"

### this branch

julia> format_text(s) |> print
for line in readlines(path)

    split_ = split(line, 't')

end

### master

julia> format_text(s) |> print
for line in readlines(path)
    split_ = split(line, 't')

end

```