### PR TITLE
Align Matrix Option

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.14.8"
+version = "0.15.0"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/docs/src/custom_alignment.md
+++ b/docs/src/custom_alignment.md
@@ -207,6 +207,8 @@ pages = [
 
 ### `align_matrix`
 
+ > TLDR: If you want to align matrix elements yourself set this to `true`
+
 Whitespace surrounding matrix elements in the original source file is maintained. Differs from other alignment options since it does not try to "detect" alignment and then adjust other elements.
 
 ```julia

--- a/docs/src/custom_alignment.md
+++ b/docs/src/custom_alignment.md
@@ -63,6 +63,7 @@ In order for alignment to occur the option must be set to `true`. Available opti
 - `align_struct_field`
 - `align_conditional`
 - `align_pair_arrow`
+- `align_matrix`
 
 > **Caveat: Since nesting is disabled when alignment occurs be careful when adding comments to the RHS expression. This will be fixed in a future release**
 
@@ -202,3 +203,45 @@ pages = [
     "API Reference"       => "api.md",
 ]
 ```
+
+
+### `align_matrix`
+
+Whitespace surrounding matrix elements in the original source file is maintained. Differs from other alignment options since it does not try to "detect" alignment and then adjust other elements.
+
+```julia
+# Elements left-aligned in original source
+julia> s = """
+       a = [
+       100 300 400
+       1   eee 40000
+       2   α   b
+       ]"""
+"a = [\n100 300 400\n1   eee 40000\n2   α   b\n]"
+
+julia> format_text(s, align_matrix=true) |> print
+a = [
+    100 300 400
+    1   eee 40000
+    2   α   b
+]
+
+# Elements right-aligned in original source
+julia> s = """
+       a = [
+       100 300   400
+         1  ee 40000
+         2   a     b
+       ]"""
+"a = [\n100 300   400\n  1  ee 40000\n  2   a     b\n]"
+
+julia>
+
+julia> format_text(s, align_matrix=true) |> print
+a = [
+    100 300   400
+      1  ee 40000
+      2   a     b
+]
+```
+

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -37,26 +37,7 @@ DefaultStyle() = DefaultStyle(nothing)
 
 @inline getstyle(s::DefaultStyle) = s.innerstyle === nothing ? s : s.innerstyle
 function options(s::DefaultStyle)
-    return (;
-        indent = 4,
-        margin = 92,
-        always_for_in = false,
-        whitespace_typedefs = false,
-        whitespace_ops_in_indices = false,
-        remove_extra_newlines = false,
-        import_to_using = false,
-        pipe_to_function_call = false,
-        short_to_long_function_def = false,
-        always_use_return = false,
-        whitespace_in_kwargs = true,
-        annotate_untyped_fields_with_any = true,
-        format_docstrings = false,
-        align_struct_field = false,
-        align_assignment = false,
-        align_conditional = false,
-        align_pair_arrow = false,
-        conditional_to_if = false,
-    )
+    return (;)
 end
 
 include("document.jl")

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -112,6 +112,7 @@ normalize_line_ending(s::AbstractString, replacer = WINDOWS_TO_UNIX) = replace(s
         align_pair_arrow::Bool = false,
         conditional_to_if = false,
         normalize_line_endings = "auto",
+        align_matrix::Bool = false,
     )::String
 
 Formats a Julia source passed in as a string, returning the formatted

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -360,12 +360,7 @@ function format_text(cst::CSTParser.EXPR, style::AbstractStyle, s::State)
 
     flatten_fst!(fst)
 
-    if s.opts.align_struct_field ||
-       s.opts.align_conditional ||
-       s.opts.align_assignment ||
-       s.opts.align_pair_arrow
-        align_fst!(fst, s.opts)
-    end
+    needs_alignment(s.opts) && align_fst!(fst, s.opts)
 
     nest!(style, fst, s)
 

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -37,7 +37,28 @@ DefaultStyle() = DefaultStyle(nothing)
 
 @inline getstyle(s::DefaultStyle) = s.innerstyle === nothing ? s : s.innerstyle
 function options(s::DefaultStyle)
-    return (;)
+    return (;
+        indent = 4,
+        margin = 92,
+        always_for_in = false,
+        whitespace_typedefs = false,
+        whitespace_ops_in_indices = false,
+        remove_extra_newlines = false,
+        import_to_using = false,
+        pipe_to_function_call = false,
+        short_to_long_function_def = false,
+        always_use_return = false,
+        whitespace_in_kwargs = true,
+        annotate_untyped_fields_with_any = true,
+        format_docstrings = false,
+        align_struct_field = false,
+        align_assignment = false,
+        align_conditional = false,
+        align_pair_arrow = false,
+        conditional_to_if = false,
+        normalize_line_endings = "auto",
+        align_matrix = false,
+    )
 end
 
 include("document.jl")

--- a/src/align.jl
+++ b/src/align.jl
@@ -261,7 +261,6 @@ function align_conditional!(fst::FST)
     return
 end
 
-
 """
 Adjust whitespace in between matrix elements such that it's the same as the original source file.
 """
@@ -297,4 +296,3 @@ function align_matrix!(fst::FST)
 
     return
 end
-

--- a/src/options.jl
+++ b/src/options.jl
@@ -23,8 +23,8 @@ end
 
 function needs_alignment(opts::Options)
     opts.align_struct_field ||
-       opts.align_conditional ||
-       opts.align_assignment ||
-       opts.align_pair_arrow ||
-       opts.align_matrix
+        opts.align_conditional ||
+        opts.align_assignment ||
+        opts.align_pair_arrow ||
+        opts.align_matrix
 end

--- a/src/options.jl
+++ b/src/options.jl
@@ -18,4 +18,13 @@ Base.@kwdef struct Options
     align_pair_arrow::Bool = false
     conditional_to_if::Bool = false
     normalize_line_endings::String = "auto"
+    align_matrix::Bool = false
+end
+
+function needs_alignment(opts::Options)
+    opts.align_struct_field ||
+       opts.align_conditional ||
+       opts.align_assignment ||
+       opts.align_pair_arrow ||
+       opts.align_matrix
 end

--- a/test/options.jl
+++ b/test/options.jl
@@ -1382,13 +1382,13 @@
             2 α b
         ]
         """
-        @test fmt(fmt(str), align_matrix=true) == str
+        @test fmt(fmt(str), align_matrix = true) == str
         str_ = """
         a = [100 300 400
              1 eee 40000
              2 α b]
         """
-        @test fmt(fmt(str), align_matrix=true, style=YASStyle()) == str_
+        @test fmt(fmt(str), align_matrix = true, style = YASStyle()) == str_
 
         # left-aligned
         str = """
