### PR TITLE
First batch of VSCode issues

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "1.0.5"
+version = "1.0.6"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/README.md
+++ b/README.md
@@ -418,6 +418,24 @@ f(a, b=1)
 f(a; b=1)
 ```
 
+### `surround_whereop_typeparameters`
+
+> default: `true`
+
+Surrounds type parameters with curly brackets when set to `true` if the brackets are not
+already present.
+
+```julia
+function func(...) where TPARAM
+end
+
+->
+
+function func(...) where {TPARAM}
+end
+```
+
+
 ### File Options
 
 ### `overwrite`

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -18,7 +18,7 @@ using CommonMark:
     FrontMatterRule
 
 export format,
-    format_text, format_file, format_md, DefaultStyle, YASStyle, BlueStyle, SciMLStyle
+    format_text, format_file, format_md, DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyle
 
 abstract type AbstractStyle end
 
@@ -30,7 +30,7 @@ abstract type AbstractStyle end
 The default formatting style. See the [Style](@ref) section of the documentation
 for more details.
 
-See also: [`BlueStyle`](@ref), [`YASStyle`](@ref)
+See also: [`BlueStyle`](@ref), [`YASStyle`](@ref), [`SciMLStyle`](@ref), [`MinimalStyle`](@ref)
 """
 struct DefaultStyle <: AbstractStyle
     innerstyle::Union{Nothing,AbstractStyle}
@@ -64,6 +64,7 @@ function options(s::DefaultStyle)
         trailing_comma = true,
         indent_submodule = false,
         separate_kwargs_with_semicolon = false,
+    surround_whereop_typeparameters= true,
     )
 end
 
@@ -146,6 +147,7 @@ normalize_line_ending(s::AbstractString, replacer = WINDOWS_TO_UNIX) = replace(s
         trailing_comma::Bool = false,
         indent_submodule::Bool = false,
         separate_kwargs_with_semicolon::Bool = false,
+        surround_whereop_typeparameters::Bool = true,
     )::String
 
 Formats a Julia source passed in as a string, returning the formatted
@@ -541,6 +543,22 @@ f(a, b=1)
 ->
 
 f(a; b=1)
+```
+
+### `surround_whereop_typeparameters`
+
+> default: `true`
+
+Surrounds type parameters with curly brackets when set to `true`.
+
+```julia
+function func(...) where TPARAM
+end
+
+->
+
+function func(...) where {TPARAM}
+end
 ```
 
 """

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -549,7 +549,8 @@ f(a; b=1)
 
 > default: `true`
 
-Surrounds type parameters with curly brackets when set to `true`.
+Surrounds type parameters with curly brackets when set to `true` if the brackets are not
+already present.
 
 ```julia
 function func(...) where TPARAM

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -18,7 +18,14 @@ using CommonMark:
     FrontMatterRule
 
 export format,
-    format_text, format_file, format_md, DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyle
+    format_text,
+    format_file,
+    format_md,
+    DefaultStyle,
+    YASStyle,
+    BlueStyle,
+    SciMLStyle,
+    MinimalStyle
 
 abstract type AbstractStyle end
 
@@ -64,7 +71,7 @@ function options(s::DefaultStyle)
         trailing_comma = true,
         indent_submodule = false,
         separate_kwargs_with_semicolon = false,
-    surround_whereop_typeparameters= true,
+        surround_whereop_typeparameters = true,
     )
 end
 

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -567,7 +567,7 @@ function add_node!(
     end
 
     # if `max_padding` >= 0 `n` should appear on the next line
-    # even if it's contrary on the original source.
+    # even if it's contrary to the original source.
     if s.opts.join_lines_based_on_source &&
        !override_join_lines_based_on_source &&
        max_padding == -1 &&

--- a/src/options.jl
+++ b/src/options.jl
@@ -23,6 +23,7 @@ Base.@kwdef struct Options
     trailing_comma::Union{Bool,Nothing} = true
     indent_submodule::Bool = false
     separate_kwargs_with_semicolon::Bool = false
+    surround_whereop_typeparameters::Bool = true
 end
 
 function needs_alignment(opts::Options)

--- a/src/styles/blue/pretty.jl
+++ b/src/styles/blue/pretty.jl
@@ -53,7 +53,7 @@ function options(style::BlueStyle)
         align_matrix = false,
         join_lines_based_on_source = false,
         trailing_comma = true,
-    surround_whereop_typeparameters= true,
+        surround_whereop_typeparameters = true,
     )
 end
 

--- a/src/styles/blue/pretty.jl
+++ b/src/styles/blue/pretty.jl
@@ -53,6 +53,7 @@ function options(style::BlueStyle)
         align_matrix = false,
         join_lines_based_on_source = false,
         trailing_comma = true,
+    surround_whereop_typeparameters= true,
     )
 end
 

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1626,7 +1626,8 @@ function p_whereopcall(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
         cst[3].head === :bracescat ||
         cst[3].head === :parameters
 
-    add_braces = s.opts.surround_whereop_typeparameters && !curly_ctx && !CSTParser.is_lbrace(cst[3])
+    add_braces =
+        s.opts.surround_whereop_typeparameters && !curly_ctx && !CSTParser.is_lbrace(cst[3])
 
     bc = curly_ctx ? t : FST(BracesCat, nspaces(s))
 

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1626,7 +1626,7 @@ function p_whereopcall(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
         cst[3].head === :bracescat ||
         cst[3].head === :parameters
 
-    add_braces = !curly_ctx && !CSTParser.is_lbrace(cst[3])
+    add_braces = s.opts.surround_whereop_typeparameters && !curly_ctx && !CSTParser.is_lbrace(cst[3])
 
     bc = curly_ctx ? t : FST(BracesCat, nspaces(s))
 

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -838,8 +838,15 @@ function p_functiondef(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
     add_node!(t, pretty(style, cst[2], s), s, join_lines = true)
     if length(cst) > 3
         if cst[3].fullspan == 0
-            add_node!(t, Whitespace(1), s)
-            add_node!(t, pretty(style, cst[4], s), s, join_lines = true)
+            n = pretty(style, cst[4], s)
+            if s.opts.join_lines_based_on_source
+                join_lines = t.endline == n.startline
+                join_lines && (add_node!(t, Whitespace(1), s))
+                add_node!(t, n, s, join_lines = join_lines)
+            else
+                add_node!(t, Whitespace(1), s)
+                add_node!(t, n, s, join_lines = true)
+            end
         else
             s.indent += s.opts.indent
             n = pretty(style, cst[3], s, ignore_single_line = true)
@@ -849,10 +856,16 @@ function p_functiondef(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
             add_node!(t, pretty(style, cst[4], s), s)
         end
     else
-        # function stub, i.e. "function foo end"
-        # this should be on one line
-        add_node!(t, Whitespace(1), s)
-        add_node!(t, pretty(style, cst[3], s), s, join_lines = true)
+        # function stub `function foo end`
+        n = pretty(style, cst[3], s)
+        if s.opts.join_lines_based_on_source
+            join_lines = t.endline == n.startline
+            join_lines && (add_node!(t, Whitespace(1), s))
+            add_node!(t, n, s, join_lines = join_lines)
+        else
+            add_node!(t, Whitespace(1), s)
+            add_node!(t, n, s, join_lines = true)
+        end
     end
     t
 end
@@ -875,8 +888,15 @@ function p_struct(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
     add_node!(t, Whitespace(1), s)
     add_node!(t, pretty(style, cst[3], s), s, join_lines = true)
     if cst[4].fullspan == 0
-        add_node!(t, Whitespace(1), s)
-        add_node!(t, pretty(style, cst[5], s), s, join_lines = true)
+        n = pretty(style, cst[5], s)
+        if s.opts.join_lines_based_on_source
+            join_lines = t.endline == n.startline
+            join_lines && (add_node!(t, Whitespace(1), s))
+            add_node!(t, n, s, join_lines = join_lines)
+        else
+            add_node!(t, Whitespace(1), s)
+            add_node!(t, n, s, join_lines = true)
+        end
     else
         s.indent += s.opts.indent
         n = pretty(style, cst[4], s, ignore_single_line = true)
@@ -902,8 +922,15 @@ function p_mutable(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
     add_node!(t, Whitespace(1), s)
     add_node!(t, pretty(style, cst[4], s), s, join_lines = true)
     if cst[5].fullspan == 0
-        add_node!(t, Whitespace(1), s)
-        add_node!(t, pretty(style, cst[6], s), s, join_lines = true)
+        n = pretty(style, cst[6], s)
+        if s.opts.join_lines_based_on_source
+            join_lines = t.endline == n.startline
+            join_lines && (add_node!(t, Whitespace(1), s))
+            add_node!(t, n, s, join_lines = join_lines)
+        else
+            add_node!(t, Whitespace(1), s)
+            add_node!(t, n, s, join_lines = true)
+        end
     else
         s.indent += s.opts.indent
         n = pretty(style, cst[5], s, ignore_single_line = true)
@@ -927,8 +954,15 @@ function p_module(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
     add_node!(t, Whitespace(1), s)
     add_node!(t, pretty(style, cst[3], s), s, join_lines = true)
     if cst[4].fullspan == 0
-        add_node!(t, Whitespace(1), s)
-        add_node!(t, pretty(style, cst[5], s), s, join_lines = true)
+        n = pretty(style, cst[5], s)
+        if s.opts.join_lines_based_on_source
+            join_lines = t.endline == n.startline
+            join_lines && (add_node!(t, Whitespace(1), s))
+            add_node!(t, n, s, join_lines = join_lines)
+        else
+            add_node!(t, Whitespace(1), s)
+            add_node!(t, n, s, join_lines = true)
+        end
     else
         if s.opts.indent_submodule && parent_is(
             cst,

--- a/src/styles/minimal/pretty.jl
+++ b/src/styles/minimal/pretty.jl
@@ -34,6 +34,6 @@ function options(style::MinimalStyle)
         align_matrix = false,
         indent_submodule = false,
         separate_kwargs_with_semicolon = false,
-    surround_whereop_typeparameters= false,
+        surround_whereop_typeparameters = false,
     )
 end

--- a/src/styles/minimal/pretty.jl
+++ b/src/styles/minimal/pretty.jl
@@ -34,5 +34,6 @@ function options(style::MinimalStyle)
         align_matrix = false,
         indent_submodule = false,
         separate_kwargs_with_semicolon = false,
+    surround_whereop_typeparameters= false,
     )
 end

--- a/src/styles/sciml/pretty.jl
+++ b/src/styles/sciml/pretty.jl
@@ -46,6 +46,7 @@ function options(style::SciMLStyle)
         trailing_comma = true,
         indent_submodule = false,
         separate_kwargs_with_semicolon = false,
+    surround_whereop_typeparameters= true,
     )
 end
 

--- a/src/styles/sciml/pretty.jl
+++ b/src/styles/sciml/pretty.jl
@@ -46,7 +46,7 @@ function options(style::SciMLStyle)
         trailing_comma = true,
         indent_submodule = false,
         separate_kwargs_with_semicolon = false,
-    surround_whereop_typeparameters= true,
+        surround_whereop_typeparameters = true,
     )
 end
 

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -48,6 +48,7 @@ function options(style::YASStyle)
         align_matrix = false,
         trailing_comma = true,
         indent_submodule = false,
+    surround_whereop_typeparameters= true,
     )
 end
 
@@ -513,7 +514,7 @@ function p_whereopcall(ys::YASStyle, cst::CSTParser.EXPR, s::State)
         cst[3].head === :bracescat ||
         cst[3].head === :parameters
 
-    add_braces = !curly_ctx && !CSTParser.is_lbrace(cst[3])
+    add_braces = s.opts.surround_whereop_typeparameters && !curly_ctx && !CSTParser.is_lbrace(cst[3])
 
     bc = curly_ctx ? t : FST(BracesCat, nspaces(s))
 

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -48,7 +48,7 @@ function options(style::YASStyle)
         align_matrix = false,
         trailing_comma = true,
         indent_submodule = false,
-    surround_whereop_typeparameters= true,
+        surround_whereop_typeparameters = true,
     )
 end
 
@@ -514,7 +514,8 @@ function p_whereopcall(ys::YASStyle, cst::CSTParser.EXPR, s::State)
         cst[3].head === :bracescat ||
         cst[3].head === :parameters
 
-    add_braces = s.opts.surround_whereop_typeparameters && !curly_ctx && !CSTParser.is_lbrace(cst[3])
+    add_braces =
+        s.opts.surround_whereop_typeparameters && !curly_ctx && !CSTParser.is_lbrace(cst[3])
 
     bc = curly_ctx ? t : FST(BracesCat, nspaces(s))
 

--- a/test/minimal_style.jl
+++ b/test/minimal_style.jl
@@ -1,3 +1,1 @@
-@testset "Minimal Style" begin
-end
-
+@testset "Minimal Style" begin end

--- a/test/minimal_style.jl
+++ b/test/minimal_style.jl
@@ -1,0 +1,3 @@
+@testset "Minimal Style" begin
+end
+

--- a/test/options.jl
+++ b/test/options.jl
@@ -2135,7 +2135,7 @@
             foo
         end
         """
