### PR TITLE
Correctly merge options as namedtuple

### DIFF
--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -579,6 +579,6 @@ function parse_config(tomlfile)
     return kwargs(config_dict)
 end
 
-overwrite_options(options, config) = kwargs(merge(options, config))
+overwrite_options(options, config) = merge(NamedTuple(options), NamedTuple(config))
 
 end


### PR DESCRIPTION
This commit changes the way of merging options to avoid promotion of type.
Currently, `overwrite_options` will call `merge` of `Dict` where types of values are promoted.
`verbose=true` is promoted to `verbose=1 (Int64)` to align with `margin=100` and it causes problem when `verbose` is passed as kwargs to `format_file` in `format`.
This commit forces `overwrite_options` to call `merge` of `NamedTuple` where type of each option is kept.