### PR TITLE
Add `-O1` and `--startup=no` to scripts

### DIFF
--- a/bin/format.jl
+++ b/bin/format.jl
@@ -1,4 +1,4 @@
-#!/usr/bin/env julia
+#!/usr/bin/env -S julia --startup-file=no -O1
 using JuliaFormatter
 
 help = """

--- a/bin/hook.jl
+++ b/bin/hook.jl
@@ -1,4 +1,4 @@
-#!/usr/bin/env julia
+#!/usr/bin/env -S julia --startup-file=no -O1
 using JuliaFormatter
 
 @debug ARGS


### PR DESCRIPTION
`--startup=no` is obvious.
I should have tried `-O0`, but `-O1` was at least faster than `--compile=min` or `-O2`, so it seems to strike a good balance here.