### PR TITLE
Fix #405

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.14.0"
+version = "0.14.1"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -275,7 +275,10 @@ end
 
 function is_macrodoc(fst::FST)
     fst.typ === GlobalRefDoc && return true
-    fst.typ === MacroBlock && fst[1].typ === Macroname && fst[1][1].val == "@doc" && return true
+    fst.typ === MacroBlock &&
+        fst[1].typ === Macroname &&
+        fst[1][1].val == "@doc" &&
+        return true
     return false
 end
 
@@ -991,4 +994,3 @@ function eq_to_in_normalization!(fst::FST, always_for_in::Bool)
         end
     end
 end
-

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -273,6 +273,12 @@ function is_macrodoc(cst::CSTParser.EXPR)
         (is_str_or_cmd(cst[3]) || is_macrostr(cst[3]))
 end
 
+function is_macrodoc(fst::FST)
+    fst.typ === GlobalRefDoc && return true
+    fst.typ === MacroBlock && fst[1].typ === Macroname && fst[1][1].val == "@doc" && return true
+    return false
+end
+
 function is_macrostr(cst::CSTParser.EXPR)
     cst.head === :macrocall || return false
     length(cst) > 2 || return false
@@ -293,6 +299,7 @@ function is_macrostr(cst::CSTParser.EXPR)
 
     return is_str_or_cmd(cst[3])
 end
+is_macrostr(fst::FST) = fst.typ === MacroStr
 
 function is_call(cst::CSTParser.EXPR)
     t = CSTParser.is_func_call(cst)
@@ -984,3 +991,4 @@ function eq_to_in_normalization!(fst::FST, always_for_in::Bool)
         end
     end
 end
+

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -302,7 +302,6 @@ function is_macrostr(cst::CSTParser.EXPR)
 
     return is_str_or_cmd(cst[3])
 end
-is_macrostr(fst::FST) = fst.typ === MacroStr
 
 function is_call(cst::CSTParser.EXPR)
     t = CSTParser.is_func_call(cst)

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -339,7 +339,7 @@ end
 """
     prepend_return!(fst::FST, s::State)
 
-Prepends `return` to the last expression of a block.
+Prepends `return` to the last expression of a block if applicable.
 
 ```julia
 function foo()
@@ -364,6 +364,12 @@ function prepend_return!(fst::FST, s::State)
     ln.typ === Return && return
     ln.typ === MacroCall && return
     ln.typ === MacroBlock && return
+    ln.typ === MacroStr && return
+    if length(fst.nodes) > 2 && (is_macrostr(fst[end-2]) || is_macrodoc(fst[end-2]))
+        # The last node is has a docstring prior to it so a return should not be prepended
+        # fst[end-1] is a newline
+        return
+    end
 
     ret = FST(Return, fst.indent)
     kw = FST(KEYWORD, -1, fst[end].startline, fst[end].endline, "return")
@@ -371,6 +377,7 @@ function prepend_return!(fst::FST, s::State)
     add_node!(ret, Whitespace(1), s)
     add_node!(ret, ln, s, join_lines = true)
     fst[end] = ret
+    return
 end
 
 """

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -365,7 +365,7 @@ function prepend_return!(fst::FST, s::State)
     ln.typ === MacroCall && return
     ln.typ === MacroBlock && return
     ln.typ === MacroStr && return
-    if length(fst.nodes) > 2 && (is_macrostr(fst[end-2]) || is_macrodoc(fst[end-2]))
+    if length(fst.nodes) > 2 && (fst[end-2].typ === MacroStr || is_macrodoc(fst[end-2]))
         # The last node is has a docstring prior to it so a return should not be prepended
         # fst[end-1] is a newline
         return

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -698,7 +698,7 @@
             raw\""" Doc string.\"""f
         end
         """
-        @test fmt(str, always_use_return=true) == str
+        @test fmt(str, always_use_return = true) == str
 
         str = """
         function __init__()
@@ -708,7 +708,7 @@
             f
         end
         """
-        @test fmt(str, always_use_return=true) == str
+        @test fmt(str, always_use_return = true) == str
 
         str = """
         function __init__()
@@ -718,6 +718,6 @@
             f
         end
         """
-        @test fmt(str, always_use_return=true) == str
+        @test fmt(str, always_use_return = true) == str
     end
 end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -691,4 +691,33 @@
             @test fmt(str, margin = 1, import_to_using = true) == str
         end
     end
+
+    @testset "issue 405" begin
+        str = """
+        function __init__()
+            raw\""" Doc string.\"""f
+        end
+        """
+        @test fmt(str, always_use_return=true) == str
+
+        str = """
+        function __init__()
+            @doc raw\"""
+            Doc string.
+            \"""
+            f
+        end
+        """
+        @test fmt(str, always_use_return=true) == str
+
+        str = """
+        function __init__()
+            raw\"""
+            Doc string.
+            \"""
+            f
+        end
+        """
+        @test fmt(str, always_use_return=true) == str
+    end
 end


### PR DESCRIPTION
* Do not prepend return if the second last node is a docstring since this
will change semantics.
* Handle `MacroStr` type. Added in CSTParser 3 upgrade.