### PR TITLE
Add `remove_trailing_comma` option

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.15.11"
+version = "0.16.0"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -58,6 +58,7 @@ function options(s::DefaultStyle)
         conditional_to_if = false,
         normalize_line_endings = "auto",
         align_matrix = false,
+        remove_trailing_comma = false,
     )
 end
 
@@ -133,6 +134,7 @@ normalize_line_ending(s::AbstractString, replacer = WINDOWS_TO_UNIX) = replace(s
         conditional_to_if = false,
         normalize_line_endings = "auto",
         align_matrix::Bool = false,
+        remove_trailing_comma::Bool = false,
     )::String
 
 Formats a Julia source passed in as a string, returning the formatted
@@ -353,6 +355,30 @@ end
 
 One of `"unix"` (normalize all `\r\n` to `\n`), `"windows"` (normalize all `\n` to `\r\n`), `"auto"` (automatically
 choose based on which line ending is more common in the file).
+
+### `remove_trailing_comma`
+
+default: `false`
+
+Trailing commas are added after the final argument when nesting occurs and the closing punctuation appears on the next line.
+
+For example when the following is nested (assuming `DefaultStyle`):
+
+```julia
+funccall(arg1, arg2, arg3)
+```
+
+it turns into:
+
+```julia
+funccall(
+    arg1,
+    arg2,
+    arg3, # trailing comma added after `arg3` (final arugment) !!!
+)
+```
+
+With `remove_trailing_comma` set to `true` the trailing comma above is never added.
 """
 function format_text(text::AbstractString; style::AbstractStyle = DefaultStyle(), kwargs...)
     return format_text(text, style; kwargs...)

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -454,12 +454,16 @@ function add_node!(t::FST, n::FST, s::State; join_lines = false, max_padding = -
            en.typ === Filter ||
            en.typ === Flatten ||
            en.typ === MacroCall ||
-           en.typ === MacroBlock ||
-           (is_comma(en) && t.typ === TupleN && n_args(t.ref[]) == 1)
-            # don't insert trailing comma in these cases
+           en.typ === MacroBlock
+            # don't add trailing comma in these cases
+        elseif is_comma(en) && t.typ === TupleN && n_args(t.ref[]) == 1
+            # preserve comma
+        elseif s.opts.remove_trailing_comma
+            if is_comma(en)
+                t[end] = Whitespace(0)
+            end
         elseif is_comma(en)
-            t.nodes[end] = n
-            t.len -= 1
+            t[end] = n
         else
             t.len += length(n)
             n.startline = t.startline

--- a/src/options.jl
+++ b/src/options.jl
@@ -19,6 +19,7 @@ Base.@kwdef struct Options
     conditional_to_if::Bool = false
     normalize_line_endings::String = "auto"
     align_matrix::Bool = false
+    remove_trailing_comma::Bool = false
 end
 
 function needs_alignment(opts::Options)

--- a/test/options.jl
+++ b/test/options.jl
@@ -1441,5 +1441,13 @@
 
         str = "funccall(arg1, arg2, arg3)"
         @test fmt(str_, remove_trailing_comma = true) == str
+
+        # corner case - if the comma is removed it is no longer a tuple
+        str_ = "(tuple,)"
+        str = """
+        (
+            tuple,
+        )"""
+        @test fmt(str_, 4, 1, remove_trailing_comma = true) == str
     end
 end

--- a/test/options.jl
+++ b/test/options.jl
@@ -1422,4 +1422,24 @@
         """
         @test fmt(str, align_matrix = true, style = YASStyle()) == str_
     end
+
+    @testset "remove trailing commas" begin
+        str = """
+        funccall(
+            arg1,
+            arg2,
+            arg3
+        )"""
+
+        str_ = "funccall(arg1, arg2, arg3)"
+        @test fmt(str_, 4, 1, remove_trailing_comma = true) == str
+
+        # last comma is removed
+
+        str_ = "funccall(arg1, arg2, arg3,)"
+        @test fmt(str_, 4, 1, remove_trailing_comma = true) == str
+
+        str = "funccall(arg1, arg2, arg3)"
+        @test fmt(str_, remove_trailing_comma = true) == str
+    end
 end


### PR DESCRIPTION
closes #76

### `remove_trailing_comma`
default: `false`
Trailing commas are added after the final argument when nesting occurs and the closing punctuation appears on the next line.
For example when the following is nested (assuming `DefaultStyle`):
```julia
funccall(arg1, arg2, arg3)
```
it turns into:
```julia
funccall(
    arg1,
    arg2,
    arg3, # trailing comma added after `arg3` (final arugment) !!!
)
```
With `remove_trailing_comma` set to `true` the trailing comma above is never added.