### PR TITLE
Fix YASStyle error when encountering a flatten expression

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.14.5"
+version = "0.14.6"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -122,10 +122,6 @@ function p_tuple(ys::YASStyle, nodes::Vector{CSTParser.EXPR}, s::State)
         elseif CSTParser.is_comma(a) && i < length(nodes) && !is_punc(nodes[i+1])
             add_node!(t, n, s, join_lines = true)
             add_node!(t, Placeholder(1), s)
-        elseif CSTParser.iskeyword(a)
-            add_node!(t, Placeholder(1), s)
-            add_node!(t, n, s, join_lines = true)
-            add_node!(t, Whitespace(1), s)
         else
             add_node!(t, n, s, join_lines = true)
         end

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -122,6 +122,10 @@ function p_tuple(ys::YASStyle, nodes::Vector{CSTParser.EXPR}, s::State)
         elseif CSTParser.is_comma(a) && i < length(nodes) && !is_punc(nodes[i+1])
             add_node!(t, n, s, join_lines = true)
             add_node!(t, Placeholder(1), s)
+        elseif CSTParser.iskeyword(a)
+            add_node!(t, Placeholder(1), s)
+            add_node!(t, n, s, join_lines = true)
+            add_node!(t, Whitespace(1), s)
         else
             add_node!(t, n, s, join_lines = true)
         end
@@ -336,6 +340,10 @@ function p_generator(ys::YASStyle, cst::CSTParser.EXPR, s::State)
                 tupargs = CSTParser.EXPR[]
                 for j = i+1:length(cst)
                     push!(tupargs, cst[j])
+
+                    # add_node!(t, Placeholder(1), s)
+                    # add_node!(t, n, s, join_lines = true)
+                    # add_node!(t, Whitespace(1), s)
                 end
                 tup = p_tuple(style, tupargs, s)
                 add_node!(t, tup, s, join_lines = true)
@@ -366,7 +374,7 @@ function p_filter(ys::YASStyle, cst::CSTParser.EXPR, s::State)
 end
 
 function p_flatten(ys::YASStyle, cst::CSTParser.EXPR, s::State)
-    p_generator(ys, cst, s)
+    t = p_generator(ys, cst, s)
     t.typ = Flatten
     t
 end

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -341,8 +341,13 @@ function p_generator(ys::YASStyle, cst::CSTParser.EXPR, s::State)
                 for j = i+1:length(cst)
                     push!(tupargs, cst[j])
                 end
+
+                # verify this is not another for loop
+                any(b -> b.head === :FOR, tupargs) && continue
+
                 tup = p_tuple(style, tupargs, s)
                 add_node!(t, tup, s, join_lines = true)
+
                 if has_for_kw
                     for nn in tup.nodes
                         eq_to_in_normalization!(nn, s.opts.always_for_in)

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -340,10 +340,6 @@ function p_generator(ys::YASStyle, cst::CSTParser.EXPR, s::State)
                 tupargs = CSTParser.EXPR[]
                 for j = i+1:length(cst)
                     push!(tupargs, cst[j])
-
-                    # add_node!(t, Placeholder(1), s)
-                    # add_node!(t, n, s, join_lines = true)
-                    # add_node!(t, Whitespace(1), s)
                 end
                 tup = p_tuple(style, tupargs, s)
                 add_node!(t, tup, s, join_lines = true)

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -743,13 +743,13 @@
         [z for y in x for z in y]
         """
         @test yasfmt(str) == str
-        @test yasfmt(str, margin=25) == str
+        @test yasfmt(str, margin = 25) == str
 
         str_ = """
         [z
          for y in x for z in y]
         """
-        @test yasfmt(str_, margin=24) == str
+        @test yasfmt(str_, margin = 24) == str
 
         str_ = """
         [z
@@ -758,6 +758,6 @@
          for z in
              y]
         """
-        @test yasfmt(str_, margin=1) == str
+        @test yasfmt(str_, margin = 1) == str
     end
 end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -737,4 +737,27 @@
         """
         @test fmt(str) == str
     end
+
+    @testset "issue 419" begin
+        str = """
+        [z for y in x for z in y]
+        """
+        @test yasfmt(str) == str
+        @test yasfmt(str, margin=25) == str
+
+        str_ = """
+        [z
+         for y in x for z in y]
+        """
+        @test yasfmt(str_, margin=24) == str
+
+        str_ = """
+        [z
+         for y in
+             x
+         for z in
+             y]
+        """
+        @test yasfmt(str_, margin=1) == str
+    end
 end


### PR DESCRIPTION
fix #419 

verifies the latter part of a generator expression does not contain a FOR keyword before assuming it's a tuple expression