### PR TITLE
fix #480

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.20.5"
+version = "0.21.0"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -641,11 +641,12 @@ function p_macrocall(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
 
         n = pretty(style, a, s)
         if CSTParser.ismacroname(a)
-            if has_closer || length(args) == 0
-                add_node!(t, n, s, join_lines = true)
-            else
-                add_node!(t, n, s, join_lines = true)
-                add_node!(t, Whitespace(1), s)
+            add_node!(t, n, s, join_lines = true)
+            if length(args) > 0
+                loc = cursor_loc(s)
+                if t[end].line_offset + length(t[end]) < loc[2]
+                    add_node!(t, Whitespace(1), s)
+                end
             end
         elseif is_opener(n) && nest
             add_node!(t, n, s, join_lines = true)
@@ -676,6 +677,7 @@ function p_macrocall(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
             end
         end
     end
+
     # move placement of @ to the end
     #
     # @Module.macro -> Module.@macro

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -422,11 +422,12 @@ function p_macrocall(ys::YASStyle, cst::CSTParser.EXPR, s::State)
 
         n = pretty(style, a, s)
         if CSTParser.ismacroname(a)
-            if has_closer || length(args) == 0
-                add_node!(t, n, s, join_lines = true)
-            else
-                add_node!(t, n, s, join_lines = true)
-                add_node!(t, Whitespace(1), s)
+            add_node!(t, n, s, join_lines = true)
+            if length(args) > 0
+                loc = cursor_loc(s)
+                if t[end].line_offset + length(t[end]) < loc[2]
+                    add_node!(t, Whitespace(1), s)
+                end
             end
         elseif CSTParser.is_comma(a) && i < length(cst) && !is_punc(cst[i+1])
             add_node!(t, n, s, join_lines = true)

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1256,4 +1256,26 @@
         str = "Base.:(|>)(r::AbstractRegister, blk::AbstractBlock) = apply!(r, blk)"
         @test fmt(str, pipe_to_function_call = true) == str
     end
+
+    @testset "480" begin
+        str = "@show (1,)"
+        @test fmt(str) == str
+
+        str = "@show(1,)"
+        @test fmt(str) == str
+
+        str = """
+        @NamedTuple{a::Int, b::Int}[]
+
+        @SVector[@SVector[1, 2], @SVector[1, 2]]
+        """
+        @test fmt(str) == str
+
+        str = """
+        @NamedTuple {a::Int, b::Int}[]
+
+        @SVector[@SVector[1, 2], @SVector [1, 2]]
+        """
+        @test fmt(str) == str
+    end
 end


### PR DESCRIPTION
use the same whitespace as the source file for macro calls rather than
adding/removing whitespace based on a heuristic.

closes #524 
