### PR TITLE
Support multi-dimensional array syntax (new in 1.7)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.18.1"
+version = "0.19.0"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/state.jl
+++ b/src/state.jl
@@ -14,13 +14,12 @@ State(doc, opts) = State(doc, 0, 1, 0, true, opts)
 @inline nspaces(s::State) = s.indent
 @inline hascomment(d::Document, line::Integer) = haskey(d.comments, line)
 
-
 """
     has_semicolon(d::Document, line::Integer)
 
 Returns whether `d` has a valid semicolon grouping on `line`.
 """
-function has_semicolon(d::Document, line::Integer) 
+function has_semicolon(d::Document, line::Integer)
     !haskey(d.semicolons, line) && return false
     return length(d.semicolons[line]) > 0
 end

--- a/src/state.jl
+++ b/src/state.jl
@@ -31,7 +31,8 @@ end
     return (l, offset - first(r) + 1, length(r))
 end
 @inline cursor_loc(s::State) = cursor_loc(s, s.offset)
-@inline function on_same_line(s::State, offset1::Int, offset2::Int)
+
+function on_same_line(s::State, offset1::Int, offset2::Int)
     l = s.doc.range_to_line[offset1:offset1]
     r = s.doc.line_to_range[l]
     return offset2 in r

--- a/src/state.jl
+++ b/src/state.jl
@@ -13,7 +13,17 @@ State(doc, opts) = State(doc, 0, 1, 0, true, opts)
 
 @inline nspaces(s::State) = s.indent
 @inline hascomment(d::Document, line::Integer) = haskey(d.comments, line)
-@inline has_semicolon(d::Document, line::Integer) = haskey(d.semicolons, line)
+
+
+"""
+    has_semicolon(d::Document, line::Integer)
+
+Returns whether `d` has a valid semicolon grouping on `line`.
+"""
+function has_semicolon(d::Document, line::Integer) 
+    !haskey(d.semicolons, line) && return false
+    return length(d.semicolons[line]) > 0
+end
 
 @inline function cursor_loc(s::State, offset::Integer)
     l = s.doc.range_to_line[offset:offset]

--- a/src/state.jl
+++ b/src/state.jl
@@ -13,7 +13,7 @@ State(doc, opts) = State(doc, 0, 1, 0, true, opts)
 
 @inline nspaces(s::State) = s.indent
 @inline hascomment(d::Document, line::Integer) = haskey(d.comments, line)
