### PR TITLE
CLI: Speed up via --compile=min -O0 flags

### DIFF
--- a/bin/format.jl
+++ b/bin/format.jl
@@ -1,4 +1,4 @@
-#!/usr/bin/env julia
+#!/usr/bin/env -S julia --compile=min -O0
 using JuliaFormatter
 
 help = """


### PR DESCRIPTION
The -S feature has existed since Linux coreutils 8.30.
See https://stackoverflow.com/questions/4303128/how-to-use-multiple-arguments-for-awk-with-a-shebang-i-e/52979955#52979955.
The comment also says that it should work on FreeBSD (not tested).

This speeds up from ~1:16.69 s to ~31 s on my laptop (Linux).

TODO:
- [ ] I haven't tested this on macOS. I can't test this by myself.