### PR TITLE
fix #512

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.20.0"
+version = "0.20.1"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/document.jl
+++ b/src/document.jl
@@ -120,8 +120,13 @@ function Document(text::AbstractString)
                         s = length(ranges) > 0 ? last(ranges[end]) + 1 : 1
                         push!(ranges, s:offset+1)
                         fc = findfirst(c -> !isspace(c), cs)
-                        idx = fc === nothing ? 1 : min(fc, ws + 1)
-                        comments[line] = (ws, cs[idx:end])
+                        if fc === nothing
+                            # comment is all whitespace
+                            comments[line] = (ws, cs[end:end])
+                        else
+                            idx = min(fc, ws + 1)
+                            comments[line] = (ws, cs[idx:end])
+                        end
                         line += 1
                         cs = ""
                     end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1130,4 +1130,23 @@
         """
         @test fmt(code) == code
     end
+
+    @testset "512" begin
+        # the 3rd line in the multiline comment contains a bunch of spaces prior 
+        # to the newline, before this fix the whitespace prior to the start of 
+        # the comment would be prepended to that line so that on repeated indents 
+        # the spaces would keep increasing.
+        str = """
+        function make_router()
+            function get_sesh()
+                #= 
+                x
+                             
+                x=#
+            end
+        end
+        """
+        ans = "function make_router()\n    function get_sesh()\n        #= \n        x\n\n        x=#\n    end\nend\n"
+        @test fmt(str) == ans
+    end
 end


### PR DESCRIPTION
Trims lines in a multiline comment that are whitespace with a newline
at the end to simply that newline. Otherwise, the amount of whitespace prior to the
start of the multiline comment is prepended to that line causing the
whitespace before the newline to increase on each format.

For example (whitespace in mutliline comment is noted by <ws>)

```
begin
    #=
    <ws><ws>\n
    =#
end
```

Since there are 4 spaces before #= on format 4 more spaces will be added
to the 2nd line in the mutliline comment, meaning `"<ws><ws>\n"` becomes
`"<ws><ws><ws><ws><ws><ws>\n"` and so on.