### PR TITLE
Support ".jmd" in `format`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.22.5"
+version = "0.22.6"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -602,7 +602,7 @@ end
         format_options...,
     )::Bool
 
-Formats the contents of `filename` assuming it's a `.jl` or `.md` file.
+Formats the contents of `filename` assuming it's a `.jl`, `.md` or `.jmd` file.
 
 ## File Options
 
@@ -653,7 +653,7 @@ function format_file(
         str = String(read(filename))
         format_text(str; format_options...)
     else
-        error("$filename must be a Julia (.jl) or Markdown (.md) source file")
+        error("$filename must be a Julia (.jl) or Markdown (.md or .jmd) source file")
     end
     formatted_str = replace(formatted_str, r"\n*$" => "\n")
     already_formatted = (formatted_str == str)
@@ -727,7 +727,7 @@ function format(paths; options...)::Bool
                     _, ext = splitext(file)
                     full_path = joinpath(root, file)
                     formatted_file &
-                    if ext in (".jl", ".md") &&
+                    if ext in (".jl", ".md", ".jmd") &&
                        !(".git" in split(full_path, Base.Filesystem.path_separator))
                         dir = abspath(root)
                         opts = if (config = find_config_file(dir)) !== nothing


### PR DESCRIPTION
I noticed that unfortunately I forgot to add support for ".jmd" files in `format` in #552.