### PR TITLE
fix #467

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.15.10"
+version = "0.15.11"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/styles/blue/pretty.jl
+++ b/src/styles/blue/pretty.jl
@@ -138,7 +138,6 @@ function p_binaryopcall(
     elseif !(CSTParser.is_in(op) || CSTParser.is_elof(op)) && (
         nospace || (
             !CSTParser.is_anon_func(op) && precedence(op) in (
-                CSTParser.ColonOp,
                 CSTParser.RationalOp,
                 CSTParser.PowerOp,
                 CSTParser.DeclarationOp,

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1539,7 +1539,6 @@ function p_binaryopcall(
     elseif !(CSTParser.is_in(op) || CSTParser.is_elof(op)) && (
         nospace || (
             !CSTParser.is_anon_func(op) && precedence(op) in (
-                CSTParser.ColonOp,
                 CSTParser.PowerOp,
                 CSTParser.DeclarationOp,
                 CSTParser.DotOp,

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1538,11 +1538,8 @@ function p_binaryopcall(
         nest ? add_node!(t, Placeholder(1), s) : add_node!(t, Whitespace(1), s)
     elseif !(CSTParser.is_in(op) || CSTParser.is_elof(op)) && (
         nospace || (
-            !CSTParser.is_anon_func(op) && precedence(op) in (
-                CSTParser.PowerOp,
-                CSTParser.DeclarationOp,
-                CSTParser.DotOp,
-            )
+            !CSTParser.is_anon_func(op) &&
+            precedence(op) in (CSTParser.PowerOp, CSTParser.DeclarationOp, CSTParser.DotOp)
         )
     )
         add_node!(t, pretty(style, op, s), s, join_lines = true)

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -922,4 +922,11 @@
             align_struct_field = true,
         ) == str
     end
+
+    @testset "issue 467" begin
+        str_ = "-3.. -2"
+        str = "-3 .. -2"
+        @test fmt(str_) == str
+        @test bluefmt(str_) == str
+    end
 end


### PR DESCRIPTION
 colons are taken care of by `p_colonopcall` so we're just messing with other ops in that precedence for no reason

```
        # Level 8
        begin_colon,
            COLON, # :
            DDOT, # ..
            LDOTS, # …
            TRICOLON, # ⁝
            VDOTS, # ⋮
            DDOTS, # ⋱
            ADOTS, # ⋰
            CDOTS, # ⋯
        end_colon,

        # Level 9
```