### PR TITLE
improved `always_use_return` heuristics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.20.3"
+version = "0.20.4"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/test/options.jl
+++ b/test/options.jl
@@ -363,6 +363,28 @@
             end
         end"""
         @test fmt(str, 4, 92, always_use_return = true) == str
+
+        @testset "426" begin
+            # throw function heuristic
+            str = """
+            function f(x)
+                x == 1 && return "a"
+                x == 2 && return "b"
+                throw(ArgumentError("x must be 1 or 2"))
+            end
+            """
+            @test fmt(str, always_use_return = true) == str
+        end
+
+        @testset "507" begin
+            # detect return
+            str = """
+            function f()
+                (1 + 1; return 2)
+            end
+            """
+            @test fmt(str, always_use_return = true) == str
+        end
     end
 
     @testset "whitespace in keyword arguments" begin


### PR DESCRIPTION
- fix #426 - if the last expression is a `throw` function call do not
  add a return keyword.
- fix #507 - search the last expression for a return keyword, if found,
  do not add a return keyword.