### PR TITLE
Improve three-valued logic handling for config toml

### DIFF
--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -762,9 +762,11 @@ function kwargs(dict)
     return pairs(NamedTuple{ns}(vs))
 end
 
+fieldnts(T::Type) = ((fieldname(T, i), fieldtype(T, i)) for i in 1:fieldcount(T))
+
 function parse_config(tomlfile)
     config_dict = parsefile(tomlfile)
-    for (field, type) in zip(fieldnames(Options), fieldtypes(Options))
+    for (field, type) in fieldnts(Options)
         if type == Union{Bool,Nothing}
             field = string(field)
             if get(config_dict, field, "") == "nothing"

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -763,7 +763,7 @@ function kwargs(dict)
     return pairs(NamedTuple{ns}(vs))
 end
 
-fieldnts(T::Type) = ((fieldname(T, i), fieldtype(T, i)) for i in 1:fieldcount(T))
+fieldnts(T::Type) = ((fieldname(T, i), fieldtype(T, i)) for i = 1:fieldcount(T))
 
 function parse_config(tomlfile)
     config_dict = parsefile(tomlfile)

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -765,7 +765,7 @@ end
 function parse_config(tomlfile)
     config_dict = parsefile(tomlfile)
     for (field, type) in zip(fieldnames(Options), fieldtypes(Options))
-        if type == Union{Bool, Nothing}
+        if type == Union{Bool,Nothing}
             field = string(field)
             if get(config_dict, field, "") == "nothing"
                 config_dict[field] = nothing

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -764,8 +764,13 @@ end
 
 function parse_config(tomlfile)
     config_dict = parsefile(tomlfile)
-    if get(config_dict, "trailing_comma", "") == "nothing"
-        config_dict["trailing_comma"] = nothing
+    for (field, type) in zip(fieldnames(Options), fieldtypes(Options))
+        if type == Union{Bool, Nothing}
+            field = string(field)
+            if get(config_dict, field, "") == "nothing"
+                config_dict[field] = nothing
+            end
+        end
     end
     if (style = get(config_dict, "style", nothing)) !== nothing
         @assert (style == "default" || style == "yas" || style == "blue") "currently $(CONFIG_FILE_NAME) accepts only \"default\" or \"yas\" or \"blue\" for the style configuration"

--- a/test/config.jl
+++ b/test/config.jl
@@ -5,258 +5,308 @@
     after2 = "begin\n  rand()\nend\n"
     after4 = "begin\n    rand()\nend\n"
 
-    # test basic configuration case
-    # test_basic_config
-    # ├─ .JuliaFormatter.toml (config2)
-    # └─ code.jl (before -> after2)
-    sandbox_dir = joinpath(tempdir(), "test_basic_config")
-    mkdir(sandbox_dir)
-    try
-        config_path = joinpath(sandbox_dir, CONFIG_FILE_NAME)
-        code_path = joinpath(sandbox_dir, "code.jl")
-        open(io -> write(io, config2), config_path, "w")
-        open(io -> write(io, before), code_path, "w")
+    @testset "basic configuration" begin
+        # test basic configuration case
+        # test_basic_config
+        # ├─ .JuliaFormatter.toml (config2)
+        # └─ code.jl (before -> after2)
+        sandbox_dir = joinpath(tempdir(), "test_basic_config")
+        mkdir(sandbox_dir)
+        try
+            config_path = joinpath(sandbox_dir, CONFIG_FILE_NAME)
+            code_path = joinpath(sandbox_dir, "code.jl")
+            open(io -> write(io, config2), config_path, "w")
+            open(io -> write(io, before), code_path, "w")
 
-        @test format(code_path) == false
-        @test read(code_path, String) == after2
-    finally
-        rm(sandbox_dir; recursive = true)
+            @test format(code_path) == false
+            @test read(code_path, String) == after2
+        finally
+            rm(sandbox_dir; recursive = true)
+        end
     end
 
