### PR TITLE
Support `trailing_comma = "nothing"` in TOML

### DIFF
--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -417,6 +417,13 @@ funccall(
 * When set to `false`, the trailing comma is always removed during nesting.
 * When set to `nothing`, the trailing comma appears as it does in the original source.
 
+In the [Configuration File](@ref), a `nothing` value can be set as the string
+value `"nothing"`:
+
+```toml
+trailing_comma = "nothing"
+```
+
 ### `join_lines_based_on_source`
 
 > default: `false`
@@ -757,6 +764,9 @@ end
 
 function parse_config(tomlfile)
     config_dict = parsefile(tomlfile)
+    if get(config_dict, "trailing_comma", "") == "nothing"
+        config_dict["trailing_comma"] = nothing
+    end
     if (style = get(config_dict, "style", nothing)) !== nothing
         @assert (style == "default" || style == "yas" || style == "blue") "currently $(CONFIG_FILE_NAME) accepts only \"default\" or \"yas\" or \"blue\" for the style configuration"
         config_dict["style"] = if (style == "yas" && @isdefined(YASStyle))

--- a/test/config.jl
+++ b/test/config.jl
@@ -201,4 +201,62 @@
     finally
         rm(sandbox_dir; recursive = true)
     end
+
+    config_trailing_comma_nothing = """
+    trailing_comma = "nothing"
+    """
+
+    code_trailing_comma = """
+    const A_SET_OF_SYMBOLS_WITH_TRAILING_COMMA = Set([
+        :accesses, :allowedtypes, :connector, :digits, :equals, :expand,
+        :ignores, :sigdigits, :sort, :val_to_string,
+    ])
+    const A_SET_OF_SYMBOLS_WITHOUT_TRAILING_COMMA = Set([
+        :accesses, :allowedtypes, :connector, :digits, :equals, :expand,
+        :ignores, :sigdigits, :sort, :val_to_string
+    ])
+    """
+    code_trailing_comma_after = """
+    const A_SET_OF_SYMBOLS_WITH_TRAILING_COMMA = Set([
+        :accesses,
+        :allowedtypes,
+        :connector,
+        :digits,
+        :equals,
+        :expand,
+        :ignores,
+        :sigdigits,
+        :sort,
+        :val_to_string,
+    ])
+    const A_SET_OF_SYMBOLS_WITHOUT_TRAILING_COMMA = Set([
+        :accesses,
+        :allowedtypes,
+        :connector,
+        :digits,
+        :equals,
+        :expand,
+        :ignores,
+        :sigdigits,
+        :sort,
+        :val_to_string
+    ])
+    """
+    # test `trailing_comma = "nothing"` in config (#539)
+    # test_trailing_comma_nothing_config
+    # ├─ .JuliaFormatter.toml (config_trailing_comma_nothing)
+    # └─ code.jl (code_trailing_comma -> code_trailing_comma_after)
+    sandbox_dir = joinpath(tempdir(), "test_trailing_comma_nothing_config")
+    mkdir(sandbox_dir)
+    try
+        config_path = joinpath(sandbox_dir, CONFIG_FILE_NAME)
+        code_path = joinpath(sandbox_dir, "code.jl")
+        open(io -> write(io, config_trailing_comma_nothing), config_path, "w")
+        open(io -> write(io, code_trailing_comma), code_path, "w")
+
+        @test format(code_path) == false
+        @test read(code_path, String) == code_trailing_comma_after
+    finally
+        rm(sandbox_dir; recursive = true)
+    end
 end


### PR DESCRIPTION
Since TOML does not have a `nothing` type, this translates the string
`"nothing"` to the value `nothing` for the `trailing_comma` options.

Closes #539