### PR TITLE
Limit usage of InverseTrailingSemicolon 

### DIFF
--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -2150,7 +2150,7 @@ function p_vcat(ds::DefaultStyle, cst::CSTParser.EXPR, s::State)
                 add_node!(t, Placeholder(1), s)
                 # Keep trailing semicolon if there's only one arg
             elseif length(args) == 1 && has_semicolon(s.doc, n.startline)
-                add_node!(t, InverseTrailingSemicolon(), s)
+                add_node!(t, Semicolon(), s)
                 add_node!(t, Placeholder(0), s)
             else
                 add_node!(t, Placeholder(0), s)

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1486,4 +1486,13 @@
         """
         @test fmt(s, 4, 92, align_assignment = true) == s
     end
+
+    @testset "655" begin
+        s = """
+        [
+          a;
+        ]
+        """
+        @test fmt(s, 2, 92, join_lines_based_on_source = true) == s
+    end
 end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1494,5 +1494,14 @@
         ]
         """
         @test fmt(s, 2, 92, join_lines_based_on_source = true) == s
+        @test fmt(s, 2, 1) == s
+        s = """
+        [
+          a
+        ]
+        """
+        @test fmt(s, 2, 92, join_lines_based_on_source = true, trailing_comma = nothing) ==
+              s
+        @test fmt(s, 2, 1, trailing_comma = nothing) == s
     end
 end


### PR DESCRIPTION
Depending on the types inside a vector

```
[
  ...
]
```

Having removing or adding the semicolon can change the type entirely.

```
julia> [
       [1,0];
       ]
2-element Vector{Int64}:
 1
 0

julia> [
       [1,0]
       ]
1-element Vector{Vector{Int64}}:
 [1, 0]
```

So we should no longer do that.

fix https://github.com/domluna/JuliaFormatter.jl/issues/655