### PR TITLE
add some precompilation statements - shaves off ~2s from first format

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.14.6"
+version = "0.14.7"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -581,4 +581,9 @@ end
 
 overwrite_options(options, config) = merge(NamedTuple(options), NamedTuple(config))
 
+if Base.VERSION >= v"1.6"
+    include("other/precompile.jl")
+    _precompile_()
+end
+
 end

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -581,7 +581,7 @@ end
 
 overwrite_options(options, config) = merge(NamedTuple(options), NamedTuple(config))
 
-if Base.VERSION >= v"1.6"
+if Base.VERSION >= v"1.5"
     include("other/precompile.jl")
     _precompile_()
 end

--- a/src/other/precompile.jl
+++ b/src/other/precompile.jl
@@ -1,0 +1,7 @@
+#! format: off
+function _precompile_()
+    # pretty
+    Base.precompile(Tuple{typeof(pretty),DefaultStyle,CSTParser.EXPR,State})
+    Base.precompile(Tuple{typeof(pretty),YASStyle,CSTParser.EXPR,State})
+    Base.precompile(Tuple{typeof(pretty),BlueStyle,CSTParser.EXPR,State})
+end


### PR DESCRIPTION
ref https://gist.github.com/domluna/875368502b5c9b0f6630ac6960d8c83b

So after a bunch of tinkering with JET.jl and SnoopCompile.jl it turns out the biggest bang for the buck comes from only precompile on `pretty`.

`format_text` and `nest!` don't seem to provide any additional benefit and it's unclear why. Currently they slow timings down by a tiny bit. It seems precompile should improve timings there too.

Also CSTParser is responsible for > 50% of compilation overhead