### PR TITLE
fix #429

### DIFF
--- a/test/issues.jl
+++ b/test/issues.jl
@@ -770,4 +770,16 @@
             (@variables(t))[1]"""
         @test fmt(str, m = length(str) - 1) == str_
     end
+
+    @testset "issue 429" begin
+        str = """
+        find_derivatives!(vars, expr::Equation, f=identity) = (find_derivatives!(vars, expr.lhs, f); find_derivatives!(vars, expr.rhs, f); vars)
+        """
+        str_ = """
+        function find_derivatives!(vars, expr::Equation, f = identity)
+            (find_derivatives!(vars, expr.lhs, f); find_derivatives!(vars, expr.rhs, f); vars)
+        end
+        """
+        @test fmt(str, m=92, short_to_long_function_def=true) == str_
+    end
 end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -780,6 +780,6 @@
             (find_derivatives!(vars, expr.lhs, f); find_derivatives!(vars, expr.rhs, f); vars)
         end
         """
-        @test fmt(str, m=92, short_to_long_function_def=true) == str_
+        @test fmt(str, m = 92, short_to_long_function_def = true) == str_
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,15 @@ fmt1(s; i = 4, m = 80, kwargs...) =
     JuliaFormatter.format_text(s; kwargs..., indent = i, margin = m)
 fmt1(s, i, m; kwargs...) = fmt1(s; kwargs..., i = i, m = m)
 
+# Verifies formatting the formatted text
+# results in the same output
+function fmt(s; i = 4, m = 80, kwargs...)
+    kws = merge(options(DefaultStyle()), kwargs)
+    s1 = fmt1(s; kws..., i = i, m = m)
+    return fmt1(s1; kws..., i = i, m = m)
+end
+fmt(s, i, m; kwargs...) = fmt(s; kwargs..., i = i, m = m)
+
 yasfmt1(str) = fmt1(str; style = YASStyle(), options(DefaultStyle())...)
 yasfmt(str; i = 4, m = 80, kwargs...) =
     fmt(str; i = i, m = m, style = YASStyle(), kwargs...)
@@ -16,15 +25,6 @@ bluefmt1(str) = fmt1(str; style = BlueStyle(), options(DefaultStyle())...)
 bluefmt(str; i = 4, m = 80, kwargs...) =
     fmt(str; i = i, m = m, style = BlueStyle(), kwargs...)
 bluefmt(str, i::Int, m::Int; kwargs...) = bluefmt(str; i = i, m = m, kwargs...)
-
-# Verifies formatting the formatted text
-# results in the same output
-function fmt(s; i = 4, m = 80, kwargs...)
-    kws = merge(options(DefaultStyle()), kwargs)
-    s1 = fmt1(s; kws..., i = i, m = m)
-    return fmt1(s1; kws..., i = i, m = m)
-end
-fmt(s, i, m; kwargs...) = fmt(s; kwargs..., i = i, m = m)
 
 function run_pretty(text::String; style = DefaultStyle(), opts = Options())
     d = JuliaFormatter.Document(text)


### PR DESCRIPTION
create a block node for the new long function definition
if the original short form function definition was not wrapped in one.