### PR TITLE
Bump minimum CSTParser to 3.2.2 due to parsing order error

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.14.1"
+version = "0.14.2"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
@@ -11,7 +11,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Tokenize = "0796e94c-ce3b-5d07-9a54-7f471281c624"
 
 [compat]
-CSTParser = "^3.2"
+CSTParser = "^3.2.1"
 CommonMark = "0.5, 0.6, 0.7, 0.8"
 DataStructures = "0.17, 0.18"
 Tokenize = "^0.5.16"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.14.2"
+version = "0.14.3"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
@@ -11,7 +11,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Tokenize = "0796e94c-ce3b-5d07-9a54-7f471281c624"
 
 [compat]
-CSTParser = "^3.2.1"
+CSTParser = "^3.2.2"
 CommonMark = "0.5, 0.6, 0.7, 0.8"
 DataStructures = "0.17, 0.18"
 Tokenize = "^0.5.16"


### PR DESCRIPTION
fix #410

multi op parsing has changed in 3.2.1 (i think unintentionally?)

waiting on response from CSTParser for what to do next