### PR TITLE
Improve jmd support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.22.4"
+version = "0.22.5"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -14,7 +14,8 @@ using CommonMark:
     MathRule,
     Parser,
     Rule,
-    TableRule
+    TableRule,
+    FrontMatterRule
 
 export format, format_text, format_file, format_md, DefaultStyle, YASStyle, BlueStyle
 
@@ -642,7 +643,7 @@ function format_file(
 )::Bool
     path, ext = splitext(filename)
     shebang_pattern = r"^#!\s*/.*\bjulia[0-9.-]*\b"
-    formatted_str = if ext == ".md"
+    formatted_str = if ext == ".md" || ext == ".jmd"
         format_markdown || return true
         verbose && println("Formatting $filename")
         str = String(read(filename))

--- a/src/markdown.jl
+++ b/src/markdown.jl
@@ -24,6 +24,7 @@ function format_md(text::AbstractString, style::AbstractStyle, opts::Options)
                 FootnoteRule(),
                 MathRule(),
                 TableRule(),
+                FrontMatterRule(),
                 FormatRule(style, opts),
             ],
         )(

--- a/test/config.jl
+++ b/test/config.jl
@@ -188,11 +188,65 @@
     # test_basic_markdown_format
     # ├─ .JuliaFormatter.toml (config2)
     # └─ file.md (before -> after2)
-    sandbox_dir = joinpath(tempdir(), "test_basic_config")
+    sandbox_dir = joinpath(tempdir(), "test_basic_markdown_format")
     mkdir(sandbox_dir)
     try
         config_path = joinpath(sandbox_dir, CONFIG_FILE_NAME)
         md_path = joinpath(sandbox_dir, "file.md")
+        open(io -> write(io, config2), config_path, "w")
+        open(io -> write(io, before), md_path, "w")
+
+        @test format(md_path) == false
+        @test read(md_path, String) == after2
+    finally
+        rm(sandbox_dir; recursive = true)
+    end
+
+    config2 = """
+    indent = 2
+    format_markdown = true
+    """
+
+    before = """
+    ---
+    title: Test file
+    author: JuliaFormatter
+    ---
+
+    # hello world
+
+    ```julia
+    begin body end
+    ```
+    - a
+    -             b
+    """
+    after2 = """
+    ---
+    title: Test file
+    author: JuliaFormatter
+    ---
+
+    # hello world
+
+    ```julia
+    begin
+      body
+    end
+    ```
+
+      - a
+      -             b
+    """
+    # test formatting a Julia markdown file
+    # test_basic_juliamarkdown_format
+    # ├─ .JuliaFormatter.toml (config2)
+    # └─ file.jmd (before -> after2)
+    sandbox_dir = joinpath(tempdir(), "test_basic_juliamarkdown_format")
+    mkdir(sandbox_dir)
+    try
+        config_path = joinpath(sandbox_dir, CONFIG_FILE_NAME)
+        md_path = joinpath(sandbox_dir, "file.jmd")
         open(io -> write(io, config2), config_path, "w")
         open(io -> write(io, before), md_path, "w")
 


### PR DESCRIPTION
I just tried to format a jmd file, and it almost worked but there were two issues:
- The check of the file extension in `format_file` is too strict (hence I tried to call `format_md` directly)
- The YAML headers are not preserved when calling `format_md`

This PR fixes both issues.