@@ -1398,13 +1398,13 @@
             2   α   b
         ]
         """
-        @test fmt(str, align_matrix=true) == str
+        @test fmt(str, align_matrix = true) == str
         str_ = """
         a = [100 300 400
              1   eee 40000
              2   α   b]
         """
-        @test fmt(str, align_matrix=true, style=YASStyle()) == str_
+        @test fmt(str, align_matrix = true, style = YASStyle()) == str_
 
         # right-aligned
         str = """
@@ -1414,12 +1414,12 @@
               2    α 40000
         ]
         """
-        fmt(str, align_matrix=true) == str
+        fmt(str, align_matrix = true) == str
         str_ = """
         a = [100 3000   400
                1  eee     b
                2    α 40000]
         """
-        @test fmt(str, align_matrix=true, style=YASStyle()) == str_
+        @test fmt(str, align_matrix = true, style = YASStyle()) == str_
     end
 end

--- a/test/options.jl
+++ b/test/options.jl
@@ -1372,4 +1372,54 @@
         @test fmt(mixed_windows_str, normalize_line_endings = "windows") == windows_str
         @test fmt(mixed_unix_str, normalize_line_endings = "windows") == windows_str
     end
+
+    @testset "align matrix" begin
+        # default formatting
+        str = """
+        a = [
+            100 300 400
+            1 eee 40000
+            2 α b
+        ]
+        """
+        @test fmt(fmt(str), align_matrix=true) == str
+        str_ = """
+        a = [100 300 400
+             1 eee 40000
+             2 α b]
+        """
+        @test fmt(fmt(str), align_matrix=true, style=YASStyle()) == str_
+
+        # left-aligned
+        str = """
+        a = [
+            100 300 400
+            1   eee 40000
+            2   α   b
+        ]
+        """
+        @test fmt(str, align_matrix=true) == str
+        str_ = """
+        a = [100 300 400
+             1   eee 40000
+             2   α   b]
+        """
+        @test fmt(str, align_matrix=true, style=YASStyle()) == str_
+
+        # right-aligned
+        str = """
+        a = [
+            100 3000   400
+              1  eee     b
+              2    α 40000
+        ]
+        """
+        fmt(str, align_matrix=true) == str
+        str_ = """
+        a = [100 3000   400
+               1  eee     b
+               2    α 40000]
+        """
+        @test fmt(str, align_matrix=true, style=YASStyle()) == str_
+    end
 end


### PR DESCRIPTION
 

Whitespace surrounding matrix elements in the original source file is maintained. Differs from other alignment options since it does not try to "detect" alignment and then adjust other elements.

```julia
# Elements left-aligned in original source
julia> s = """
       a = [
       100 300 400
       1   eee 40000
       2   α   b
       ]"""
"a = [\n100 300 400\n1   eee 40000\n2   α   b\n]"
julia> format_text(s, align_matrix=true) |> print
a = [
    100 300 400
    1   eee 40000
    2   α   b
]
# Elements right-aligned in original source
julia> s = """
       a = [
       100 300   400
         1  ee 40000
         2   a     b
       ]"""
"a = [\n100 300   400\n  1  ee 40000\n  2   a     b\n]"
julia>
julia> format_text(s, align_matrix=true) |> print
a = [
    100 300   400
      1  ee 40000
      2   a     b
]
```

fixes #425 