### PR TITLE
add `trailing_zero` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,12 @@ funccall(
 * When set to `false`, the trailing comma is always removed during nesting.
 * When set to `nothing`, the trailing comma appears as it does in the original source.
 
+### `trailing_zero`
+
+> default: `true`
+
+Add a trailing zero, if needed.
+
 ### `join_lines_based_on_source`
 
 > default: `false`

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -87,6 +87,7 @@ function options(s::DefaultStyle)
         align_matrix = false,
         join_lines_based_on_source = false,
         trailing_comma = true,
+        trailing_zero = true,
         indent_submodule = false,
         separate_kwargs_with_semicolon = false,
         surround_whereop_typeparameters = true,
@@ -176,6 +177,7 @@ normalize_line_ending(s::AbstractString, replacer = WINDOWS_TO_UNIX) = replace(s
         normalize_line_endings = "auto",
         align_matrix::Bool = false,
         trailing_comma::Bool = false,
+        trailing_zero::Bool = true,
         indent_submodule::Bool = false,
         separate_kwargs_with_semicolon::Bool = false,
         surround_whereop_typeparameters::Bool = true,
@@ -484,6 +486,12 @@ value `"nothing"`:
 ```toml
 trailing_comma = "nothing"
 ```
+
+### `trailing_zero`
+
+> default: `true`
+
+Add a trailing zero, if needed.
 
 ### `join_lines_based_on_source`
 

--- a/src/options.jl
+++ b/src/options.jl
@@ -25,6 +25,7 @@ Base.@kwdef struct Options
     align_matrix::Bool = false
     join_lines_based_on_source::Bool = false
     trailing_comma::Union{Bool,Nothing} = true
+    trailing_zero::Bool = true
     indent_submodule::Bool = false
     separate_kwargs_with_semicolon::Bool = false
     surround_whereop_typeparameters::Bool = true

--- a/src/styles/blue/pretty.jl
+++ b/src/styles/blue/pretty.jl
@@ -54,6 +54,7 @@ function options(style::BlueStyle)
         align_matrix = false,
         join_lines_based_on_source = false,
         trailing_comma = true,
+        trailing_zero = true,
         surround_whereop_typeparameters = true,
     )
 end

--- a/src/styles/minimal/pretty.jl
+++ b/src/styles/minimal/pretty.jl
@@ -14,6 +14,7 @@ function options(style::MinimalStyle)
         annotate_untyped_fields_with_any = false,
         join_lines_based_on_source = true,
         trailing_comma = nothing,
+        trailing_zero = false,
         margin = 10_000,
         always_for_in = nothing,
         whitespace_in_kwargs = false,

--- a/src/styles/sciml/pretty.jl
+++ b/src/styles/sciml/pretty.jl
@@ -45,6 +45,7 @@ function options(style::SciMLStyle)
         align_pair_arrow = false,
         align_matrix = false,
         trailing_comma = true,
+        trailing_zero = true,
         indent_submodule = false,
         separate_kwargs_with_semicolon = false,
         surround_whereop_typeparameters = true,

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -48,6 +48,7 @@ function options(style::YASStyle)
         normalize_line_endings = "auto",
         align_matrix = false,
         trailing_comma = true,
+        trailing_zero = true,
         indent_submodule = false,
         surround_whereop_typeparameters = true,
     )

--- a/test/options.jl
+++ b/test/options.jl
@@ -2310,4 +2310,14 @@
             for_in_replacement = "ni!",
         )
     end
+
+    @testset "trailing zero" begin
+        @test fmt("1e-2", trailing_zero = true) == "1e-2"
+        @test fmt("1f0", trailing_zero = true) == "1.0f0"
+        @test fmt("1.", trailing_zero = true) == "1.0"
+
+        @test fmt("1e-2", trailing_zero = false) == "1e-2"
+        @test fmt("1f0", trailing_zero = false) == "1f0"
+        @test fmt("1.", trailing_zero = false) == "1."
+    end
 end


### PR DESCRIPTION
Fix https://github.com/domluna/JuliaFormatter.jl/issues/517.
To be discussed.

Adding a `leading_zero` option is left for another PR (couldn't come up with a nice implementation).