-        @test fmt(s, surround_whereop_typeparameters = false, m=100) == s
+        @test fmt(s, surround_whereop_typeparameters = false, m = 100) == s
 
         s = """
         NotificationType(method::AbstractString, ::Type{TPARAM}) where TPARAM = foo

--- a/test/options.jl
+++ b/test/options.jl
@@ -1992,13 +1992,13 @@
             function foo()
             end
             """
-            @test fmt(s, join_lines_based_on_source=true) == s
+            @test fmt(s, join_lines_based_on_source = true) == s
 
             s = """
             function foo
             end
             """
-            @test fmt(s, join_lines_based_on_source=true) == s
+            @test fmt(s, join_lines_based_on_source = true) == s
         end
 
         @testset "macro defs" begin
@@ -2006,13 +2006,13 @@
             macro foo()
             end
             """
-            @test fmt(s, join_lines_based_on_source=true) == s
+            @test fmt(s, join_lines_based_on_source = true) == s
 
             s = """
             macro foo
             end
             """
-            @test fmt(s, join_lines_based_on_source=true) == s
+            @test fmt(s, join_lines_based_on_source = true) == s
         end
 
         @testset "typedefs" begin
@@ -2020,13 +2020,13 @@
             struct S
             end
             """
-            @test fmt(s, join_lines_based_on_source=true) == s
+            @test fmt(s, join_lines_based_on_source = true) == s
 
             s = """
             mutable struct S
             end
             """
