### PR TITLE
Use SnoopPrecompile.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ CommonMark = "a80b9123-70ca-4bc0-993e-6e3bcb318db6"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 Tokenize = "0796e94c-ce3b-5d07-9a54-7f471281c624"
 
 [compat]

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -1,5 +1,9 @@
 module JuliaFormatter
 
+if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@max_methods"))
+    @eval Base.Experimental.@max_methods 1
+end
+
 using CSTParser
 using Tokenize
 using DataStructures
@@ -974,7 +978,6 @@ end
 
 if Base.VERSION >= v"1.5"
     include("other/precompile.jl")
-    _precompile_()
 end
 
 end

--- a/src/other/precompile.jl
+++ b/src/other/precompile.jl
@@ -7,3 +7,10 @@ function _precompile_()
     Base.precompile(Tuple{typeof(pretty),BlueStyle,CSTParser.EXPR,State})
     Base.precompile(Tuple{typeof(pretty),MinimalStyle,CSTParser.EXPR,State})
 end
+using SnoopPrecompile
+@precompile_setup begin
+    dir = joinpath(@__DIR__,"../..")
+    @precompile_all_calls begin
+        format(dir)
+    end
+end

--- a/src/other/precompile.jl
+++ b/src/other/precompile.jl
@@ -8,7 +8,7 @@ using SnoopPrecompile
     """
     @precompile_all_calls begin
         format(dir)
-        for style = [DefaultStyle(), BlueStyle(), SciMLStyle(), YASStyle()]
+        for style = [DefaultStyle(), BlueStyle(), SciMLStyle(), YASStyle(), MinimalStyle()]
           format_text(str, style)
         end
     end

--- a/src/other/precompile.jl
+++ b/src/other/precompile.jl
@@ -1,16 +1,15 @@
 #! format: off
-function _precompile_()
-    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-    # pretty
-    Base.precompile(Tuple{typeof(pretty),DefaultStyle,CSTParser.EXPR,State})
-    Base.precompile(Tuple{typeof(pretty),YASStyle,CSTParser.EXPR,State})
-    Base.precompile(Tuple{typeof(pretty),BlueStyle,CSTParser.EXPR,State})
-    Base.precompile(Tuple{typeof(pretty),MinimalStyle,CSTParser.EXPR,State})
-end
 using SnoopPrecompile
 @precompile_setup begin
     dir = joinpath(@__DIR__,"..", "..")
+    str = raw"""
+       @noinline require_complete(m::Matching) =
+           m.inv_match === nothing && throw(ArgumentError("Backwards matching not defined. `complete` the matching first."))
+    """
     @precompile_all_calls begin
         format(dir)
+        for style = [DefaultStyle(), BlueStyle(), SciMLStyle(), YASStyle()]
+          format_text(str, style)
+        end
     end
 end

--- a/src/other/precompile.jl
+++ b/src/other/precompile.jl
@@ -9,7 +9,7 @@ function _precompile_()
 end
 using SnoopPrecompile
 @precompile_setup begin
-    dir = joinpath(@__DIR__,"../..")
+    dir = joinpath(@__DIR__,"..", "..")
     @precompile_all_calls begin
         format(dir)
     end


### PR DESCRIPTION
With this PR:
```julia
julia> @time using JuliaFormatter
[ Info: Precompiling JuliaFormatter [98e50ef6-434e-11e9-1051-2b60c6c9e899]
 33.716529 seconds (2.11 M allocations: 124.493 MiB, 0.13% gc time, 0.11% compilation time)

julia> @time @eval JuliaFormatter.format("/home/chriselrod/.julia/dev/Octavian/")
  1.131611 seconds (1.63 M allocations: 103.127 MiB, 887.14% compilation time)
true
```

Versus the master branch:
```julia
julia> @time using JuliaFormatter
[ Info: Precompiling JuliaFormatter [98e50ef6-434e-11e9-1051-2b60c6c9e899]
  9.866693 seconds (1.75 M allocations: 102.886 MiB, 0.42% gc time, 0.37% compilation time)

julia> @time @eval JuliaFormatter.format("/home/chriselrod/.julia/dev/Octavian/")
  8.763866 seconds (8.31 M allocations: 543.450 MiB, 1.22% gc time, 1102.95% compilation time)
true
```

This is on Julia master.

For me, the increase in precompile time is well worth the benefit to time-to-first-format, but I understand how some may disagree.
I use JuliaFormatter a lot -- I set my text editor to run the formatter every time I save a Julia file.
So this would save a decent bit of time for me.
Of course, some people may use `LanguageServer.jl`, which depends on JuliaFormatter, without ever running format...