### PR TITLE
fix #656

### DIFF
--- a/src/fst.jl
+++ b/src/fst.jl
@@ -1139,7 +1139,14 @@ function eq_to_in_normalization!(fst::FST, always_for_in::Bool, for_in_replaceme
             op.len = length(op.val)
         end
     elseif fst.typ === Block || fst.typ === Brackets || fst.typ === Filter
+        past_if = false
         for (i, n) in enumerate(fst.nodes)
+            if n.typ === KEYWORD && n.val == "if"
+                # [x for x in xs if x in 1:length(ys)]
+                # we do not want to convert the binary operations after an "if" keyword.
+                past_if = true
+            end
+            past_if && break
             eq_to_in_normalization!(n, always_for_in, for_in_replacement)
         end
     end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1486,4 +1486,9 @@
         """
         @test fmt(s, 4, 92, align_assignment = true) == s
     end
+
+    @testset "656" begin
+        s = "[x for x in xs if x in 1:length(ys)]"
+        @test fmt(s, 4, 92) == s
+    end
 end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1504,7 +1504,7 @@
               s
         @test fmt(s, 2, 1, trailing_comma = nothing) == s
     end
-    
+
     @testset "656" begin
         s = "[x for x in xs if x in 1:length(ys)]"
         @test fmt(s, 4, 92) == s


### PR DESCRIPTION
Do not convert binary operators that occur after the if keyword.

@MichaelHatherly do you know if there are other keywords besides `if` that would lead to a similar bug?