-            @test fmt(s, join_lines_based_on_source=true) == s
+            @test fmt(s, join_lines_based_on_source = true) == s
         end
 
         @testset "modules" begin
@@ -2034,13 +2034,13 @@
             module M
             end
             """
-            @test fmt(s, join_lines_based_on_source=true) == s
+            @test fmt(s, join_lines_based_on_source = true) == s
 
             s = """
             baremodule BM
             end
             """
-            @test fmt(s, join_lines_based_on_source=true) == s
+            @test fmt(s, join_lines_based_on_source = true) == s
         end
     end
 

--- a/test/options.jl
+++ b/test/options.jl
@@ -2121,4 +2121,30 @@
         @test yasfmt1(str_, separate_kwargs_with_semicolon = true) == str
         @test yasfmt(str_, separate_kwargs_with_semicolon = true) == str
     end
+
+    @testset "`surround_whereop_typeparameters`" begin
+        s = """
+        function NotificationType(method::AbstractString, ::Type{TPARAM}) where TPARAM
+            foo
+        end
+        """
+        @test fmt(s, surround_whereop_typeparameters = false) == s
+
+        s = """
+        function NotificationType(method::AbstractString, ::Type{TPARAM})::R where TPARAM
+            foo
+        end
+        """
+        @test fmt(s, surround_whereop_typeparameters = false, m=100) == s
+
+        s = """
+        NotificationType(method::AbstractString, ::Type{TPARAM}) where TPARAM = foo
+        """
+        @test fmt(s, surround_whereop_typeparameters = false) == s
+
+        s = """
+        NotificationType(method::AbstractString, ::Type{TPARAM})::R where TPARAM = foo
+        """
+        @test fmt(s, surround_whereop_typeparameters = false) == s
+    end
 end

--- a/test/options.jl
+++ b/test/options.jl
@@ -1986,6 +1986,62 @@
                 d e Expr()]"""
             @test fmt(str_, join_lines_based_on_source = true) == str
         end
