### PR TITLE
fix #530

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.21.0"
+version = "0.21.1"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/styles/blue/pretty.jl
+++ b/src/styles/blue/pretty.jl
@@ -147,6 +147,8 @@ function p_binaryopcall(
         )
     )
         add_node!(t, pretty(style, op, s), s, join_lines = true)
+    elseif op.val in RADICAL_OPS
+        add_node!(t, pretty(style, op, s), s, join_lines = true)
     else
         add_node!(t, Whitespace(1), s)
         add_node!(t, pretty(style, op, s), s, join_lines = true)

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1498,6 +1498,10 @@ end
 p_kw(style::S, cst::CSTParser.EXPR, s::State) where {S<:AbstractStyle} =
     p_kw(DefaultStyle(style), cst, s)
 
+# Radical operators were introduced in 1.7 which require no surrounding whitespace.
+# https://github.com/domluna/JuliaFormatter.jl/issues/530
+const RADICAL_OPS = Set(["√", "∛", "∜"])
+
 function p_binaryopcall(
     ds::DefaultStyle,
     cst::CSTParser.EXPR,
@@ -1559,6 +1563,8 @@ function p_binaryopcall(
             precedence(op) in (CSTParser.PowerOp, CSTParser.DeclarationOp, CSTParser.DotOp)
         )
     )
+        add_node!(t, pretty(style, op, s), s, join_lines = true)
+    elseif op.val in RADICAL_OPS
         add_node!(t, pretty(style, op, s), s, join_lines = true)
     else
         add_node!(t, Whitespace(1), s)

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1278,4 +1278,20 @@
         """
         @test fmt(str) == str
     end
+
+    @testset "530" begin
+        @testset "DefaultStyle" begin
+            for op in JuliaFormatter.RADICAL_OPS
+                s = "3$(op)2"
+                @test fmt(s) == s
+            end
+        end
+
+        @testset "DefaultStyle" begin
+            for op in JuliaFormatter.RADICAL_OPS
+                s = "3$(op)2"
+                @test bluefmt(s) == s
+            end
+        end
+    end
 end


### PR DESCRIPTION
Radical operators were introduced in 1.7 which require no surrounding whitespace.