### PR TITLE
fix #533

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.21.1"
+version = "0.21.2"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -933,6 +933,11 @@ function is_function_or_macro_def(cst::CSTParser.EXPR)
     CSTParser.defines_function(cst) && return true
     cst.head === :macro && return true
     cst.head === :where && return true
+    CSTParser.isoperator(cst.head) &&
+        cst.head.val == "::" &&
+        cst.parent !== nothing &&
+        cst.parent.head == :where &&
+        return true
     return false
 end
 

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -936,7 +936,7 @@ function is_function_or_macro_def(cst::CSTParser.EXPR)
     CSTParser.isoperator(cst.head) &&
         cst.head.val == "::" &&
         cst.parent !== nothing &&
-        cst.parent.head == :where &&
+        (cst.parent.head == :where || cst.parent.head === :function) &&
         return true
     return false
 end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1300,5 +1300,9 @@
         s = "function linterp(x0::T, y0::T, x1::T, y1::T, x::T, extrap::Bool = false)::T where {T<:AbstractFloat} end"
         @test bluefmt(s, m = 200) == s
         @test yasfmt(s, m = 200) == s
+
+        s = "function linterp(x0::T, y0::T, x1::T, y1::T, x::T, extrap::Bool = false)::T end"
+        @test bluefmt(s, m = 200) == s
+        @test yasfmt(s, m = 200) == s
     end
 end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1294,4 +1294,11 @@
             end
         end
     end
+
+    @testset "533" begin
+        # semicolon should not be added prior to `extrap` since it's a function definition.
+        s = "function linterp(x0::T, y0::T, x1::T, y1::T, x::T, extrap::Bool = false)::T where {T<:AbstractFloat} end"
+        @test bluefmt(s, m=200) == s
+        @test yasfmt(s, m=200) == s
+    end
 end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1298,7 +1298,7 @@
     @testset "533" begin
         # semicolon should not be added prior to `extrap` since it's a function definition.
         s = "function linterp(x0::T, y0::T, x1::T, y1::T, x::T, extrap::Bool = false)::T where {T<:AbstractFloat} end"
-        @test bluefmt(s, m=200) == s
-        @test yasfmt(s, m=200) == s
+        @test bluefmt(s, m = 200) == s
+        @test yasfmt(s, m = 200) == s
     end
 end


### PR DESCRIPTION
There was an unhandled case where a where clause that also has a return
type:

```
function foo(...)::T where T
end
```

was not being flagged as a function definition