-    # test upward config search
-    # test_search
-    # ├─ .JuliaFormatter.toml (config2)
-    # └─ sub
-    #    ├─ sub_code.jl (before -> after2)
-    #    └─ subsub
-    #       └─ subsub_code.jl (before -> after2)
-    sandbox_dir = joinpath(tempdir(), "test_search")
-    mkdir(sandbox_dir)
-    try
-        config_path = joinpath(sandbox_dir, CONFIG_FILE_NAME)
-        sub_dir = joinpath(sandbox_dir, "sub")
-        mkdir(sub_dir)
-        sub_code_path = joinpath(sub_dir, "sub_code.jl")
-        subsub_dir = joinpath(sub_dir, "sub")
-        mkdir(subsub_dir)
-        subsub_code_path = joinpath(subsub_dir, "sub_code.jl")
-        open(io -> write(io, config2), config_path, "w")
-        open(io -> write(io, before), sub_code_path, "w")
-        open(io -> write(io, before), subsub_code_path, "w")
+    @testset "upward config search" begin
+        # test upward config search
+        # test_search
+        # ├─ .JuliaFormatter.toml (config2)
+        # └─ sub
+        #    ├─ sub_code.jl (before -> after2)
+        #    └─ subsub
+        #       └─ subsub_code.jl (before -> after2)
+        sandbox_dir = joinpath(tempdir(), "test_search")
+        mkdir(sandbox_dir)
+        try
+            config_path = joinpath(sandbox_dir, CONFIG_FILE_NAME)
+            sub_dir = joinpath(sandbox_dir, "sub")
+            mkdir(sub_dir)
+            sub_code_path = joinpath(sub_dir, "sub_code.jl")
+            subsub_dir = joinpath(sub_dir, "sub")
+            mkdir(subsub_dir)
+            subsub_code_path = joinpath(subsub_dir, "sub_code.jl")
+            open(io -> write(io, config2), config_path, "w")
+            open(io -> write(io, before), sub_code_path, "w")
+            open(io -> write(io, before), subsub_code_path, "w")
 
-        @test format(sub_code_path) == false
-        @test read(sub_code_path, String) == after2
-        @test format(subsub_code_path) == false
-        @test read(subsub_code_path, String) == after2
-        @test format(sub_code_path) == true
-        @test format(subsub_code_path) == true
-    finally
-        rm(sandbox_dir; recursive = true)
+            @test format(sub_code_path) == false
+            @test read(sub_code_path, String) == after2
+            @test format(subsub_code_path) == false
+            @test read(subsub_code_path, String) == after2
+            @test format(sub_code_path) == true
+            @test format(subsub_code_path) == true
+        finally
+            rm(sandbox_dir; recursive = true)
+        end
     end
 
-    # test basic directory walk
-    # test_basic_walk
-    # ├─ .JuliaFormatter.toml (config2)
-    # ├─ code.jl (before -> after2)
-    # └─ sub
-    #    └─ sub_code.jl (before -> after2)
-    sandbox_dir = joinpath(tempdir(), "test_basic_walk")
-    mkdir(sandbox_dir)
-    try
-        config_path = joinpath(sandbox_dir, CONFIG_FILE_NAME)
-        code_path = joinpath(sandbox_dir, "code.jl")
-        sub_dir = joinpath(sandbox_dir, "sub")
-        mkdir(sub_dir)
-        sub_code_path = joinpath(sub_dir, "sub_code.jl")
-        open(io -> write(io, config2), config_path, "w")
-        open(io -> write(io, before), code_path, "w")
-        open(io -> write(io, before), sub_code_path, "w")
+    @testset "basic directory walk" begin
+        # test basic directory walk
+        # test_basic_walk
+        # ├─ .JuliaFormatter.toml (config2)
+        # ├─ code.jl (before -> after2)
+        # └─ sub
+        #    └─ sub_code.jl (before -> after2)
+        sandbox_dir = joinpath(tempdir(), "test_basic_walk")
+        mkdir(sandbox_dir)
+        try
+            config_path = joinpath(sandbox_dir, CONFIG_FILE_NAME)
+            code_path = joinpath(sandbox_dir, "code.jl")
+            sub_dir = joinpath(sandbox_dir, "sub")
+            mkdir(sub_dir)
+            sub_code_path = joinpath(sub_dir, "sub_code.jl")
+            open(io -> write(io, config2), config_path, "w")
+            open(io -> write(io, before), code_path, "w")
+            open(io -> write(io, before), sub_code_path, "w")
 
