### PR TITLE
Fix #618 and #636

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "1.0.10"
+version = "1.0.11"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -138,13 +138,17 @@ function pipe_to_function_call(fst::FST)
         if dot && arg2.typ === IDENTIFIER
             n = FST(PUNCTUATION, -1, arg2.endline, arg2.endline, ".")
             push!(nodes, n)
-        elseif dot && arg2.typ === Binary &&
-           arg2[end].typ === Quotenode &&
-           arg2[end][end].typ === IDENTIFIER
+        elseif dot &&
+               arg2.typ === Binary &&
+               arg2[end].typ === Quotenode &&
+               arg2[end][end].typ === IDENTIFIER
             n = FST(PUNCTUATION, -1, arg2.endline, arg2.endline, ".")
             push!(nodes, n)
-       elseif dot && arg2.typ === Brackets 
-            idx = findfirst(n -> n.typ === Binary && op_kind(n) === Tokens.ANON_FUNC, arg2.nodes)
+        elseif dot && arg2.typ === Brackets
+            idx = findfirst(
+                n -> n.typ === Binary && op_kind(n) === Tokens.ANON_FUNC,
+                arg2.nodes,
+            )
             if idx !== nothing
                 n = FST(PUNCTUATION, -1, arg2.endline, arg2.endline, ".")
                 push!(nodes, n)

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1415,4 +1415,43 @@
         """
         @test format_text(s) == s
     end
+
+    @testset "636" begin
+        s = "a |> M.f"
+        @test fmt(s, 4, 92, pipe_to_function_call = true) == "M.f(a)"
+
+        # -> has a higher precedence than |>
+        s = """
+        coordsperm = coords .|> x -> x.I[[2, 1, 3]] |> CartesianIndex
+        """
+        s_ = """
+        coordsperm = (x -> CartesianIndex(x.I[[2, 1, 3]])).(coords)
+        """
+        @test fmt(s, 4, 92, pipe_to_function_call = true) == s_
+
+        # -> has a higher precedence than |>
+        s = """
+        coordsperm = coords .|> x -> x.I[[2, 1, 3]] .|> CartesianIndex
+        """
+        s_ = """
+        coordsperm = (x -> CartesianIndex.(x.I[[2, 1, 3]])).(coords)
+        """
+        @test fmt(s, 4, 92, pipe_to_function_call = true) == s_
+
+        s = """
+        coordsperm = coords .|> (x -> x.I[[2, 1, 3]]) .|> CartesianIndex
+        """
+        s_ = """
+        coordsperm = CartesianIndex.((x -> x.I[[2, 1, 3]]).(coords))
+        """
+        @test fmt(s, 4, 92, pipe_to_function_call = true) == s_
+
+        s = """
+        coordsperm = coords |> (x -> x.I[[2, 1, 3]]) |> CartesianIndex
+        """
+        s_ = """
+        coordsperm = CartesianIndex((x -> x.I[[2, 1, 3]])(coords))
+        """
+        @test fmt(s, 4, 92, pipe_to_function_call = true) == s_
+    end
 end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1454,4 +1454,14 @@
         """
         @test fmt(s, 4, 92, pipe_to_function_call = true) == s_
     end
+
+    @testset "618" begin
+        s = """
+        2 |> x -> 2x
+        """
+        s_ = """
+        (x -> 2x)(2)
+        """
+        @test fmt(s, 4, 92, pipe_to_function_call = true) == s_
+    end
 end


### PR DESCRIPTION
Support more cases of converting pipe to function calls, particularly anon functions and more dot/broadcast cases.
