### PR TITLE
Fix #417

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.14.3"
+version = "0.14.4"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -720,4 +720,21 @@
         """
         @test fmt(str, always_use_return = true) == str
     end
+
+    @testset "issue 417" begin
+        str = """
+        formαt"JPEG"
+        """
+        @test fmt(str) == str
+
+        str = """
+        A.formαt"JPEG"
+        """
+        @test fmt(str) == str
+
+        str = """
+        A.B.formαt"JPEG"
+        """
+        @test fmt(str) == str
+    end
 end


### PR DESCRIPTION
Macro strings: handle the case where the identifier is part of a
quotenode(s), i.e. `A.foo"a"` along with `foo"a"`.

Since the identifier is a special case we add a prettify function
for it `p_macrostr_identifier` which is only called very specific
circumstances, meaning it's not included in the main `pretty` function.