-        @test format(sandbox_dir) == false
-        @test read(code_path, String) == after2
-        @test read(sub_code_path, String) == after2
-        @test format(sandbox_dir) == true
-    finally
-        rm(sandbox_dir; recursive = true)
+            @test format(sandbox_dir) == false
+            @test read(code_path, String) == after2
+            @test read(sub_code_path, String) == after2
+            @test format(sandbox_dir) == true
+        finally
+            rm(sandbox_dir; recursive = true)
+        end
     end
 
-    # test directory walk with nested configs
-    # test_nested_config
-    # ├─ .JuliaFormatter.toml (config2)
-    # ├─ code.jl (before -> after2)
-    # ├─ sub1
-    # │  ├─ .JuliaFormatter.toml (config4)
-    # │  └─ sub_code1.jl (before -> after4)
-    # └─ sub2
-    #    └─ sub_code2.jl (before -> after2)
-    sandbox_dir = joinpath(tempdir(), "test_nested_config")
-    mkdir(sandbox_dir)
-    try
-        sub1_dir = joinpath(sandbox_dir, "sub1")
-        sub2_dir = joinpath(sandbox_dir, "sub2")
-        mkdir(sub1_dir)
-        mkdir(sub2_dir)
-        config_path = joinpath(sandbox_dir, CONFIG_FILE_NAME)
-        code_path = joinpath(sandbox_dir, "code.jl")
-        sub_config1_path = joinpath(sub1_dir, CONFIG_FILE_NAME)
-        sub_code1_path = joinpath(sub1_dir, "sub_code1.jl")
-        sub_code2_path = joinpath(sub2_dir, "sub_code2.jl")
-        open(io -> write(io, config2), config_path, "w")
-        open(io -> write(io, before), code_path, "w")
-        open(io -> write(io, config4), sub_config1_path, "w")
-        open(io -> write(io, before), sub_code1_path, "w")
-        open(io -> write(io, before), sub_code2_path, "w")
+    @testset "directory walk with nested configs" begin
+        # test directory walk with nested configs
+        # test_nested_config
+        # ├─ .JuliaFormatter.toml (config2)
+        # ├─ code.jl (before -> after2)
+        # ├─ sub1
+        # │  ├─ .JuliaFormatter.toml (config4)
+        # │  └─ sub_code1.jl (before -> after4)
+        # └─ sub2
+        #    └─ sub_code2.jl (before -> after2)
+        sandbox_dir = joinpath(tempdir(), "test_nested_config")
+        mkdir(sandbox_dir)
+        try
+            sub1_dir = joinpath(sandbox_dir, "sub1")
+            sub2_dir = joinpath(sandbox_dir, "sub2")
+            mkdir(sub1_dir)
+            mkdir(sub2_dir)
+            config_path = joinpath(sandbox_dir, CONFIG_FILE_NAME)
+            code_path = joinpath(sandbox_dir, "code.jl")
+            sub_config1_path = joinpath(sub1_dir, CONFIG_FILE_NAME)
+            sub_code1_path = joinpath(sub1_dir, "sub_code1.jl")
+            sub_code2_path = joinpath(sub2_dir, "sub_code2.jl")
+            open(io -> write(io, config2), config_path, "w")
+            open(io -> write(io, before), code_path, "w")
+            open(io -> write(io, config4), sub_config1_path, "w")
+            open(io -> write(io, before), sub_code1_path, "w")
+            open(io -> write(io, before), sub_code2_path, "w")
 
-        @test format(sandbox_dir) == false
-        @test read(code_path, String) == after2
-        @test read(sub_code1_path, String) == after4
-        @test read(sub_code2_path, String) == after2
-        @test format(sandbox_dir) == true
-    finally
-        rm(sandbox_dir; recursive = true)
+            @test format(sandbox_dir) == false
+            @test read(code_path, String) == after2
+            @test read(sub_code1_path, String) == after4
+            @test read(sub_code2_path, String) == after2
+            @test format(sandbox_dir) == true
+        finally
+            rm(sandbox_dir; recursive = true)
+        end
     end
 
