### PR TITLE
Make `format_file` an alias for `format`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "1.0.7"
+version = "1.0.8"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -680,6 +680,41 @@ function format_text(cst::CSTParser.EXPR, style::AbstractStyle, s::State)
     return text
 end
 
+function _format_file(
+    filename::AbstractString;
+    overwrite::Bool = true,
+    verbose::Bool = false,
+    format_markdown::Bool = false,
+    format_options...,
+)::Bool
+    path, ext = splitext(filename)
+    shebang_pattern = r"^#!\s*/.*\bjulia[0-9.-]*\b"
+    formatted_str = if match(r"^\.[jq]*md$", ext) ≠ nothing
+        format_markdown || return true
+        verbose && println("Formatting $filename")
+        str = String(read(filename))
+        format_md(str; format_options...)
+    elseif ext == ".jl" || match(shebang_pattern, readline(filename)) !== nothing
+        verbose && println("Formatting $filename")
+        str = String(read(filename))
+        format_text(str; format_options...)
+    else
+        error("$filename must be a Julia (.jl) or Markdown (.md, .jmd or .qmd) source file")
+    end
+    formatted_str = replace(formatted_str, r"\n*$" => "\n")
+    already_formatted = (formatted_str == str)
+    if overwrite && !already_formatted
+        write(filename, formatted_str)
+    end
+    return already_formatted
+end
+
+function _format_file(filename::AbstractString, style::AbstractStyle; kwargs...)
+    return _format_file(filename; style = style, kwargs...)
+end
+
+const CONFIG_FILE_NAME = ".JuliaFormatter.toml"
+
 """
     format_file(
         filename::AbstractString;
@@ -727,37 +762,15 @@ function format_file(
     verbose::Bool = false,
     format_markdown::Bool = false,
     format_options...,
-)::Bool
-    path, ext = splitext(filename)
-    shebang_pattern = r"^#!\s*/.*\bjulia[0-9.-]*\b"
-    formatted_str = if match(r"^\.[jq]*md$", ext) ≠ nothing
-        format_markdown || return true
-        verbose && println("Formatting $filename")
-        str = String(read(filename))
-        format_md(str; format_options...)
-    elseif ext == ".jl" || match(shebang_pattern, readline(filename)) !== nothing
-        verbose && println("Formatting $filename")
-        str = String(read(filename))
-        format_text(str; format_options...)
-    else
-        error("$filename must be a Julia (.jl) or Markdown (.md, .jmd or .qmd) source file")
-    end
-    formatted_str = replace(formatted_str, r"\n*$" => "\n")
-    already_formatted = (formatted_str == str)
-    if overwrite && !already_formatted
-        write(filename, formatted_str)
-    end
-    return already_formatted
+)
+    format(
+        filename;
+        overwrite = overwrite,
+        verbose = verbose,
+        format_markdown = format_markdown,
+        format_options...,
+    )
 end
-
-"""
-    format_file(filename::AbstractString, style::AbstractStyle; kwargs...)::Bool
-"""
-function format_file(filename::AbstractString, style::AbstractStyle; kwargs...)
-    return format_file(filename; style = style, kwargs...)
-end
-
-const CONFIG_FILE_NAME = ".JuliaFormatter.toml"
 
 """
     format(
@@ -765,8 +778,7 @@ const CONFIG_FILE_NAME = ".JuliaFormatter.toml"
         options...,
     )::Bool
 
-Recursively descend into files and directories, formatting any `.jl` files by calling
-`format_file` on them.
+Recursively descend into files and directories, formatting any `.jl` files.
 
 See [`format_file`](@ref) and [`format_text`](@ref) for a description of the options.
 
@@ -805,7 +817,7 @@ function format(paths; options...)::Bool
             else
                 options
             end
-            format_file(path; opts...)
+            _format_file(path; opts...)
         else
             reduce(walkdir(path), init = true) do formatted_path, dir_branch
                 root, dirs, files = dir_branch
@@ -822,7 +834,7 @@ function format(paths; options...)::Bool
                         else
                             options
                         end
-                        format_file(full_path; opts...)
+                        _format_file(full_path; opts...)
                     else
                         true
                     end

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -772,6 +772,10 @@ function format_file(
     )
 end
 
+function format_file(filename::AbstractString, style::AbstractStyle; kwargs...)
+    return format_file(filename; style = style, kwargs...)
+end
+
 """
     format(
         paths; # a path or collection of paths


### PR DESCRIPTION
At the moment when `format_file` is called it does not look for options set
in a .JuliaFormatter.toml as `format` does. This can cause different
outputs based on whether you call either `format` or `format_file` which
should not be the case.

This PR renames the old `format_file` to `_format_file` and
then has `format_file` be an alias to `format` so that it works as
intended.

ref #626 
closes #474