### PR TITLE
fix #543

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.22.3"
+version = "0.22.4"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/align.jl
+++ b/src/align.jl
@@ -270,13 +270,15 @@ function align_matrix!(fst::FST)
         r[1].line_offset
     end)
 
-    # add whitespace prior to initial element
-    # if elements are aligned to the right
+    line = 0
+    # add whitespace prior to initial element if elements are aligned to the right and
+    # it's the first row on that line.
     for r in rows
-        if r[1].line_offset > min_offset
+        if r[1].line_offset > min_offset && line != r.startline
             diff = r[1].line_offset - min_offset
             insert!(r.nodes, 1, Whitespace(diff))
         end
+        line = r.startline
     end
 
     for r in rows

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1317,6 +1317,66 @@
         @test fmt(str, align_matrix = true) == str
     end
 
+    @testset "543" begin
+        str_ = """
+        G4 = [ H    Zero  H; Zero    H   H
+              Zero  Zero  H]
+        """
+        str = """
+        G4 = [
+             H    Zero  H
+            Zero    H   H
+            Zero  Zero  H
+        ]
+        """
+        @test fmt(str_, align_matrix = true) == str
+
+        str_ = """
+        H = [1 1; 1 1]
+        Zero = [0 0; 0 0]
+
+        G1 = vcat(hcat(H,    Zero, H),
+                  hcat(Zero, H,    H),
+                  hcat(Zero, Zero, H))
+
+        G2 = [ H    Zero  H
+              Zero    H   H
+              Zero  Zero  H]
+
+        G3 = [ H    Zero  H;
+              Zero    H   H
+              Zero  Zero  H]
+
+        G4 = [ H    Zero  H; Zero    H   H
+              Zero  Zero  H]
+        """
+        str = """
+        H = [1 1; 1 1]
+        Zero = [0 0; 0 0]
+
+        G1 = vcat(hcat(H, Zero, H), hcat(Zero, H, H), hcat(Zero, Zero, H))
+
+        G2 = [
+             H    Zero  H
+            Zero    H   H
+            Zero  Zero  H
+        ]
+
+        G3 = [
+             H    Zero  H
+            Zero    H   H
+            Zero  Zero  H
+        ]
+
+        G4 = [
+             H    Zero  H
+            Zero    H   H
+            Zero  Zero  H
+        ]
+        """
+        @test fmt(str_, align_matrix = true) == str
+    end
+
     @testset "546" begin
         str = """
         function _plot_augmented_roc(inference_signals::DataFrame, per_threshold_sensitivity,


### PR DESCRIPTION
This problem occurs when a line in the original source code contains >=
2 rows.

The current format breaks up the rows into individual lines but it
prepends an undesirable amount of whitespace, based on the length of the
previous rows on that line.

The fix is to just not prepend whitespace if the row is not the initial
row on that line.

I'm not sure this is the "best" fix but it's certainly better than what
the current format by some margin (pun intended).