-    # test directory walk with nested configs
-    # same as above except format from within the
-    # top level directory, i.e. `format(".")`
-    #
-    # test_nested_config
-    # ├─ .JuliaFormatter.toml (config2)
-    # ├─ code.jl (before -> after2)
-    # ├─ sub1
-    # │  ├─ .JuliaFormatter.toml (config4)
-    # │  └─ sub_code1.jl (before -> after4)
-    # └─ sub2
-    #    └─ sub_code2.jl (before -> after2)
-    sandbox_dir = joinpath(tempdir(), "test_nested_config")
-    mkdir(sandbox_dir)
-    original_dir = pwd()
-    try
-        sub1_dir = joinpath(sandbox_dir, "sub1")
-        sub2_dir = joinpath(sandbox_dir, "sub2")
-        mkdir(sub1_dir)
-        mkdir(sub2_dir)
-        config_path = joinpath(sandbox_dir, CONFIG_FILE_NAME)
-        code_path = joinpath(sandbox_dir, "code.jl")
-        sub_config1_path = joinpath(sub1_dir, CONFIG_FILE_NAME)
-        sub_code1_path = joinpath(sub1_dir, "sub_code1.jl")
-        sub_code2_path = joinpath(sub2_dir, "sub_code2.jl")
-        open(io -> write(io, config2), config_path, "w")
-        open(io -> write(io, before), code_path, "w")
-        open(io -> write(io, config4), sub_config1_path, "w")
-        open(io -> write(io, before), sub_code1_path, "w")
-        open(io -> write(io, before), sub_code2_path, "w")
+    @testset "directory walk with nested configs toplevel" begin
+        # test directory walk with nested configs
+        # same as above except format from within the
+        # top level directory, i.e. `format(".")`
+        #
+        # test_nested_config
+        # ├─ .JuliaFormatter.toml (config2)
+        # ├─ code.jl (before -> after2)
+        # ├─ sub1
+        # │  ├─ .JuliaFormatter.toml (config4)
+        # │  └─ sub_code1.jl (before -> after4)
+        # └─ sub2
+        #    └─ sub_code2.jl (before -> after2)
+        sandbox_dir = joinpath(tempdir(), "test_nested_config")
+        mkdir(sandbox_dir)
+        original_dir = pwd()
+        try
+            sub1_dir = joinpath(sandbox_dir, "sub1")
+            sub2_dir = joinpath(sandbox_dir, "sub2")
+            mkdir(sub1_dir)
+            mkdir(sub2_dir)
+            config_path = joinpath(sandbox_dir, CONFIG_FILE_NAME)
+            code_path = joinpath(sandbox_dir, "code.jl")
+            sub_config1_path = joinpath(sub1_dir, CONFIG_FILE_NAME)
+            sub_code1_path = joinpath(sub1_dir, "sub_code1.jl")
+            sub_code2_path = joinpath(sub2_dir, "sub_code2.jl")
+            open(io -> write(io, config2), config_path, "w")
+            open(io -> write(io, before), code_path, "w")
+            open(io -> write(io, config4), sub_config1_path, "w")
+            open(io -> write(io, before), sub_code1_path, "w")
+            open(io -> write(io, before), sub_code2_path, "w")
 
-        cd(sandbox_dir)
-        @test format(".") == false
-        @test read(code_path, String) == after2
-        @test read(sub_code1_path, String) == after4
-        @test read(sub_code2_path, String) == after2
-        @test format(".") == true
-    finally
-        cd(original_dir)
-        rm(sandbox_dir; recursive = true)
+            cd(sandbox_dir)
+            @test format(".") == false
+            @test read(code_path, String) == after2
+            @test read(sub_code1_path, String) == after4
+            @test read(sub_code2_path, String) == after2
+            @test format(".") == true
+        finally
+            cd(original_dir)
+            rm(sandbox_dir; recursive = true)
+        end
     end
 
-    config2 = """
-    indent = 2
-    format_markdown = true
-    """
+    @testset "markdown formatting" begin
+        config2 = """
+        indent = 2
+        format_markdown = true
+        """
 
-    before = """
-    # hello world
+        before = """
+        # hello world
 
