### PR TITLE
Parallelize over subpaths

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "1.0.13"
+version = "1.0.14"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"


### PR DESCRIPTION
This adds basic parallelization over subpaths, which is useful when you need to repeatedly format a large package. Using my 8 core M1, my SymbolicRegression.jl package (~5000 SLOC) now only takes 80 ms seconds to format, down from 260 ms before this change.