+
+        @testset "function defs" begin
+            s = """
+            function foo()
+            end
+            """
+            @test fmt(s, join_lines_based_on_source=true) == s
+
+            s = """
+            function foo
+            end
+            """
+            @test fmt(s, join_lines_based_on_source=true) == s
+        end
+
+        @testset "macro defs" begin
+            s = """
+            macro foo()
+            end
+            """
+            @test fmt(s, join_lines_based_on_source=true) == s
+
+            s = """
+            macro foo
+            end
+            """
+            @test fmt(s, join_lines_based_on_source=true) == s
+        end
+
+        @testset "typedefs" begin
+            s = """
+            struct S
+            end
+            """
+            @test fmt(s, join_lines_based_on_source=true) == s
+
+            s = """
+            mutable struct S
+            end
+            """
+            @test fmt(s, join_lines_based_on_source=true) == s
+        end
+
+        @testset "modules" begin
+            s = """
+            module M
+            end
+            """
+            @test fmt(s, join_lines_based_on_source=true) == s
+
+            s = """
+            baremodule BM
+            end
+            """
+            @test fmt(s, join_lines_based_on_source=true) == s
+        end
     end
 
     @testset "`indent_submodule`" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,11 @@ bluefmt(str; i = 4, m = 80, kwargs...) =
     fmt(str; i = i, m = m, style = BlueStyle(), kwargs...)
 bluefmt(str, i::Int, m::Int; kwargs...) = bluefmt(str; i = i, m = m, kwargs...)
 
+minimalfmt1(str) = fmt1(str; style = MinimalStyle(), options(DefaultStyle())...)
+minimalfmt(str; i = 4, m = 92, kwargs...) =
+    fmt(str; i = i, m = m, style = MinimalStyle(), kwargs...)
+minimalfmt(str, i::Int, m::Int; kwargs...) = minimalfmt(str; i = i, m = m, kwargs...)
+
 function run_pretty(text::String; style = DefaultStyle(), opts = Options())
     d = JuliaFormatter.Document(text)
     s = JuliaFormatter.State(d, opts)


### PR DESCRIPTION
### `surround_whereop_typeparameters`
> default: `true`
Surrounds type parameters with curly brackets when set to `true` if the brackets are not
already present.
```julia
function func(...) where TPARAM
end

->

function func(...) where {TPARAM}
end
```

Enables the `end` keyword to be placed on the next line when using `join_lines_based_on_source=true`

Before

```julia
function foo
end
```

Would have had end been joined to the first line: `function foo end`, even when `join_based_based_on_source` was `true`. Now if it originally on another line `end` will remain there.

fix #591
fix #595 
fix #590