-    ```julia
-    begin body end
-    ```
-    - a
-    -             b
-    """
-    after2 = """
-    # hello world
+        ```julia
+        begin body end
+        ```
+        - a
+        -             b
+        """
+        after2 = """
+        # hello world
 
-    ```julia
-    begin
-      body
+        ```julia
+        begin
+          body
+        end
+        ```
+
+          - a
+          -             b
+        """
+        # test formatting a markdown file
+        # test_basic_markdown_format
+        # ├─ .JuliaFormatter.toml (config2)
+        # └─ file.md (before -> after2)
+        sandbox_dir = joinpath(tempdir(), "test_basic_config")
+        mkdir(sandbox_dir)
+        try
+            config_path = joinpath(sandbox_dir, CONFIG_FILE_NAME)
+            md_path = joinpath(sandbox_dir, "file.md")
+            open(io -> write(io, config2), config_path, "w")
+            open(io -> write(io, before), md_path, "w")
+
+            @test format(md_path) == false
+            @test read(md_path, String) == after2
+        finally
+            rm(sandbox_dir; recursive = true)
+        end
     end
-    ```
 
-      - a
-      -             b
-    """
-    # test formatting a markdown file
-    # test_basic_markdown_format
-    # ├─ .JuliaFormatter.toml (config2)
-    # └─ file.md (before -> after2)
-    sandbox_dir = joinpath(tempdir(), "test_basic_config")
-    mkdir(sandbox_dir)
-    try
-        config_path = joinpath(sandbox_dir, CONFIG_FILE_NAME)
-        md_path = joinpath(sandbox_dir, "file.md")
-        open(io -> write(io, config2), config_path, "w")
-        open(io -> write(io, before), md_path, "w")
+    @testset "trailing_comma = nothing" begin
+        config_trailing_comma_nothing = """
+        trailing_comma = "nothing"
+        """
 
-        @test format(md_path) == false
-        @test read(md_path, String) == after2
-    finally
-        rm(sandbox_dir; recursive = true)
+        code_trailing_comma = """
+        const A_SET_OF_SYMBOLS_WITH_TRAILING_COMMA = Set([
+            :accesses, :allowedtypes, :connector, :digits, :equals, :expand,
+            :ignores, :sigdigits, :sort, :val_to_string,
+        ])
+        const A_SET_OF_SYMBOLS_WITHOUT_TRAILING_COMMA = Set([
+            :accesses, :allowedtypes, :connector, :digits, :equals, :expand,
+            :ignores, :sigdigits, :sort, :val_to_string
+        ])
+        """
+        code_trailing_comma_after = """
+        const A_SET_OF_SYMBOLS_WITH_TRAILING_COMMA = Set([
+            :accesses,
+            :allowedtypes,
+            :connector,
+            :digits,
+            :equals,
+            :expand,
+            :ignores,
+            :sigdigits,
+            :sort,
+            :val_to_string,
+        ])
+        const A_SET_OF_SYMBOLS_WITHOUT_TRAILING_COMMA = Set([
+            :accesses,
+            :allowedtypes,
+            :connector,
+            :digits,
+            :equals,
+            :expand,
+            :ignores,
+            :sigdigits,
+            :sort,
+            :val_to_string
+        ])
+        """
+        # test `trailing_comma = "nothing"` in config (#539)
+        # test_trailing_comma_nothing_config
+        # ├─ .JuliaFormatter.toml (config_trailing_comma_nothing)
+        # └─ code.jl (code_trailing_comma -> code_trailing_comma_after)
+        sandbox_dir = joinpath(tempdir(), "test_trailing_comma_nothing_config")
+        mkdir(sandbox_dir)
+        try
+            config_path = joinpath(sandbox_dir, CONFIG_FILE_NAME)
+            code_path = joinpath(sandbox_dir, "code.jl")
+            open(io -> write(io, config_trailing_comma_nothing), config_path, "w")
+            open(io -> write(io, code_trailing_comma), code_path, "w")
+
+            @test format(code_path) == false
+            @test read(code_path, String) == code_trailing_comma_after
+        finally
+            rm(sandbox_dir; recursive = true)
+        end
     end
 
-    config_trailing_comma_nothing = """
-    trailing_comma = "nothing"
-    """
+    @testset "always_for_in = nothing" begin
+        config_always_for_in_nothing = """
+        always_for_in = "nothing"
+        """
+        code_always_for_in = """
+        for i in 1:10
+                for j = 1:10
+            end
+        end
+        """
+        code_always_for_in_after = """
+        for i in 1:10
+            for j = 1:10
+            end
+        end
+        """
 
-    code_trailing_comma = """
-    const A_SET_OF_SYMBOLS_WITH_TRAILING_COMMA = Set([
-        :accesses, :allowedtypes, :connector, :digits, :equals, :expand,
-        :ignores, :sigdigits, :sort, :val_to_string,
-    ])
-    const A_SET_OF_SYMBOLS_WITHOUT_TRAILING_COMMA = Set([
-        :accesses, :allowedtypes, :connector, :digits, :equals, :expand,
-        :ignores, :sigdigits, :sort, :val_to_string
-    ])
-    """
-    code_trailing_comma_after = """
-    const A_SET_OF_SYMBOLS_WITH_TRAILING_COMMA = Set([
-        :accesses,
-        :allowedtypes,
-        :connector,
-        :digits,
-        :equals,
-        :expand,
-        :ignores,
-        :sigdigits,
-        :sort,
-        :val_to_string,
-    ])
-    const A_SET_OF_SYMBOLS_WITHOUT_TRAILING_COMMA = Set([
-        :accesses,
-        :allowedtypes,
-        :connector,
-        :digits,
-        :equals,
-        :expand,
-        :ignores,
-        :sigdigits,
-        :sort,
-        :val_to_string
-    ])
-    """
-    # test `trailing_comma = "nothing"` in config (#539)
-    # test_trailing_comma_nothing_config
-    # ├─ .JuliaFormatter.toml (config_trailing_comma_nothing)
-    # └─ code.jl (code_trailing_comma -> code_trailing_comma_after)
-    sandbox_dir = joinpath(tempdir(), "test_trailing_comma_nothing_config")
-    mkdir(sandbox_dir)
-    try
-        config_path = joinpath(sandbox_dir, CONFIG_FILE_NAME)
-        code_path = joinpath(sandbox_dir, "code.jl")
-        open(io -> write(io, config_trailing_comma_nothing), config_path, "w")
-        open(io -> write(io, code_trailing_comma), code_path, "w")
+        # test `always_for_in = "nothing"` in config (#539)
+        # test_always_for_in_nothing_config
+        # ├─ .JuliaFormatter.toml (always_for_in_nothing)
+        # └─ code.jl (code_always_for_in -> code_always_for_in_after)
+        sandbox_dir = joinpath(tempdir(), "test_always_for_in_nothing_config")
+        mkdir(sandbox_dir)
+        try
+            config_path = joinpath(sandbox_dir, CONFIG_FILE_NAME)
+            code_path = joinpath(sandbox_dir, "code.jl")
+            open(io -> write(io, config_always_for_in_nothing), config_path, "w")
+            open(io -> write(io, code_always_for_in), code_path, "w")
 
-        @test format(code_path) == false
-        @test read(code_path, String) == code_trailing_comma_after
-    finally
-        rm(sandbox_dir; recursive = true)
+            @test format(code_path) == false
+            @test read(code_path, String) == code_always_for_in_after
+        finally
+            rm(sandbox_dir; recursive = true)
+        end
     end
 end

--- a/test/config.jl
+++ b/test/config.jl
@@ -225,7 +225,9 @@
         title: Test file
         author: JuliaFormatter
         ---
+
         # hello world
+
         ```julia
         begin body end
         ```
@@ -237,12 +239,15 @@
         title: Test file
         author: JuliaFormatter
         ---
+
         # hello world
+
         ```julia
         begin
           body
         end
         ```
+
           - a
           -             b
         """


### PR DESCRIPTION
The only functional change here is allowing `always_for_in = "nothing"` in .JuliaFormatter.toml, but the implementation is future proof in the sense that it inspects the `Options` type and automatically replaces all `"nothing"`s for fields that are declared as `Union{Bool, Nothing}`.

I've also added a bit of additional structure to the config tests via additional testsets.