### PR TITLE
Do not add trailing comma to single argument tuple

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "0.22.9"
+version = "0.22.10"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1841,7 +1841,9 @@ function p_tuple(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
         elseif is_closer(n) && nest
             # An odd case but this could occur if there are no keyword arguments.
             # In which case ";," is invalid syntax.
-            if t[end].typ !== SEMICOLON
+            #
+            # no trailing comma since (arg) is semantically different from (arg,) !!!
+            if t[end].typ !== SEMICOLON && length(args) > 1
                 add_node!(t, TrailingComma(), s)
             end
             add_node!(t, Placeholder(0), s)

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -2561,7 +2561,7 @@
 
         str = """
         @somemacro function (
-            fcall_ | fcall_,
+            fcall_ | fcall_
         )
             body_
         end"""
@@ -2571,7 +2571,7 @@
         str = """
         @somemacro function (
             fcall_ |
-            fcall_,
+            fcall_
         )
             body_
         end"""

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1408,6 +1408,23 @@
         ) == str_
     end
 
+    @testset "568" begin
+        s = """
+        function (func(arg))
+            body
+        end
+        """
+        # no trailing comma since (arg) is semantically different from (arg,) !!!
+        s_ = """
+        function (
+            func(arg)
+        )
+            body
+        end
+        """
+        @test fmt(s, 4, 19) == s_
+    end
+
     @testset "571" begin
         s = """
         arraycopy_common(false#=fwd=#, LLVM.Builder(B), orig, origops[1], gutils)


### PR DESCRIPTION
(arg) -> (arg,) is semantically different.

fix #568