-@inline has_semicolon(d::Document, line::Integer) = line in d.semicolons
+@inline has_semicolon(d::Document, line::Integer) = haskey(d.semicolons, line)
 
 @inline function cursor_loc(s::State, offset::Integer)
     l = s.doc.range_to_line[offset:offset]

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -2104,8 +2104,12 @@ function p_vcat(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
                 end
                 add_node!(t, Placeholder(1), s)
                 # Keep trailing semicolon if there's only one arg
-            elseif length(args) == 1
-                add_node!(t, Semicolon(), s)
+            elseif length(args) == 1 && has_semicolon(s.doc, n.startline)
+                semicolons = s.doc.semicolons[n.startline]
+                count = popfirst!(semicolons)
+                for _ = 1:count
+                    add_node!(t, Semicolon(), s)
+                end
                 add_node!(t, Placeholder(0), s)
             else
                 add_node!(t, Placeholder(0), s)

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -119,6 +119,10 @@ function pretty(ds::DefaultStyle, cst::CSTParser.EXPR, s::State; kwargs...)
         return p_using(style, cst, s)
     elseif cst.head === :row
         return p_row(style, cst, s)
+    elseif cst.head === :ncat
+        return p_vcat(style, cst, s)
+    elseif cst.head === :typed_ncat
+        return p_typedvcat(style, cst, s)
     elseif cst.head === :vcat
         return p_vcat(style, cst, s)
     elseif cst.head === :typed_vcat
@@ -2087,8 +2091,17 @@ function p_vcat(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
         elseif !is_closer(a) && i > st
             add_node!(t, n, s, join_lines = true)
             if i != length(cst) - 1
-                has_semicolon(s.doc, n.startline) &&
-                    add_node!(t, InverseTrailingSemicolon(), s)
+                if has_semicolon(s.doc, n.startline)
+                    semicolons = s.doc.semicolons[n.startline]
+                    count = popfirst!(semicolons)
+                    if count > 1
+                        for _ in 1:count
+                            add_node!(t, Semicolon(), s)
+                        end
+                    else
+                        add_node!(t, InverseTrailingSemicolon(), s)
+                    end
+                end
                 add_node!(t, Placeholder(1), s)
                 # Keep trailing semicolon if there's only one arg
             elseif length(args) == 1

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -2090,6 +2090,7 @@ function p_vcat(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
             add_node!(t, Placeholder(0), s)
         elseif !is_closer(a) && i > st
             add_node!(t, n, s, join_lines = true)
+
             if i != length(cst) - 1
                 if has_semicolon(s.doc, n.startline)
                     semicolons = s.doc.semicolons[n.startline]

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -2095,7 +2095,7 @@ function p_vcat(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
                     semicolons = s.doc.semicolons[n.startline]
                     count = popfirst!(semicolons)
                     if count > 1
-                        for _ in 1:count
+                        for _ = 1:count
                             add_node!(t, Semicolon(), s)
                         end
                     else

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -294,8 +294,17 @@ function p_vcat(ys::YASStyle, cst::CSTParser.EXPR, s::State)
                 override_join_lines_based_on_source = i == st + 1,
             )
             if i != length(cst) - 1
-                has_semicolon(s.doc, n.startline) &&
-                    add_node!(t, InverseTrailingSemicolon(), s)
+                if has_semicolon(s.doc, n.startline)
+                    semicolons = s.doc.semicolons[n.startline]
+                    count = popfirst!(semicolons)
+                    if count > 1
+                        for _ in 1:count
+                            add_node!(t, Semicolon(), s)
+                        end
+                    else
+                        add_node!(t, InverseTrailingSemicolon(), s)
+                    end
+                end
             end
         else
             add_node!(t, n, s, join_lines = true)

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -293,16 +293,20 @@ function p_vcat(ys::YASStyle, cst::CSTParser.EXPR, s::State)
                 join_lines = join_lines,
                 override_join_lines_based_on_source = i == st + 1,
             )
-            if i != length(cst) - 1
-                if has_semicolon(s.doc, n.startline)
-                    semicolons = s.doc.semicolons[n.startline]
-                    count = popfirst!(semicolons)
+            if has_semicolon(s.doc, n.startline)
+                semicolons = s.doc.semicolons[n.startline]
+                count = popfirst!(semicolons)
+                if i != length(cst) - 1
                     if count > 1
                         for _ = 1:count
                             add_node!(t, Semicolon(), s)
                         end
                     else
                         add_node!(t, InverseTrailingSemicolon(), s)
+                    end
+                elseif count > 1
+                    for _ = 1:count
+                        add_node!(t, Semicolon(), s)
                     end
                 end
             end

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -298,7 +298,7 @@ function p_vcat(ys::YASStyle, cst::CSTParser.EXPR, s::State)
                     semicolons = s.doc.semicolons[n.startline]
                     count = popfirst!(semicolons)
                     if count > 1
-                        for _ in 1:count
+                        for _ = 1:count
                             add_node!(t, Semicolon(), s)
                         end
                     else

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1039,8 +1039,20 @@
             str = "[v1 v2;;]"
             @test fmt(str) == str
 
+            str_ = """
+            [
+                v1 v2;;
+            ]"""
+            @test fmt(str, 4, 1) == str_
+
             str = "T[v1 v2;;]"
             @test fmt(str) == str
+
+            str_ = """
+            T[
+                v1 v2;;
+            ]"""
+            @test fmt(str, 4, 1) == str_
         end
 
         @testset "YASStyle" begin
@@ -1062,9 +1074,11 @@
 
             str = "[v1 v2;;]"
             @test yasfmt(str) == str
+            @test yasfmt(str, 4, 1) == str
 
             str = "T[v1 v2;;]"
             @test yasfmt(str) == str
+            @test yasfmt(str, 4, 1) == str
         end
     end
 

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1013,7 +1013,6 @@
         @test bluefmt(str, 4, 1) == str
     end
 
-
     @testset "490" begin
         @testset "DefaultStyle" begin
             str = "[1;; 2]"
@@ -1088,5 +1087,5 @@
 
         str = "Base.@deprecate f(x, y) g(x, y = y)\n"
         @test bluefmt(str) == str
-		end
+    end
 end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1015,41 +1015,57 @@
 
 
     @testset "490" begin
-        str = "[1;; 2]"
-        @test fmt(str) == str
+        @testset "DefaultStyle" begin
+            str = "[1;; 2]"
+            @test fmt(str) == str
 
-        str_ = """
-        [
-            1;;
-            2
-        ]"""
-        @test fmt(str, 4, 1) == str_
+            str_ = """
+            [
+                1;;
+                2
+            ]"""
+            @test fmt(str, 4, 1) == str_
 
-        str = "T[1;; 2]"
-        @test fmt(str) == str
+            str = "T[1;; 2]"
+            @test fmt(str) == str
 
-        str_ = """
-        T[
-            1;;
-            2
-        ]"""
-        @test fmt(str, 4, 1) == str_
+            str_ = """
+            T[
+                1;;
+                2
+            ]"""
+            @test fmt(str, 4, 1) == str_
 
-        str = "[1;; 2]"
-        @test yasfmt(str) == str
+            str = "[v1 v2;;]"
+            @test fmt(str) == str
 
-        str_ = """
-        [1;;
-         2]"""
-        @test yasfmt(str, 4, 1) == str_
+            str = "T[v1 v2;;]"
+            @test fmt(str) == str
+        end
 
-        str = "T[1;; 2]"
-        @test yasfmt(str) == str
+        @testset "YASStyle" begin
+            str = "[1;; 2]"
+            @test yasfmt(str) == str
 
-        str_ = """
-        T[1;;
-          2]"""
-        @test yasfmt(str, 4, 1) == str_
+            str_ = """
+            [1;;
+             2]"""
+            @test yasfmt(str, 4, 1) == str_
+
+            str = "T[1;; 2]"
+            @test yasfmt(str) == str
+
+            str_ = """
+            T[1;;
+              2]"""
+            @test yasfmt(str, 4, 1) == str_
+
+            str = "[v1 v2;;]"
+            @test yasfmt(str) == str
+
+            str = "T[v1 v2;;]"
+            @test yasfmt(str) == str
+        end
     end
 
     @testset "494" begin

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1013,11 +1013,50 @@
         @test bluefmt(str, 4, 1) == str
     end
 
+
+    @testset "490" begin
+        str = "[1;; 2]"
+        @test fmt(str) == str
+
+        str_ = """
+        [
+            1;;
+            2
+        ]"""
+        @test fmt(str, 4, 1) == str_
+
+        str = "T[1;; 2]"
+        @test fmt(str) == str
+
+        str_ = """
+        T[
+            1;;
+            2
+        ]"""
+        @test fmt(str, 4, 1) == str_
+
+        str = "[1;; 2]"
+        @test yasfmt(str) == str
+
+        str_ = """
+        [1;;
+         2]"""
+        @test yasfmt(str, 4, 1) == str_
+
+        str = "T[1;; 2]"
+        @test yasfmt(str) == str
+
+        str_ = """
+        T[1;;
+          2]"""
+        @test yasfmt(str, 4, 1) == str_
+    end
+
     @testset "494" begin
         str = "Base.@deprecate f(x, y = x) g(x, y)\n"
         @test bluefmt(str) == str
 
         str = "Base.@deprecate f(x, y) g(x, y = y)\n"
         @test bluefmt(str) == str
-    end
+		end
 end


### PR DESCRIPTION
closes #490

semicolons are now tracked by groupings, where a group is 1 or more consecutive semicolons. There can be multiple groupings per line (unclear if that syntax actually makes sense practically but it is allowed).

```
[v1;;;;; v2;;;] # equivalent to [v1;;;;; v2]
```

in this case the semicolons groupings would be [5, 3] since there are two groupings the first with 5 semicolons,  the second with 3.

The trailing semicolon group is not removed unless it's singular (count of 1) since it can be semantically meaningful, such as the following case

```
julia> [v1 v2;;;;;]
3×2×1×1×1 Array{Int64, 5}:
[:, :, 1, 1, 1] =
 1  4
 2  5
 3  6
```

For other uses of semicolons that are not array related simply checking if the line has a semicolon group is sufficient so nothing changes there.
