### PR TITLE
Fixes for floating point leading 0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.19.1"
+version = "0.19.2"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -364,25 +364,26 @@ end
             return FST(LITERAL, loc[2], loc[1], loc[1], "")
         end
 
-        if cst.head === :FLOAT && endswith(cst.val, "f0")
-            # Float32
-            val = val[1:end-2]
+        if cst.head === :FLOAT
+            fidx = findlast(c -> c == 'f', val)
+            float_suffix = ""
+            if fidx !== nothing
+                float_suffix = val[fidx:end]
+                val = val[1:fidx-1]
+            end
+
             dotidx = findlast(c -> c == '.', val)
             if dotidx === nothing
                 val *= ".0"
             elseif dotidx == length(val)
+                # If a floating point ends in `.`, add trailing zero.
                 val *= '0'
             elseif dotidx == 1
                 val = '0' * val
+            elseif dotidx == 2 && val[1] == '-'
+                val = val[1] * '0' * val[2:end]
             end
-            val *= "f0"
-        elseif cst.head === :FLOAT
-            if endswith(cst.val, ".")
-                # If a floating point ends in `.`, add trailing zero.
-                val *= '0'
-            elseif startswith(cst.val, ".")
-                val = '0' * val
-            end
+            val *= float_suffix
         end
 
         s.offset += length(cst.val) + (cst.fullspan - cst.span)

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -373,7 +373,9 @@ end
             end
 
             dotidx = findlast(c -> c == '.', val)
-            if dotidx === nothing
+
+            if fidx !== nothing && dotidx === nothing
+                # append a trailing zero prior to the float suffix
                 val *= ".0"
             elseif dotidx == length(val)
                 # If a floating point ends in `.`, add trailing zero.

--- a/test/files/ChainRules.jl/test/rulesets/Base/mapreduce.jl
+++ b/test/files/ChainRules.jl/test/rulesets/Base/mapreduce.jl
@@ -181,7 +181,7 @@ struct SumRuleConfig <: RuleConfig{Union{HasReverseMode}} end
             end
         end
         @testset "Array{Float32}, no zero entries" begin
-            v = [1f-5, 1f-10, 1f-15, 1f-20]
+            v = [1.0f-5, 1.0f-10, 1.0f-15, 1.0f-20]
             @test prod(v) == 0
             @test unthunk(rrule(prod, v)[2](1.0f0)[2]) == zeros(4)
             test_rrule(prod, v)

--- a/test/files/ChainRules.jl/test/rulesets/LinearAlgebra/dense.jl
+++ b/test/files/ChainRules.jl/test/rulesets/LinearAlgebra/dense.jl
@@ -25,8 +25,8 @@
             F in (adjoint, permuteddimsarray)
 
             A = F(rand(T, 4, 3)) ⊢ F(rand(T, 4, 3))
-            test_frule(dot, rand(T, 3), A, rand(T, 4); rtol=1f-3)
-            test_rrule(dot, rand(T, 3), A, rand(T, 4); rtol=1f-3)
+            test_frule(dot, rand(T, 3), A, rand(T, 4); rtol=1.0f-3)
+            test_rrule(dot, rand(T, 3), A, rand(T, 4); rtol=1.0f-3)
         end
         @testset "different types" begin
             test_rrule(dot, rand(2), rand(2, 2), rand(ComplexF64, 2))

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -563,6 +563,38 @@
         f = 0.123f0
         """
         @test fmt(str_) == str
+
+        @testset "500 - leading zeros with '-.'" begin
+            s0 = """
+            a = -.2
+            b = - .2
+            """
+            s1 = """
+            a = -0.2
+            b = -0.2
+            """
+            @test fmt(s0) == s1
+
+            s0 = """
+            a = -.2f32
+            b = - .2f32
+            """
+            s1 = """
+            a = -0.2f32
+            b = -0.2f32
+            """
+            @test fmt(s0) == s1
+
+            s0 = """
+            a = -.2f-5
+            b = - .2f-5
+            """
+            s1 = """
+            a = -0.2f-5
+            b = -0.2f-5
+            """
+            @test fmt(s0) == s1
+        end
     end
 
     @testset "issue 289 - no spaces/nesting for matrix elements" begin
@@ -1087,28 +1119,6 @@
 
         str = "Base.@deprecate f(x, y) g(x, y = y)\n"
         @test bluefmt(str) == str
-    end
-
-    @testset "500 - leading zeros with '-.'" begin
-        s0 = """
-        a = -.2
-        b = - .2
-        """
-        s1 = """
-        a = -0.2
-        b = -0.2
-        """
-        @test fmt(s0) == s1
-
-        s0 = """
-        a = -.2f32
-        b = - .2f32
-        """
-        s1 = """
-        a = -0.2f32
-        b = -0.2f32
-        """
-        @test fmt(s0) == s1
     end
 
     @testset "509" begin

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1089,6 +1089,28 @@
         @test bluefmt(str) == str
     end
 
+    @testset "500 - leading zeros with '-.'" begin
+        s0 = """
+        a = -.2
+        b = - .2
+        """
+        s1 = """
+        a = -0.2
+        b = -0.2
+        """
+        @test fmt(s0) == s1
+
+        s0 = """
+        a = -.2f32
+        b = - .2f32
+        """
+        s1 = """
+        a = -0.2f32
+        b = -0.2f32
+        """
+        @test fmt(s0) == s1
+    end
+
     @testset "509" begin
         code = """M.var"@f";"""
         @test fmt(code) == code


### PR DESCRIPTION
fixes #500 to the extent that the ruling is now consistent. These could be made optional later.

```
-.2 -> -0.2
```

This also generalizes the rule to other floating point suffixes than just "f32", so as can be seen in the diff 1f-5 will now become 1.0f-5, etc.
