### PR TITLE
Do not overwrite files that are already formatted

### DIFF
--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -459,11 +459,11 @@ function format_file(
         error("$filename must be a Julia (.jl) or Markdown (.md) source file")
     end
     formatted_str = replace(formatted_str, r"\n*$" => "\n")
-
-    if overwrite
+    already_formatted = (formatted_str == str)
+    if overwrite && !already_formatted
         write(filename, formatted_str)
     end
-    return formatted_str == str
+    return already_formatted
 end
 
 """


### PR DESCRIPTION
JuliaFormatter.jl currently overwrites all files, whether they are already formatted or not. Besides efficiency issues, this can be problematic for projects using GNU Make. For example, [UnitCommitment.jl](https://github.com/ANL-CEEESA/UnitCommitment.jl) uses a [Makefile](https://github.com/ANL-CEEESA/UnitCommitment.jl/blob/dev/Makefile) to rebuild a system image whenever the files `Project.toml`, `Manifest.toml` or `sysimage.jl` are modified. This significantly accelerate our tests. Reformatting our `src` directory with JuliaFormatter.jl, however, currently triggers a new rebuild of the system image, because the file `sysimage.jl` gets a new timestamp, even if the contents of the file have not changed.

This PR modifies the `format_file` function so that `write` is only called if the file is not already formatted.