### PR TITLE
fix #604

### DIFF
--- a/src/styles/sciml/pretty.jl
+++ b/src/styles/sciml/pretty.jl
@@ -100,7 +100,8 @@ function p_begin(ss::SciMLStyle, cst::CSTParser.EXPR, s::State)
     else
         stmts_idxs = 2:length(cst)-1
         # Don't nest into multiple lines when there's only one statement
-        if length(stmts_idxs) == 1
+        # and it's not a macroblock.
+        if length(stmts_idxs) == 1 && !(cst[2].head === :macrocall && !is_closer(cst[2][end]))
             add_node!(t, Whitespace(1), s)
             add_node!(t, pretty(style, cst[2], s), s, join_lines = true)
             add_node!(t, Whitespace(1), s)

--- a/src/styles/sciml/pretty.jl
+++ b/src/styles/sciml/pretty.jl
@@ -101,7 +101,8 @@ function p_begin(ss::SciMLStyle, cst::CSTParser.EXPR, s::State)
         stmts_idxs = 2:length(cst)-1
         # Don't nest into multiple lines when there's only one statement
         # and it's not a macroblock.
-        if length(stmts_idxs) == 1 && !(cst[2].head === :macrocall && !is_closer(cst[2][end]))
+        if length(stmts_idxs) == 1 &&
+           !(cst[2].head === :macrocall && !is_closer(cst[2][end]))
             add_node!(t, Whitespace(1), s)
             add_node!(t, pretty(style, cst[2], s), s, join_lines = true)
             add_node!(t, Whitespace(1), s)

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1407,6 +1407,23 @@
         @test format_text(s) == s_
     end
 
+    @testset "604" begin
+        str = raw"""
+        begin @foo a end
+        """
+        str_ = raw"""
+        begin
+            @foo a
+        end
+        """
+        @test format_text(str, SciMLStyle()) == str_
+
+        str = raw"""
+        begin @foo(a) end
+        """
+        @test format_text(str, SciMLStyle()) == str
+    end
+
     @testset "613" begin
         s = """
         x = ```


### PR DESCRIPTION
Do not join the single statement in a begin block if it's a macroblock, i.e. a macrocall with whitespace separation such as "@foo a b".