### PR TITLE
Add `pre-commit` support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+# NOTE: Do NOT use this config in your own repositories. Instead, see 
+#   docs/integrations.md
+repos:
+- repo: local
+  hooks:
+  - id: "julia-formatter"

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: julia-formatter
   name: "Julia Formatter"
-  entry: "./bin/hook.jl"
-  pass_filenames: true 
-  # always_run: true
+  entry: "julia -e 'import JuliaFormatter: format; format(\".\")'"
+  pass_filenames: false
+  always_run: true
   language: "system"
   description: "An opinionated code formatter for Julia. Plot twist - the opinion is your own."

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: julia-formatter
   name: "Julia Formatter"
-  entry: "./bin/format.jl ."
-  pass_filenames: false
-  always_run: true
+  entry: "./bin/hook.jl"
+  pass_filenames: true 
+  # always_run: true
   language: "system"
   description: "An opinionated code formatter for Julia. Plot twist - the opinion is your own."

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: julia-formatter
+  name: "Julia Formatter"
+  entry: "./bin/format.jl ."
+  pass_filenames: false
+  always_run: true
+  language: "system"
+  description: "An opinionated code formatter for Julia. Plot twist - the opinion is your own."

--- a/bin/hook.jl
+++ b/bin/hook.jl
@@ -1,0 +1,6 @@
+#!/usr/bin/env julia
+using JuliaFormatter
+
+@debug ARGS
+filename = ARGS[1]
+exit(format_file(filename) ? 0 : 1)

--- a/docs/src/integrations.md
+++ b/docs/src/integrations.md
@@ -1,0 +1,23 @@
+# Integrations
+
+## `pre-commit`
+
+To learn more about `pre-commit`, [check out their docs](https://pre-commit.com).
+
+With [Pull 674](https://github.com/domluna/JuliaFormatter.jl/pull/674), support for 
+`pre-commit` was added. To add `JuliaFormatter.jl` to your own `pre-commit` workflow,
+add the following to your `.pre-commit-config.yaml`.
+
+```yaml
+repos:
+# ... other repos you may have
+- repo: "https://github.com/domluna/JuliaFormatter.jl"
+  rev: "v1.0.18"  # or whatever the desired release is
+  hooks:
+  - id: "julia-formatter"
+# ... other repos you may have
+```
+
+You can find a list of releases [here](https://github.com/domluna/JuliaFormatter.jl/releases).
+**Be sure to use the entire version string!** (You can double-check this by opening the
+release and looking at the part of the URL that follows `.../releases/tag/VERSION`.)


### PR DESCRIPTION
Hacks together `pre-commit` support using the `./bin/format.jl` script in the repository root. Closes #498. (Hackish because `pre-commit` lacks direct support for Julia (WIP by me, but will take a bit).)

Some major quirks that seem to deviate (particularly from the `black` inspiration, and seemingly the `pre-commit` execution flow (of passing individual files)) is that passing individual files appears to:

1. ignore the local `.JuliaFormatter.toml`
2. require using the Julia REPL, like so: `julia -e "import JuliaFormatter: format_file; format_file(path)"`

(2) can probably be remedied with it's own script that mirrors `./bin/format.jl`, but I'm not quite sure how to remedy (1) without guidance on desired execution of `JuliaFormatter`.