### PR TITLE
Allow `always_for_in=nothing`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.19.2"
+version = "0.20.0"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ be formatted across multiple lines.
 > default: `false`
 
 If true, `=` is always replaced with `in` if part of a `for` loop condition.
-For example, `for i = 1:10` will be transformed to `for i in 1:10`.
+For example, `for i = 1:10` will be transformed to `for i in 1:10`. Set
+this to `nothing` to leave the choice to the user.
 
 ### `whitespace_typedefs`
 

--- a/docs/src/transforms.md
+++ b/docs/src/transforms.md
@@ -5,6 +5,7 @@
 By default if the RHS is a range, i.e. `1:10` then `for in` is converted to `for =`. Otherwise `for =` is converted to `for in`. See [this issue](https://github.com/domluna/JuliaFormatter.jl/issues/34) for the rationale and further explanation.
 
 Alternative to the above - setting `always_for_in` to `true`, i.e. `format_text(..., always_for_in = true)` will always convert `=` to `in` even if the RHS is a range.
+`always_for_in=nothing` will leave the choice of `in` vs `=` up to the user.
 
 ## Trailing Commas
 

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -117,7 +117,7 @@ normalize_line_ending(s::AbstractString, replacer = WINDOWS_TO_UNIX) = replace(s
         style::AbstractStyle = DefaultStyle(),
         indent::Int = 4,
         margin::Int = 92,
-        always_for_in::Bool = false,
+        always_for_in::Union{Bool,Nothing} = false,
         whitespace_typedefs::Bool = false,
         whitespace_ops_in_indices::Bool = false,
         remove_extra_newlines::Bool = false,

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -1074,6 +1074,7 @@ end
 
 """
     eq_to_in_normalization!(fst::FST, always_for_in::Bool)
+    eq_to_in_normalization!(fst::FST, always_for_in::Nothing)
 
 Transforms
 
@@ -1094,6 +1095,8 @@ for i in 1:10 body end
 
 for i = 1:10 body end
 ```
+
+`always_for_in=nothing` disables this normalization behavior.
 
 - https://github.com/domluna/JuliaFormatter.jl/issues/34
 """
@@ -1122,3 +1125,5 @@ function eq_to_in_normalization!(fst::FST, always_for_in::Bool)
         end
     end
 end
+
+eq_to_in_normalization!(::FST, ::Nothing) = nothing

--- a/src/options.jl
+++ b/src/options.jl
@@ -1,7 +1,7 @@
 Base.@kwdef struct Options
     indent::Int = 4
     margin::Int = 92
-    always_for_in::Bool = false
+    always_for_in::Union{Bool,Nothing} = false
     whitespace_typedefs::Bool = false
     whitespace_ops_in_indices::Bool = false
     remove_extra_newlines::Bool = false

--- a/test/options.jl
+++ b/test/options.jl
@@ -230,6 +230,8 @@
         end"""
         @test fmt(str_, always_for_in = true) == str
         @test fmt(str, always_for_in = true) == str
+        @test fmt(str_, always_for_in = nothing) == str_
+        @test fmt(str, always_for_in = nothing) == str
 
         str_ = "[(i,j) for i=I1,j=I2]"
         str = "[(i, j) for i in I1, j in I2]"


### PR DESCRIPTION
to disable `=`/`in` normalization.