### PR TITLE
fix #546

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.22.2"
+version = "0.22.3"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/nest_utils.jl
+++ b/src/nest_utils.jl
@@ -28,6 +28,10 @@ Walks `fst` calling `f` on each node.
 
 In situations where descending further into a subtree is not desirable `f`
 should return a value other than `nothing`.
+
+!!! note
+    This function mutates the State's (`s`) `line_offset`. If this is not desired
+    you should save the value before calling this function and restore it after.
 """
 function walk(f, fst::FST, s::State)
     stop = f(fst, s)

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -382,11 +382,13 @@ function prepend_return!(fst::FST, s::State)
         end
         return
     end
+    lo = s.line_offset
     walk(f, ln, s)
+    s.line_offset = lo
     found_return && return
 
     ret = FST(Return, fst.indent)
-    kw = FST(KEYWORD, -1, fst[end].startline, fst[end].endline, "return")
+    kw = FST(KEYWORD, -1, ln.startline, ln.startline, "return")
     add_node!(ret, kw, s)
     add_node!(ret, Whitespace(1), s)
     add_node!(ret, ln, s, join_lines = true)

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1344,7 +1344,7 @@
             92,
             join_lines_based_on_source = true,
             always_use_return = true,
-            whitespace_in_kwargs = true,
+            whitespace_in_kwargs = false,
         ) == str_
     end
 end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1316,4 +1316,35 @@
         """
         @test fmt(str, align_matrix = true) == str
     end
+
+    @testset "546" begin
+        str = """
+        function _plot_augmented_roc(inference_signals::DataFrame, per_threshold_sensitivity,
+                                     thresholds; save_dir=nothing, save_prefix="", title_suffix="",
+                                     xaxis_prefix="Control dataset: ")
+            plot_data = augment_roc_data(inference_signals, thresholds)
+            _plot_augmented_roc(plot_data, per_threshold_sensitivity;
+                                       save_dir=save_dir, save_prefix=save_prefix,
+                                       title_suffix=title_suffix, xaxis_prefix=xaxis_prefix)
+        end
+        """
+        str_ = """
+        function _plot_augmented_roc(inference_signals::DataFrame, per_threshold_sensitivity,
+                                     thresholds; save_dir=nothing, save_prefix="", title_suffix="",
+                                     xaxis_prefix="Control dataset: ")
+            plot_data = augment_roc_data(inference_signals, thresholds)
+            return _plot_augmented_roc(plot_data, per_threshold_sensitivity;
+                                       save_dir=save_dir, save_prefix=save_prefix,
+                                       title_suffix=title_suffix, xaxis_prefix=xaxis_prefix)
+        end
+        """
+        @test yasfmt(
+            str,
+            4,
+            92,
+            join_lines_based_on_source = true,
+            always_use_return = true,
+            whitespace_in_kwargs = true,
+        ) == str_
+    end
 end


### PR DESCRIPTION
1. The startline/endline for the created "return" keyword was using the
range of the block node instead of the last node in the block. Odd this
didn't pop up as a bug sooner but I guess since the following node was
automatically joined to the return node it hasn't been problematic.
Nonetheless `join_lines_based_on_source` brings this issue to light so
we need to deal with it.
2. `walk` mutates the `line_offset` of the `State` and we weren't resetting
it properly in `prepend_return!` which could cause odd indentation,
seemingly only when `join_lines_based_on_source` is `true`. It's now
properly reset so this is no longer an issue.