### PR TITLE
Multiline comment corner case + better error message on formatted text error

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.22.8"
+version = "0.22.9"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/print.jl
+++ b/src/print.jl
@@ -144,6 +144,12 @@ function print_inlinecomment(io::IOBuffer, fst::FST, s::State)
     ws, v = get(s.doc.comments, fst.startline, (0, ""))
     isempty(v) && return
     v = v[end] == '\n' ? v[nextind(v, 1):prevind(v, end)] : v
-    ws > 0 && write(io, repeat(" ", ws))
+    if ws > 0
+        write(io, repeat(" ", ws))
+    elseif startswith(v, "#=") && endswith(v, "=#")
+        # hack to overcome the bug noticed in https://github.com/domluna/JuliaFormatter.jl/issues/571#issuecomment-1114446297
+        # until multiline comments aren't moved to the end of the line.
+        write(io, " ")
+    end
     write(io, v)
 end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1407,4 +1407,16 @@
             whitespace_in_kwargs = false,
         ) == str_
     end
+
+    @testset "571" begin
+        s = """
+        arraycopy_common(false#=fwd=#, LLVM.Builder(B), orig, origops[1], gutils)
+        return nothing
+        """
+        s_ = """
+        arraycopy_common(false, LLVM.Builder(B), orig, origops[1], gutils) #=fwd=#
+        return nothing
+        """
+        @test format_text(s) == s_
+    end
 end


### PR DESCRIPTION
Unfortunately it looks like the the position the error occurred is hard
to derive from CSTParser's ParseState so for now we'll at least number the
formatted output. Although without accurate line info I'm not sure how
helpful that actually is.

Example:

```julia
ERROR: Error while PARSING formatted text:

1 arraycopy_common(false, LLVM.Builder(B), orig, origops[1], gutils)#=fwd=#
2 return nothing

...

Error occurred on line 2, offset 1 of formatted text.

```

In slightly better news we've added a temporary measure to handle a
corner case of multi line comments being moved to the end of the Lines
which can apparently cause havoc for CSTParser. Luckily this can be
alleviated by prepending a single space prior to the comment. It's
pretty hacky but better than throwing an error for no good reason!

#571 