### PR TITLE
Fix #460

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.15.8"
+version = "0.15.9"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -234,12 +234,17 @@ using C: C
 
 Exceptions:
 
-1. If `as` is found in the import expression. `using` CANNOT be used in this context. The following example will not be rewritten.
+If `as` is found in the import expression. `using` CANNOT be used in this context. The following example will NOT BE rewritten.
 
-```
+```julia
 import Base.Threads as th
 ```
 
+If `import` is used in the following context it is NOT rewritten. This may change in a future patch.
+
+```julia
+@everywhere import A, B
+```
 
 ### `pipe_to_function_call`
 

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -507,12 +507,11 @@ function add_node!(t::FST, n::FST, s::State; join_lines = false, max_padding = -
             add_node!(t, nn, s, join_lines = true)
         end
         return
-    elseif s.opts.import_to_using && n.typ === Import
+    elseif s.opts.import_to_using && n.typ === Import && t.typ !== MacroBlock
         usings = import_to_usings(n, s)
         if length(usings) > 0
             for (i, nn) in enumerate(usings)
-                join_lines = i == 1 ? true : false
-                add_node!(t, nn, s; join_lines = join_lines, max_padding = 0)
+                add_node!(t, nn, s; join_lines = false, max_padding = 0)
             end
             return
         end

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -510,8 +510,9 @@ function add_node!(t::FST, n::FST, s::State; join_lines = false, max_padding = -
     elseif s.opts.import_to_using && n.typ === Import
         usings = import_to_usings(n, s)
         if length(usings) > 0
-            for nn in usings
-                add_node!(t, nn, s, join_lines = false, max_padding = 0)
+            for (i, nn) in enumerate(usings)
+                join_lines = i == 1 ? true : false
+                add_node!(t, nn, s; join_lines = join_lines, max_padding = 0)
             end
             return
         end

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -149,6 +149,7 @@ function import_to_usings(fst::FST, s::State)
 
         push!(usings, use)
     end
+
     return usings
 end
 

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -881,4 +881,27 @@
         """
         @test fmt(str, align_assignment = true) == str_aligned
     end
+
+    @testset "issue 460" begin
+        # NOTE: if there are two packages imported on the same line then this will be
+        # rewritten as:
+        #
+        #   @everywhere import A, B
+        #
+        #   @everywhere using A: A
+        #   using B: B
+        #
+        # This shouldn't be a practical issue but it's important to keep in mind.
+        str_ = """
+        using Distributed
+        @everywhere import Distributed
+        have_workers = Distributed.nprocs()-1
+        """
+        str = """
+        using Distributed
+        @everywhere using Distributed: Distributed
+        have_workers = Distributed.nprocs() - 1
+        """
+        @test fmt(str_, import_to_using = true) == str
+    end
 end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -888,10 +888,19 @@
         #
         #   @everywhere import A, B
         #
+        #   ->
+        #
         #   @everywhere using A: A
         #   using B: B
         #
         # This shouldn't be a practical issue but it's important to keep in mind.
+        #
+        # A solution could be to wrap it in a begin end block
+        #
+        #   @everywhere begin
+        #       using A: A
+        #       using B: B
+        #   end
         str_ = """
         using Distributed
         @everywhere import Distributed


### PR DESCRIPTION
If `import` is used in the following context it is NOT rewritten. This may change in a future patch.

```julia
@everywhere import A, B
```

Further reasoning:

Do not allow import to using conversion when in a macroblock context such as:

 ```
@everywhere import A, B
```

Prior to this change this would be rewritten as:

```
@everywhere
using A: A
using B: B
```

which breaks the code.

There's an easy fix such that the first `using` is on the same line as `@everywhere`
but beyond that we probably have to wrap it in a `begin/end` block. For now it's best
to just not do the conversion in this situation.


