### PR TITLE
fix type instabilities detected by JET

### DIFF
--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -905,7 +905,7 @@ function format(path::AbstractString, options::Configuration)
     end
     try
         return _format_file(path; [Symbol(k) => v for (k, v) in pairs(options)]...)
-    catch
+    catch err
         @info "Error in formatting file $path"
         @debug "formatting failed due to" exception = (err, catch_backtrace())
         return _format_file(path; [Symbol(k) => v for (k, v) in pairs(options)]...)
@@ -920,7 +920,11 @@ format(path, style::AbstractStyle; options...) = format(path; style = style, opt
 """
     format(mod::Module, args...; options...)
 """
-format(mod::Module, args...; options...) = format(pkgdir(mod), args...; options...)
+function format(mod::Module, args...; options...)
+    path = pkgdir(mod)
+    path === nothing && throw(ArgumentError("couldn't find a directory of module `$mod`"))
+    format(path, args...; options...)
+end
 
 function kwargs(dict)
     ns = (Symbol.(keys(dict))...,)

--- a/src/align.jl
+++ b/src/align.jl
@@ -262,7 +262,7 @@ function align_conditional!(fst::FST)
 
     for (i, ind) in enumerate(colon_group.node_inds)
         # the placeholder would be i+1 if not for a possible inline comment
-        nind = findnext(n -> n.typ === PLACEHOLDER, nodes, ind + 1)
+        nind = findnext(n -> n.typ === PLACEHOLDER, nodes, ind + 1)::Int
         if nodes[nind+1].startline != nodes[nind].startline
             nodes[nind] = Newline(nest_behavior = AlwaysNest)
         end
@@ -284,7 +284,7 @@ end
 Adjust whitespace in between matrix elements such that it's the same as the original source file.
 """
 function align_matrix!(fst::FST)
-    rows = filter(n -> n.typ === Row, fst.nodes)
+    rows = filter(n -> n.typ === Row, fst.nodes::Vector{FST})
     length(rows) == 0 && return
 
     min_offset = minimum(map(rows) do r
@@ -297,7 +297,7 @@ function align_matrix!(fst::FST)
     for r in rows
         if r[1].line_offset > min_offset && line != r.startline
             diff = r[1].line_offset - min_offset
-            insert!(r.nodes, 1, Whitespace(diff))
+            insert!(r.nodes::Vector{FST}, 1, Whitespace(diff))
         end
         line = r.startline
     end

--- a/src/document.jl
+++ b/src/document.jl
@@ -135,7 +135,7 @@ function Document(text::AbstractString)
                     offset += 1
                 end
                 # last comment
-                idx = min(findfirst(c -> !isspace(c), cs), ws + 1)
+                idx = min(findfirst(c -> !isspace(c), cs)::Int, ws + 1)
                 comments[line] = (ws, cs[idx:end])
             end
 
@@ -147,8 +147,8 @@ function Document(text::AbstractString)
             elseif occursin(r"^#!\s*format\s*:\s*on\s*$", t.val) && length(stack) > 0
                 # If "#! format: off" has not been seen
                 # "#! format: on" is treated as a normal comment.
-                idx1 = findfirst(c -> c == '\n', str)
-                idx2 = findlast(c -> c == '\n', str)
+                idx1 = findfirst(c -> c == '\n', str)::Int
+                idx2 = findlast(c -> c == '\n', str)::Int
                 str = str[idx1:idx2]
                 push!(format_skips, (pop!(stack), t.startpos[1], str))
                 str = ""
@@ -192,7 +192,7 @@ function Document(text::AbstractString)
     if length(stack) == 1 && length(format_skips) == 0
         # -1 signifies everything afterwards "#! format: off"
         # will not formatted.
-        idx1 = findfirst(c -> c == '\n', str)
+        idx1 = findfirst(c -> c == '\n', str)::Int
         str = str[idx1:end]
         push!(format_skips, (stack[1], -1, str))
     end

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -175,23 +175,25 @@ function FST(
 end
 
 @inline function Base.setindex!(fst::FST, node::FST, ind::Int)
-    fst.len -= fst.nodes[ind].len
-    fst.nodes[ind] = node
+    nodes = fst.nodes::Vector{FST}
+    fst.len -= nodes[ind].len
+    nodes[ind] = node
     fst.len += node.len
 end
-@inline Base.getindex(fst::FST, inds...) = fst.nodes[inds...]
-@inline Base.lastindex(fst::FST) = length(fst.nodes)
+@inline Base.getindex(fst::FST, inds...) = (fst.nodes::Vector{FST})[inds...]
+@inline Base.lastindex(fst::FST) = length(fst.nodes::Vector{FST})
 @inline Base.firstindex(fst::FST) = 1
 @inline Base.length(fst::FST) = fst.len
 @inline function Base.iterate(fst::FST, state = 1)
-    if state > length(fst.nodes)
+    nodes = fst.nodes::Vector{FST}
+    if state > length(nodes::Vector{FST})
         return nothing
     end
-    return fst.nodes[state], state + 1
+    return nodes[state], state + 1
 end
 
 @inline function Base.insert!(fst::FST, ind::Int, node::FST)
-    insert!(fst.nodes, ind, node)
+    insert!(fst.nodes::Vector{FST}, ind, node)
     fst.len += node.len
     return
 end
@@ -246,9 +248,9 @@ end
 @inline is_comment(fst::FST) = fst.typ === INLINECOMMENT || fst.typ === NOTCODE
 
 @inline is_circumflex_accent(x::CSTParser.EXPR) =
-    CSTParser.isoperator(x) && endswith(CSTParser.valof(x), "^")
+    CSTParser.isoperator(x) && endswith(CSTParser.valof(x)::String, "^")
 @inline is_fwdfwd_slash(x::CSTParser.EXPR) =
-    CSTParser.isoperator(x) && endswith(CSTParser.valof(x), "//")
+    CSTParser.isoperator(x) && endswith(CSTParser.valof(x)::String, "//")
 
 # TODO: fix this
 function is_multiline(fst::FST)
@@ -305,12 +307,14 @@ end
 
 function is_macrostr_identifier(cst::CSTParser.EXPR)
     CSTParser.isidentifier(cst) || return false
-    # handles odd cases like """M.var"@f";"""
-    cst.val !== nothing || return false
+    val = cst.val
 
-    m = match(r"@(.*)_(str|cmd)", cst.val)
+    # handles odd cases like """M.var"@f";"""
+    val !== nothing || return false
+
+    m = match(r"@(.*)_(str|cmd)", val)
     m !== nothing || return false
-    val = m.captures[1]
+    val = m.captures[1]::AbstractString
 
     # r"hello" is parsed as @r_str"hello"
     # if it was originally r"hello" then
@@ -331,10 +335,6 @@ function is_if(cst::CSTParser.EXPR)
     cst.head === :if && cst[1].head === :IF && return true
     cst.head === :elseif && cst[1].head === :ELSEIF && return true
     return false
-end
-
-function is_conditional(cst::CSTParser.EXPR)
-    CSTParser.isconditional(x)
 end
 
 function is_colon_call(cst::CSTParser.EXPR)
@@ -378,7 +378,7 @@ end
 contains_comment(nodes::Vector{FST}) = findfirst(is_comment, nodes) !== nothing
 function contains_comment(fst::FST)
     is_leaf(fst) && return false
-    contains_comment(fst.nodes)
+    contains_comment(fst.nodes::Vector)
 end
 
 # TODO: Remove once this is fixed in CSTParser.
@@ -461,6 +461,7 @@ function add_node!(
     max_padding::Int = -1,
     override_join_lines_based_on_source::Bool = false,
 )
+    tnodes = t.nodes
     if n.typ === SEMICOLON
         join_lines = true
         loc = if s.offset > length(s.doc.text) && t.typ === TopLevel
@@ -482,11 +483,11 @@ function add_node!(
             t.len += length(n)
             n.startline = t.endline
             n.endline = t.endline
-            push!(t.nodes, n)
+            push!(tnodes, n)
             return
         end
     elseif n.typ === TRAILINGCOMMA
-        en = t.nodes[end]
+        en = tnodes[end]
         if en.typ === Generator ||
            en.typ === Filter ||
            en.typ === Flatten ||
@@ -507,33 +508,33 @@ function add_node!(
             t.len += length(n)
             n.startline = t.endline
             n.endline = t.endline
-            push!(t.nodes, n)
+            push!(tnodes, n)
         end
         return
     elseif n.typ === NOTCODE
         n.indent = s.indent
-        push!(t.nodes, n)
+        push!(tnodes, n)
         return
     elseif n.typ === INLINECOMMENT
-        push!(t.nodes, n)
+        push!(tnodes, n)
         return
     elseif is_custom_leaf(n)
         t.len += length(n)
         n.startline = t.endline
         n.endline = t.endline
-        push!(t.nodes, n)
+        push!(tnodes, n)
         return
     end
 
     if n.typ === Block && length(n) == 0
-        push!(t.nodes, n)
+        push!(tnodes, n)
         return
     elseif n.typ === Parameters
         # unpack Parameters arguments into the parent node
         if t.ref !== nothing && n_args(t.ref[]) == n_args(n.ref[])
             # There are no arguments prior to params
             # so we can remove the initial placeholder.
-            idx = findfirst(n -> n.typ === PLACEHOLDER, t.nodes)
+            idx = findfirst(n -> n.typ === PLACEHOLDER, tnodes)
             idx !== nothing && (t[idx] = Whitespace(0))
         end
         add_node!(t, Semicolon(), s)
@@ -564,12 +565,12 @@ function add_node!(
         binaryop_to_whereop!(n, s)
     end
 
-    if length(t.nodes) == 0
+    if length(tnodes) == 0
         t.startline = n.startline
         t.endline = n.endline
         t.len += length(n)
         t.line_offset = n.line_offset
-        push!(t.nodes, n)
+        push!(tnodes, n)
         return
     end
 
@@ -592,11 +593,11 @@ function add_node!(
         join_lines = t.endline == n.startline
     end
 
-    if !is_prev_newline(t.nodes[end])
+    if !is_prev_newline(tnodes[end])
         current_line = t.endline
         notcode_startline = current_line + 1
         notcode_endline = n.startline - 1
-        nt = t.nodes[end].typ
+        nt = tnodes[end].typ
 
         if notcode_startline <= notcode_endline
             # If there are comments in between node elements
@@ -622,7 +623,7 @@ function add_node!(
 
             # If the previous node type is WHITESPACE - reset it.
             # This fixes cases similar to the one shown in issue #51.
-            nt === WHITESPACE && (t.nodes[end] = Whitespace(0))
+            nt === WHITESPACE && (tnodes[end] = Whitespace(0))
 
             if hascomment(s.doc, current_line)
                 add_node!(t, InlineComment(current_line), s)
@@ -632,8 +633,8 @@ function add_node!(
                 add_node!(t, Newline(nest_behavior = AlwaysNest), s)
             elseif hascomment(s.doc, current_line) && nt === PLACEHOLDER
                 # swap PLACEHOLDER (will be NEWLINE) with INLINECOMMENT node
-                idx = length(t.nodes)
-                t.nodes[idx-1], t.nodes[idx] = t.nodes[idx], t.nodes[idx-1]
+                idx = length(tnodes)
+                tnodes[idx-1], tnodes[idx] = tnodes[idx], tnodes[idx-1]
             end
 
             if nest
@@ -651,13 +652,13 @@ function add_node!(
             t.nest_behavior = AlwaysNest
             add_node!(t, InlineComment(current_line), s)
             # swap PLACEHOLDER (will be NEWLINE) with INLINECOMMENT node
-            idx = length(t.nodes)
-            t.nodes[idx-1], t.nodes[idx] = t.nodes[idx], t.nodes[idx-1]
+            idx = length(tnodes)
+            tnodes[idx-1], tnodes[idx] = tnodes[idx], tnodes[idx-1]
         elseif nt === WHITESPACE &&
                hascomment(s.doc, current_line) &&
                current_line != n.startline
             # rely on the whitespace tracked for the inline comment
-            t.nodes[end] = Whitespace(0)
+            tnodes[end] = Whitespace(0)
             add_node!(t, InlineComment(current_line), s)
             add_node!(t, Newline(nest_behavior = AlwaysNest), s)
         end
@@ -686,14 +687,14 @@ function add_node!(
     else
         t.len += length(n)
     end
-    push!(t.nodes, n)
+    push!(tnodes, n)
     nothing
 end
 
 @inline function is_prev_newline(fst::FST)
     if fst.typ === NEWLINE
         return true
-    elseif is_leaf(fst) || length(fst.nodes) == 0
+    elseif is_leaf(fst) || length(fst.nodes::Vector) == 0
         return false
     end
     is_prev_newline(fst[end])
@@ -708,8 +709,9 @@ Returns the length to any node type in `ntyps` based off the `start` index.
     fst.typ in ntyps && return 0, true
     is_leaf(fst) && return length(fst), false
     len = 0
-    for i in start:length(fst.nodes)
-        l, found = length_to(fst.nodes[i], ntyps)
+    nodes = fst.nodes::Vector
+    for i in start:length(nodes)
+        l, found = length_to(nodes[i], ntyps)
         len += l
         found && return len, found
     end
@@ -1025,7 +1027,7 @@ function op_kind(fst::FST)
     if fst.typ === OPERATOR
         return fst.metadata.op_kind
     elseif is_opcall(fst)
-        idx = findfirst(n -> n.typ === OPERATOR, fst.nodes)
+        idx = findfirst(n -> n.typ === OPERATOR, fst.nodes::Vector)
         idx === nothing && return nothing
         return fst[idx].metadata.op_kind
     end
@@ -1122,7 +1124,7 @@ for i = 1:10 body end
 """
 function eq_to_in_normalization!(fst::FST, always_for_in::Bool, for_in_replacement::String)
     if fst.typ === Binary
-        idx = findfirst(n -> n.typ === OPERATOR, fst.nodes)
+        idx = findfirst(n -> n.typ === OPERATOR, fst.nodes::Vector)
         idx === nothing && return
         op = fst[idx]
 
@@ -1140,7 +1142,7 @@ function eq_to_in_normalization!(fst::FST, always_for_in::Bool, for_in_replaceme
         end
     elseif fst.typ === Block || fst.typ === Brackets || fst.typ === Filter
         past_if = false
-        for (i, n) in enumerate(fst.nodes)
+        for (i, n) in enumerate(fst.nodes::Vector)
             if n.typ === KEYWORD && n.val == "if"
                 # [x for x in xs if x in 1:length(ys)]
                 # we do not want to convert the binary operations after an "if" keyword.

--- a/src/nest_utils.jl
+++ b/src/nest_utils.jl
@@ -36,7 +36,7 @@ should return a value other than `nothing`.
 function walk(f, fst::FST, s::State)
     stop = f(fst, s)
     (stop !== nothing || is_leaf(fst)) && return
-    walk(f, fst.nodes, s, fst.indent)
+    walk(f, fst.nodes::Vector, s, fst.indent)
 end
 
 function increment_line_offset!(fst::FST, s::State)
@@ -164,7 +164,7 @@ function nest_if_over_margin!(
     end
 
     if margin > s.opts.margin ||
-       (idx < length(fst.nodes) && is_comment(fst[idx+1])) ||
+       (idx < length(fst.nodes::Vector) && is_comment(fst[idx+1])) ||
        (idx > 1 && is_comment(fst[idx-1]))
         fst[idx] = Newline(length = fst[idx].len)
         s.line_offset = fst.indent

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -24,7 +24,7 @@ function flatten_binaryopcall(fst::FST; top = true)
     rhs_kind = op_kind(rhs)
     lhs_same_op = lhs_kind === kind
     rhs_same_op = rhs_kind === kind
-    idx = findlast(n -> n.typ === PLACEHOLDER, fst.nodes)
+    idx = findlast(n -> n.typ === PLACEHOLDER, fst.nodes::Vector)
 
     if (top && !lhs_same_op && !rhs_same_op) || idx === nothing
         return nodes
@@ -51,7 +51,7 @@ end
 
 function flatten_conditionalopcall(fst::FST)
     nodes = FST[]
-    for n in fst.nodes
+    for n in fst.nodes::Vector
         if n.typ === Conditional
             push!(nodes, flatten_conditionalopcall(n)...)
         else
@@ -63,7 +63,7 @@ end
 
 function flatten_fst!(fst::FST)
     is_leaf(fst) && return
-    for n in fst.nodes
+    for n in fst.nodes::Vector
         if is_leaf(n)
             continue
         elseif n.typ === Binary && flattenable(op_kind(n))
@@ -95,7 +95,7 @@ function pipe_to_function_call_pass!(fst::FST)
         fst.typ = Call
         return
     end
-    for n in fst.nodes
+    for n in fst.nodes::Vector
         if is_leaf(n)
             continue
         elseif op_kind(n) === Tokens.RPIPE && (n[end].typ !== PUNCTUATION)
@@ -167,12 +167,13 @@ function pipe_to_function_call(fst::FST)
 end
 
 function import_to_usings(fst::FST, s::State)
-    findfirst(n -> is_colon(n) || n.typ === As, fst.nodes) === nothing || return FST[]
+    nodes = fst.nodes::Vector
+    findfirst(n -> is_colon(n) || n.typ === As, nodes) === nothing || return FST[]
     findfirst(n -> n.typ === PUNCTUATION && n.val == ".", fst[3].nodes) === nothing ||
         return FST[]
 
     usings = FST[]
-    idxs = findall(n -> !is_leaf(n), fst.nodes)
+    idxs = findall(n -> !is_leaf(n), nodes)
 
     for i in idxs
         n = fst[i]
@@ -206,7 +207,7 @@ no type annotation is provided.
 """
 function annotate_typefields_with_any!(fst::FST, s::State)
     is_leaf(fst) && return
-    for (i, n) in enumerate(fst.nodes)
+    for (i, n) in enumerate(fst.nodes::Vector)
         if n.typ === IDENTIFIER
             nn = FST(Binary, n.indent)
             nn.startline = n.startline
@@ -319,22 +320,23 @@ f(arg1, arg2) = body
 ```
 """
 function long_to_short_function_def!(fst::FST, s::State)
-    any(is_comment, fst.nodes) && return false
+    nodes = fst.nodes::Vector
+    any(is_comment, nodes) && return false
 
-    I = findall(n -> n.typ === Block, fst.nodes)
+    I = findall(n -> n.typ === Block, nodes)
     length(I) == 1 || return false  # function must have a single block
 
-    block = fst.nodes[first(I)]
+    block = nodes[first(I)]
     length(block.nodes) == 1 || return false  # block must have a single statement
 
-    I = findfirst(n -> n.typ === Call || n.typ === Where, fst.nodes)
+    I = findfirst(n -> n.typ === Call || n.typ === Where, nodes)
     I === nothing && return false
-    lhs = fst.nodes[I]
+    lhs = nodes[I]
 
     rhs = first(block.nodes)
 
     if rhs.typ === Return
-        I = findall(!is_custom_leaf, fst.nodes)
+        I = findall(!is_custom_leaf, nodes)
         length(I) < 2 && return false
         popfirst!(I)  # remove leading `return` keyword
         rhs = rhs.nodes[first(I)]
@@ -454,7 +456,8 @@ function prepend_return!(fst::FST, s::State)
     ln.typ === MacroCall && return
     ln.typ === MacroBlock && return
     ln.typ === MacroStr && return
-    if length(fst.nodes) > 2 && (fst[end-2].typ === MacroStr || is_macrodoc(fst[end-2]))
+    if length(fst.nodes::Vector) > 2 &&
+       (fst[end-2].typ === MacroStr || is_macrodoc(fst[end-2]))
         # The last node is has a docstring prior to it so a return should not be prepended
         # fst[end-1] is a newline
         return
@@ -552,11 +555,12 @@ function conditional_to_if_block!(fst::FST, s::State; top = true)
     add_node!(t, Whitespace(1), s, join_lines = true)
     add_node!(t, fst[1], s, join_lines = true)
 
-    idx1 = findfirst(n -> n.typ === OPERATOR && n.val == "?", fst.nodes)
-    idx2 = findfirst(n -> n.typ === OPERATOR && n.val == ":", fst.nodes)
+    nodes = fst.nodes::Vector
+    idx1 = findfirst(n -> n.typ === OPERATOR && n.val == "?", nodes)
+    idx2 = findfirst(n -> n.typ === OPERATOR && n.val == ":", nodes)
 
     block1 = FST(Block, fst.indent + s.opts.indent)
-    for n in fst.nodes[idx1+1:idx2-1]
+    for n in nodes[idx1+1:idx2-1]
         if n.typ === PLACEHOLDER ||
            n.typ === WHITESPACE ||
            n.typ === NEWLINE ||
@@ -620,12 +624,13 @@ a = f(; x = 1, y = 2)
 ```
 """
 function separate_kwargs_with_semicolon!(fst::FST)
-    kw_idx = findfirst(n -> n.typ === Kw, fst.nodes)
+    nodes = fst.nodes::Vector
+    kw_idx = findfirst(n -> n.typ === Kw, nodes)
     kw_idx === nothing && return
-    sc_idx = findfirst(n -> n.typ === SEMICOLON, fst.nodes)
+    sc_idx = findfirst(n -> n.typ === SEMICOLON, nodes)
     # first "," prior to a kwarg
-    comma_idx = findlast(is_comma, fst.nodes[1:kw_idx-1])
-    ph_idx = findlast(n -> n.typ === PLACEHOLDER, fst.nodes[1:kw_idx-1])
+    comma_idx = findlast(is_comma, nodes[1:kw_idx-1])
+    ph_idx = findlast(n -> n.typ === PLACEHOLDER, nodes[1:kw_idx-1])
 
     if sc_idx !== nothing && sc_idx > kw_idx
         # move ; prior to first kwarg
@@ -666,9 +671,10 @@ Soft deletes `WHITESPACE` or `PLACEHOLDER` that's directly followed by a `NEWLIN
 """
 function remove_superfluous_whitespace!(fst::FST)
     is_leaf(fst) && return
-    for (i, n) in enumerate(fst.nodes)
+    nodes = fst.nodes::Vector
+    for (i, n) in enumerate(nodes)
         if (n.typ === WHITESPACE || n.typ === PLACEHOLDER || n.typ === NEWLINE) &&
-           i < length(fst.nodes) &&
+           i < length(nodes) &&
            (fst[i+1].typ === NEWLINE || fst[i+1].typ === INLINECOMMENT)
             fst[i] = Whitespace(0)
         else

--- a/src/styles/blue/nest.jl
+++ b/src/styles/blue/nest.jl
@@ -1,15 +1,16 @@
 function n_tuple!(bs::BlueStyle, fst::FST, s::State)
     style = getstyle(bs)
     line_margin = s.line_offset + length(fst) + fst.extra_margin
-    lidx = findlast(n -> n.typ === PLACEHOLDER, fst.nodes)
-    fidx = findfirst(n -> n.typ === PLACEHOLDER, fst.nodes)
-    multiline_arg = findfirst(is_block, fst.nodes) !== nothing
+    nodes = fst.nodes::Vector
+    lidx = findlast(n -> n.typ === PLACEHOLDER, nodes)
+    fidx = findfirst(n -> n.typ === PLACEHOLDER, nodes)
+    multiline_arg = findfirst(is_block, nodes) !== nothing
     multiline_arg && (fst.nest_behavior = AlwaysNest)
     has_closer = is_closer(fst[end])
 
     # "foo(a, b, c)" is true if "foo" and "c" are on different lines
     src_diff_line = if s.opts.join_lines_based_on_source
-        last_arg_idx = findlast(is_iterable_arg, fst.nodes)
+        last_arg_idx = findlast(is_iterable_arg, nodes)
         last_arg = last_arg_idx === nothing ? fst[end] : fst[last_arg_idx]
         fst[1].endline != last_arg.startline
     else
@@ -17,12 +18,13 @@ function n_tuple!(bs::BlueStyle, fst::FST, s::State)
     end
 
     if lidx !== nothing && (line_margin > s.opts.margin || must_nest(fst) || src_diff_line)
+        fidx = fidx::Int
         args_range = fidx+1:lidx-1
         args_margin = sum(length.(fst[args_range]))
 
         nest_to_oneline =
             if can_nest(fst) && (fst.indent + s.opts.indent + args_margin <= s.opts.margin)
-                !contains_comment(fst.nodes[args_range])
+                !contains_comment(nodes[args_range])
             else
                 false
             end
@@ -36,14 +38,14 @@ function n_tuple!(bs::BlueStyle, fst::FST, s::State)
                 1
             elseif is_opener(fst[1])
                 # (...)
-                findfirst(is_iterable_arg, fst.nodes)
+                findfirst(is_iterable_arg, nodes)
             else
                 # f(...)
-                findnext(is_iterable_arg, fst.nodes, 2)
+                findnext(is_iterable_arg, nodes, 2)
             end
             first_arg = first_arg_idx === nothing ? fst[1] : fst[first_arg_idx]
             # last arg
-            last_arg_idx = findlast(is_iterable_arg, fst.nodes)
+            last_arg_idx = findlast(is_iterable_arg, nodes)
             last_arg = last_arg_idx === nothing ? fst[end] : fst[last_arg_idx]
 
             first_arg.endline != last_arg.startline
@@ -61,7 +63,7 @@ function n_tuple!(bs::BlueStyle, fst::FST, s::State)
 
         add_trailing_comma = (src_nest && args_diff_line) || (!src_nest && !nest_to_oneline)
 
-        for (i, n) in enumerate(fst.nodes)
+        for (i, n) in enumerate(nodes)
             if n.typ === NEWLINE
                 s.line_offset = fst.indent
             elseif (i == fidx || i == lidx) && !src_diff_line && nest_to_oneline
@@ -71,7 +73,7 @@ function n_tuple!(bs::BlueStyle, fst::FST, s::State)
                 if src_diff_line
                     si = findnext(
                         n -> n.typ === PLACEHOLDER || n.typ === NEWLINE,
-                        fst.nodes,
+                        nodes,
                         i + 1,
                     )
                     nested = nest_if_over_margin!(style, fst, s, i; stop_idx = si)
@@ -105,13 +107,13 @@ function n_tuple!(bs::BlueStyle, fst::FST, s::State)
                 n.val = ""
                 n.len = 0
                 nest!(style, n, s)
-            elseif has_closer && (i == 1 || i == length(fst.nodes))
+            elseif has_closer && (i == 1 || i == length(nodes))
                 nest!(style, n, s)
             else
                 diff = fst.indent - fst[i].indent
                 add_indent!(n, s, diff)
                 n.extra_margin =
-                    !nest_to_oneline ? 1 : i < length(fst.nodes) ? length(fst[i+1]) : 0
+                    !nest_to_oneline ? 1 : i < length(nodes) ? length(fst[i+1]) : 0
                 nest!(style, n, s)
             end
         end
@@ -123,7 +125,7 @@ function n_tuple!(bs::BlueStyle, fst::FST, s::State)
     else
         extra_margin = fst.extra_margin
         has_closer && (extra_margin += 1)
-        nest!(style, fst.nodes, s, fst.indent, extra_margin = extra_margin)
+        nest!(style, nodes, s, fst.indent, extra_margin = extra_margin)
     end
 end
 @inline n_call!(bs::BlueStyle, fst::FST, s::State) = n_tuple!(bs, fst, s)

--- a/src/styles/blue/pretty.jl
+++ b/src/styles/blue/pretty.jl
@@ -101,7 +101,7 @@ function p_binaryopcall(
 
     nonest = nonest || CSTParser.is_colon(op)
 
-    if CSTParser.iscurly(cst.parent) &&
+    if CSTParser.iscurly(cst.parent::CSTParser.EXPR) &&
        (op.val == "<:" || op.val == ">:") &&
        !s.opts.whitespace_typedefs
         nospace = true
@@ -184,7 +184,8 @@ function p_binaryopcall(
 
     if nest
         # for indent, will be converted to `indent` if needed
-        insert!(t.nodes, length(t.nodes), Placeholder(0))
+        nodes = t.nodes::Vector
+        insert!(nodes, length(nodes), Placeholder(0))
     end
 
     t

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -140,12 +140,12 @@ function nest!(ds::DefaultStyle, fst::FST, s::State)
         n_for!(style, fst, s)
     elseif fst.typ === Let
         n_let!(style, fst, s)
-    elseif fst.typ === Unary && length(fst.nodes) > 1 && fst[2].typ === OPERATOR
+    elseif fst.typ === Unary && length(fst.nodes::Vector) > 1 && fst[2].typ === OPERATOR
         n_unaryopcall!(style, fst, s)
     elseif fst.typ === StringN
         n_string!(style, fst, s)
     else
-        nest!(style, fst.nodes, s, fst.indent, extra_margin = fst.extra_margin)
+        nest!(style, fst.nodes::Vector, s, fst.indent, extra_margin = fst.extra_margin)
     end
 end
 nest!(style::S, fst::FST, s::State) where {S<:AbstractStyle} =
@@ -157,7 +157,7 @@ function n_string!(ds::DefaultStyle, fst::FST, s::State)
     # from the source document to the formatted document
     diff = s.line_offset - fst.indent
 
-    for (i, n) in enumerate(fst.nodes)
+    for (i, n) in enumerate(fst.nodes::Vector)
         if n.typ === NEWLINE
             s.line_offset = fst[i+1].indent + diff
         else
@@ -196,7 +196,8 @@ n_do!(style::S, fst::FST, s::State) where {S<:AbstractStyle} =
 function n_using!(ds::DefaultStyle, fst::FST, s::State)
     style = getstyle(ds)
     line_margin = s.line_offset + length(fst) + fst.extra_margin
-    idx = findfirst(n -> n.typ === PLACEHOLDER, fst.nodes)
+    nodes = fst.nodes::Vector
+    idx = findfirst(n -> n.typ === PLACEHOLDER, nodes)
     fst.indent += s.opts.indent
 
     if idx !== nothing && (line_margin > s.opts.margin || must_nest(fst))
@@ -208,12 +209,12 @@ function n_using!(ds::DefaultStyle, fst::FST, s::State)
             end
         end
 
-        for (i, n) in enumerate(fst.nodes)
+        for (i, n) in enumerate(nodes)
             if n.typ === NEWLINE
                 s.line_offset = fst.indent
             elseif n.typ === PLACEHOLDER
                 if s.opts.join_lines_based_on_source
-                    si = findnext(n -> n.typ === PLACEHOLDER, fst.nodes, i + 1)
+                    si = findnext(n -> n.typ === PLACEHOLDER, nodes, i + 1)
                     nest_if_over_margin!(style, fst, s, i; stop_idx = si)
                 else
                     fst[i] = Newline(length = n.len)
@@ -222,12 +223,12 @@ function n_using!(ds::DefaultStyle, fst::FST, s::State)
             else
                 diff = fst.indent - fst[i].indent
                 add_indent!(n, s, diff)
-                i < length(fst.nodes) && (n.extra_margin = 1)
+                i < length(nodes) && (n.extra_margin = 1)
                 nest!(style, n, s)
             end
         end
     else
-        nest!(style, fst.nodes, s, fst.indent, extra_margin = fst.extra_margin)
+        nest!(style, nodes, s, fst.indent, extra_margin = fst.extra_margin)
     end
 end
 n_using!(style::S, fst::FST, s::State) where {S<:AbstractStyle} =
@@ -244,7 +245,8 @@ n_import!(style::S, fst::FST, s::State) where {S<:AbstractStyle} =
 function n_tuple!(ds::DefaultStyle, fst::FST, s::State)
     style = getstyle(ds)
     line_margin = s.line_offset + length(fst) + fst.extra_margin
-    idx = findlast(n -> n.typ === PLACEHOLDER, fst.nodes)
+    nodes = fst.nodes::Vector
+    idx = findlast(n -> n.typ === PLACEHOLDER, nodes)
     has_closer = is_closer(fst[end])
 
     line_offset = s.line_offset
@@ -257,7 +259,7 @@ function n_tuple!(ds::DefaultStyle, fst::FST, s::State)
 
     # "foo(a, b, c)" is true if "foo" and "c" are on different lines
     src_diff_line = if s.opts.join_lines_based_on_source
-        last_arg_idx = findlast(is_iterable_arg, fst.nodes)
+        last_arg_idx = findlast(is_iterable_arg, nodes)
         last_arg = last_arg_idx === nothing ? fst[end] : fst[last_arg_idx]
         fst[1].endline != last_arg.startline
     else
@@ -265,14 +267,14 @@ function n_tuple!(ds::DefaultStyle, fst::FST, s::State)
     end
 
     if idx !== nothing && (line_margin > s.opts.margin || must_nest(fst) || src_diff_line)
-        for (i, n) in enumerate(fst.nodes)
+        for (i, n) in enumerate(nodes)
             if n.typ === NEWLINE
                 s.line_offset = fst.indent
             elseif n.typ === PLACEHOLDER
                 if src_diff_line
                     si = findnext(
                         n -> n.typ === PLACEHOLDER || n.typ === NEWLINE,
-                        fst.nodes,
+                        nodes,
                         i + 1,
                     )
                     nested = nest_if_over_margin!(style, fst, s, i; stop_idx = si)
@@ -302,7 +304,7 @@ function n_tuple!(ds::DefaultStyle, fst::FST, s::State)
                 n.val = ""
                 n.len = 0
                 nest!(style, n, s)
-            elseif has_closer && (i == 1 || i == length(fst.nodes))
+            elseif has_closer && (i == 1 || i == length(nodes))
                 nest!(style, n, s)
             else
                 diff = fst.indent - fst[i].indent
@@ -318,7 +320,7 @@ function n_tuple!(ds::DefaultStyle, fst::FST, s::State)
     else
         extra_margin = fst.extra_margin
         has_closer && (extra_margin += 1)
-        nest!(style, fst.nodes, s, fst.indent, extra_margin = extra_margin)
+        nest!(style, nodes, s, fst.indent, extra_margin = extra_margin)
     end
 
     return
@@ -387,13 +389,14 @@ function _n_comprehension!(ds::DefaultStyle, fst::FST, s::State)
 
     line_margin = s.line_offset + length(fst) + fst.extra_margin
     closer = is_closer(fst[end])
+    nodes = fst.nodes::Vector
 
     if closer && (line_margin > s.opts.margin || must_nest(fst))
-        idx = findfirst(n -> n.typ === PLACEHOLDER, fst.nodes)
+        idx = findfirst(n -> n.typ === PLACEHOLDER, nodes)
         if idx !== nothing
             fst[idx] = Newline(length = fst[idx].len)
         end
-        idx = findlast(n -> n.typ === PLACEHOLDER, fst.nodes)
+        idx = findlast(n -> n.typ === PLACEHOLDER, nodes)
         if idx !== nothing
             fst[idx] = Newline(length = fst[idx].len)
         end
@@ -403,7 +406,7 @@ function _n_comprehension!(ds::DefaultStyle, fst::FST, s::State)
         nested = true
     end
 
-    for (i, n) in enumerate(fst.nodes)
+    for (i, n) in enumerate(nodes)
         if n.typ === NEWLINE
             s.line_offset = fst.indent
         elseif n.typ === PLACEHOLDER
@@ -413,7 +416,7 @@ function _n_comprehension!(ds::DefaultStyle, fst::FST, s::State)
             else
                 nest_if_over_margin!(style, fst, s, i)
             end
-        elseif i == length(fst.nodes) && !closer
+        elseif i == length(nodes) && !closer
             nest!(style, n, s)
         else
             n.extra_margin = nested ? 0 : 1
@@ -440,8 +443,9 @@ function n_generator!(ds::DefaultStyle, fst::FST, s::State; indent = -1)
     line_offset = s.line_offset
     fst.indent = s.line_offset
 
+    nodes = fst.nodes::Vector
     if line_margin > s.opts.margin || must_nest(fst) || s.opts.join_lines_based_on_source
-        phs = reverse(findall(n -> n.typ === PLACEHOLDER, fst.nodes))
+        phs = reverse(findall(n -> n.typ === PLACEHOLDER, nodes))
         if s.opts.join_lines_based_on_source
             phs = filter(idx -> fst[idx+1].typ !== NEWLINE, phs)
         end
@@ -459,10 +463,10 @@ function n_generator!(ds::DefaultStyle, fst::FST, s::State; indent = -1)
             end
         end
 
-        for (i, n) in enumerate(fst.nodes)
+        for (i, n) in enumerate(nodes)
             if n.typ === NEWLINE
                 s.line_offset = fst.indent
-            elseif i == length(fst.nodes)
+            elseif i == length(nodes)
                 nest!(style, n, s)
             else
                 n.extra_margin = 1
@@ -471,7 +475,7 @@ function n_generator!(ds::DefaultStyle, fst::FST, s::State; indent = -1)
         end
 
         s.line_offset = line_offset
-        for (i, n) in enumerate(fst.nodes)
+        for (i, n) in enumerate(nodes)
             if n.typ === NEWLINE &&
                !is_comment(fst[i+1]) &&
                !is_comment(fst[i-1]) &&
@@ -496,7 +500,7 @@ function n_generator!(ds::DefaultStyle, fst::FST, s::State; indent = -1)
         s.line_offset = line_offset
         walk(increment_line_offset!, fst, s)
     else
-        nest!(style, fst.nodes, s, fst.indent, extra_margin = fst.extra_margin)
+        nest!(style, nodes, s, fst.indent, extra_margin = fst.extra_margin)
     end
 end
 
@@ -561,7 +565,7 @@ function n_whereopcall!(ds::DefaultStyle, fst::FST, s::State)
         return
     end
 
-    nest!(style, fst.nodes, s, fst.indent, extra_margin = fst.extra_margin)
+    nest!(style, fst.nodes::Vector, s, fst.indent, extra_margin = fst.extra_margin)
     return
 end
 n_whereopcall!(style::S, fst::FST, s::State) where {S<:AbstractStyle} =
@@ -573,8 +577,9 @@ function n_conditionalopcall!(ds::DefaultStyle, fst::FST, s::State)
     line_offset = s.line_offset
     fst.indent = s.line_offset
 
+    nodes = fst.nodes::Vector
     if line_margin > s.opts.margin || must_nest(fst) || s.opts.join_lines_based_on_source
-        phs = reverse(findall(n -> n.typ === PLACEHOLDER, fst.nodes))
+        phs = reverse(findall(n -> n.typ === PLACEHOLDER, nodes))
         if s.opts.join_lines_based_on_source
             phs = filter(idx -> fst[idx+1].typ !== NEWLINE, phs)
         end
@@ -592,8 +597,8 @@ function n_conditionalopcall!(ds::DefaultStyle, fst::FST, s::State)
             end
         end
 
-        for (i, n) in enumerate(fst.nodes)
-            if i == length(fst.nodes)
+        for (i, n) in enumerate(nodes)
+            if i == length(nodes)
                 n.extra_margin = fst.extra_margin
                 nest!(style, n, s)
             elseif fst[i+1].typ === WHITESPACE
@@ -607,14 +612,14 @@ function n_conditionalopcall!(ds::DefaultStyle, fst::FST, s::State)
         end
 
         s.line_offset = line_offset
-        for (i, n) in enumerate(fst.nodes)
+        for (i, n) in enumerate(nodes)
             if n.typ === NEWLINE &&
                !is_comment(fst[i+1]) &&
                !is_comment(fst[i-1]) &&
                i in phs
                 # +1 for newline to whitespace conversion
                 width = s.line_offset + 1
-                if i == length(fst.nodes) - 1
+                if i == length(nodes) - 1
                     width += sum(length.(fst[i+1:end])) + fst.extra_margin
                 else
                     width += sum(length.(fst[i+1:i+3]))
@@ -635,7 +640,7 @@ function n_conditionalopcall!(ds::DefaultStyle, fst::FST, s::State)
         s.line_offset = line_offset
         walk(increment_line_offset!, fst, s)
     else
-        nest!(style, fst.nodes, s, fst.indent, extra_margin = fst.extra_margin)
+        nest!(style, nodes, s, fst.indent, extra_margin = fst.extra_margin)
     end
 end
 n_conditionalopcall!(style::S, fst::FST, s::State) where {S<:AbstractStyle} =
@@ -657,7 +662,8 @@ function n_binaryopcall!(ds::DefaultStyle, fst::FST, s::State; indent::Int = -1)
     line_margin = line_offset + length(fst) + fst.extra_margin
 
     # If there's no placeholder the binary call is not nestable
-    idxs = findall(n -> n.typ === PLACEHOLDER, fst.nodes)
+    nodes = fst.nodes::Vector
+    idxs = findall(n -> n.typ === PLACEHOLDER, nodes)
 
     rhs = fst[end]
     rhs.typ === Block && (rhs = rhs[1])
@@ -757,13 +763,13 @@ function n_binaryopcall!(ds::DefaultStyle, fst::FST, s::State; indent::Int = -1)
     # length of op and surrounding whitespace
     oplen = sum(length.(fst[2:end]))
 
-    for (i, n) in enumerate(fst.nodes)
+    for (i, n) in enumerate(nodes)
         if n.typ === NEWLINE
             s.line_offset = fst.indent
         elseif i == 1
             n.extra_margin = oplen + fst.extra_margin
             nest!(style, n, s)
-        elseif i == length(fst.nodes)
+        elseif i == length(nodes)
             n.extra_margin = fst.extra_margin
             nest!(style, n, s)
         else
@@ -776,7 +782,7 @@ n_binaryopcall!(style::S, fst::FST, s::State; indent = -1) where {S<:AbstractSty
 
 function n_for!(ds::DefaultStyle, fst::FST, s::State)
     style = getstyle(ds)
-    nest!(style, fst.nodes, s, fst.indent, extra_margin = fst.extra_margin)
+    nest!(style, fst.nodes::Vector, s, fst.indent, extra_margin = fst.extra_margin)
 end
 n_for!(style::S, fst::FST, s::State) where {S<:AbstractStyle} =
     n_for!(DefaultStyle(style), fst, s)
@@ -788,7 +794,8 @@ n_let!(style::S, fst::FST, s::State) where {S<:AbstractStyle} =
 function n_block!(ds::DefaultStyle, fst::FST, s::State; indent = -1)
     style = getstyle(ds)
     line_margin = s.line_offset + length(fst) + fst.extra_margin
-    idx = findfirst(n -> n.typ === PLACEHOLDER, fst.nodes)
+    nodes = fst.nodes::Vector
+    idx = findfirst(n -> n.typ === PLACEHOLDER, nodes)
     line_offset = s.line_offset
     has_nl = false
     indent >= 0 && (fst.indent = indent)
@@ -799,7 +806,7 @@ function n_block!(ds::DefaultStyle, fst::FST, s::State; indent = -1)
 
     if idx !== nothing &&
        (line_margin > s.opts.margin || must_nest(fst) || s.opts.join_lines_based_on_source)
-        for (i, n) in enumerate(fst.nodes)
+        for (i, n) in enumerate(nodes)
             if n.typ === NEWLINE
                 s.line_offset = fst.indent
                 has_nl = true
@@ -823,10 +830,10 @@ function n_block!(ds::DefaultStyle, fst::FST, s::State; indent = -1)
                 # end
                 #
                 if s.opts.join_lines_based_on_source
-                    if i < length(fst.nodes)
+                    if i < length(nodes)
                         si = findnext(
                             n -> n.typ === PLACEHOLDER || n.typ === NEWLINE,
-                            fst.nodes,
+                            nodes,
                             i + 1,
                         )
                         nest_if_over_margin!(style, fst, s, i; stop_idx = si)
@@ -848,11 +855,11 @@ function n_block!(ds::DefaultStyle, fst::FST, s::State; indent = -1)
             else
                 diff = fst.indent - fst[i].indent
                 add_indent!(n, s, diff)
-                if i < length(fst.nodes) - 1 && fst[i+2].typ === OPERATOR
+                if i < length(nodes) - 1 && fst[i+2].typ === OPERATOR
                     # chainopcall / comparison
                     n.extra_margin = 1 + length(fst[i+2])
-                elseif i < length(fst.nodes)
-                    if !(i == length(fst.nodes) - 1 && fst[i+1].typ === PLACEHOLDER)
+                elseif i < length(nodes)
+                    if !(i == length(nodes) - 1 && fst[i+1].typ === PLACEHOLDER)
                         n.extra_margin = 1
                     end
                 end
@@ -860,7 +867,7 @@ function n_block!(ds::DefaultStyle, fst::FST, s::State; indent = -1)
             end
         end
     else
-        nest!(style, fst.nodes, s, fst.indent, extra_margin = fst.extra_margin)
+        nest!(style, nodes, s, fst.indent, extra_margin = fst.extra_margin)
     end
     return
 end

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1734,8 +1734,9 @@ function p_unaryopcall(ds::DefaultStyle, cst::CSTParser.EXPR, s::State; nospace 
     style = getstyle(ds)
     t = FST(Unary, cst, nspaces(s))
     if length(cst) == 1
-        if cst.head.fullspan != 0
-            add_node!(t, pretty(style, cst.head, s), s, join_lines = true)
+        head = cst.head::CSTParser.EXPR
+        if head.fullspan != 0
+            add_node!(t, pretty(style, head, s), s, join_lines = true)
         end
         add_node!(t, pretty(style, cst[1], s), s, join_lines = true)
     else

--- a/src/styles/sciml/nest.jl
+++ b/src/styles/sciml/nest.jl
@@ -45,6 +45,6 @@ function n_binaryopcall!(ss::SciMLStyle, fst::FST, s::State; indent::Int = -1)
     end
 
     start_line_offset = s.line_offset
-    walk(increment_line_offset!, fst.nodes[1:end-1], s, fst.indent)
+    walk(increment_line_offset!, (fst.nodes::Vector)[1:end-1], s, fst.indent)
     nest!(style, fst[end], s)
 end

--- a/src/styles/sciml/pretty.jl
+++ b/src/styles/sciml/pretty.jl
@@ -54,7 +54,7 @@ end
 
 function is_binaryop_nestable(::SciMLStyle, cst::CSTParser.EXPR)
     (CSTParser.defines_function(cst) || is_assignment(cst)) && return false
-    (cst[2].val in ("=>", "->", "in")) && return false
+    ((cst[2]::CSTParser.EXPR).val in ("=>", "->", "in")) && return false
     return true
 end
 

--- a/src/styles/yas/nest.jl
+++ b/src/styles/yas/nest.jl
@@ -3,7 +3,8 @@ function n_call!(ys::YASStyle, fst::FST, s::State)
 
     f = n -> n.typ === PLACEHOLDER || n.typ === NEWLINE
 
-    for (i, n) in enumerate(fst.nodes)
+    nodes = fst.nodes::Vector
+    for (i, n) in enumerate(nodes)
         if i == 3
             # The indent is set here to handle the edge
             # case where the first argument of Call is
@@ -15,7 +16,7 @@ function n_call!(ys::YASStyle, fst::FST, s::State)
         if n.typ === NEWLINE
             s.line_offset = fst.indent
         elseif n.typ === PLACEHOLDER
-            si = findnext(f, fst.nodes, i + 1)
+            si = findnext(f, nodes, i + 1)
             nest_if_over_margin!(style, fst, s, i; stop_idx = si)
         elseif n.typ === TRAILINGSEMICOLON
             n.val = ""
@@ -42,15 +43,16 @@ end
 function n_tuple!(ys::YASStyle, fst::FST, s::State)
     style = getstyle(ys)
     fst.indent = s.line_offset
-    length(fst.nodes) > 0 && is_opener(fst[1]) && (fst.indent += 1)
+    nodes = fst.nodes::Vector
+    length(nodes) > 0 && is_opener(fst[1]) && (fst.indent += 1)
 
     f = n -> n.typ === PLACEHOLDER || n.typ === NEWLINE
 
-    for (i, n) in enumerate(fst.nodes)
+    for (i, n) in enumerate(nodes)
         if n.typ === NEWLINE
             s.line_offset = fst.indent
         elseif n.typ === PLACEHOLDER
-            si = findnext(f, fst.nodes, i + 1)
+            si = findnext(f, nodes, i + 1)
             nest_if_over_margin!(style, fst, s, i; stop_idx = si)
         elseif n.typ === TRAILINGSEMICOLON
             n.val = ""
@@ -85,11 +87,12 @@ function n_generator!(ys::YASStyle, fst::FST, s::State)
     # expression
     add_indent!(fst[1], s, diff)
 
-    for (i, n) in enumerate(fst.nodes)
+    nodes = fst.nodes::Vector
+    for (i, n) in enumerate(nodes)
         if n.typ === NEWLINE
             s.line_offset = fst.indent
         elseif n.typ === PLACEHOLDER
-            si = findnext(n -> n.typ === PLACEHOLDER, fst.nodes, i + 1)
+            si = findnext(n -> n.typ === PLACEHOLDER, nodes, i + 1)
             nest_if_over_margin!(style, fst, s, i; stop_idx = si)
         elseif is_gen(n)
             n.indent = fst.indent
@@ -111,16 +114,17 @@ function n_whereopcall!(ys::YASStyle, fst::FST, s::State)
     Blen = sum(length.(fst[2:end]))
     fst[1].extra_margin = Blen + fst.extra_margin
 
-    for (i, n) in enumerate(fst.nodes)
+    nodes = fst.nodes::Vector
+    for (i, n) in enumerate(nodes)
         if n.typ === NEWLINE
             s.line_offset = fst.indent
         elseif n.typ === PLACEHOLDER
-            si = findnext(n -> n.typ === PLACEHOLDER, fst.nodes, i + 1)
+            si = findnext(n -> n.typ === PLACEHOLDER, nodes, i + 1)
             nest_if_over_margin!(style, fst, s, i; stop_idx = si)
         elseif is_opener(n) && n.val == "{"
             fst.indent = s.line_offset + 1
             nest!(style, n, s)
-        elseif i == 1 || i == length(fst.nodes)
+        elseif i == 1 || i == length(nodes)
             nest!(style, n, s)
         else
             n.extra_margin = 1
@@ -131,16 +135,17 @@ end
 
 function n_using!(ys::YASStyle, fst::FST, s::State)
     style = getstyle(ys)
-    idx = findfirst(n -> n.val == ":", fst.nodes)
+    nodes = fst.nodes::Vector
+    idx = findfirst(n -> n.val == ":", nodes)
     fst.indent = s.line_offset
     if idx === nothing
         fst.indent += sum(length.(fst[1:2]))
     else
         fst.indent += sum(length.(fst[1:idx+1]))
     end
-    for (i, n) in enumerate(fst.nodes)
+    for (i, n) in enumerate(nodes)
         if n.typ === PLACEHOLDER
-            si = findnext(n -> n.typ === PLACEHOLDER, fst.nodes, i + 1)
+            si = findnext(n -> n.typ === PLACEHOLDER, nodes, i + 1)
             nest_if_over_margin!(style, fst, s, i; stop_idx = si)
         elseif n.typ === NEWLINE
             s.line_offset = fst.indent
@@ -164,30 +169,32 @@ end
 
 function n_binaryopcall!(ys::YASStyle, fst::FST, s::State; indent::Int = -1)
     style = getstyle(ys)
-    if findfirst(n -> n.typ === PLACEHOLDER, fst.nodes) !== nothing
+    nodes = fst.nodes::Vector
+    if findfirst(n -> n.typ === PLACEHOLDER, nodes) !== nothing
         n_binaryopcall!(DefaultStyle(style), fst, s; indent = indent)
         return
     end
 
     start_line_offset = s.line_offset
-    walk(increment_line_offset!, fst.nodes[1:end-1], s, fst.indent)
+    walk(increment_line_offset!, nodes[1:end-1], s, fst.indent)
     nest!(style, fst[end], s)
 end
 
 function n_for!(ys::YASStyle, fst::FST, s::State)
     style = getstyle(ys)
-    block_idx = findfirst(n -> !is_leaf(n), fst.nodes)
+    nodes = fst.nodes::Vector
+    block_idx = findfirst(n -> !is_leaf(n), nodes)
     if block_idx === nothing || length(fst[block_idx]) == 0
-        nest!(style, fst.nodes, s, fst.indent, extra_margin = fst.extra_margin)
+        nest!(style, nodes, s, fst.indent, extra_margin = fst.extra_margin)
         return
     end
 
-    ph_idx = findfirst(n -> n.typ === PLACEHOLDER, fst[block_idx].nodes)
-    for (i, n) in enumerate(fst.nodes)
-        if n.typ === NEWLINE && fst.nodes[i+1].typ === Block
-            s.line_offset = fst.nodes[i+1].indent
-        elseif n.typ === NOTCODE && fst.nodes[i+1].typ === Block
-            s.line_offset = fst.nodes[i+1].indent
+    ph_idx = findfirst(n -> n.typ === PLACEHOLDER, fst[block_idx].nodes::Vector)
+    for (i, n) in enumerate(nodes)
+        if n.typ === NEWLINE && nodes[i+1].typ === Block
+            s.line_offset = nodes[i+1].indent
+        elseif n.typ === NOTCODE && nodes[i+1].typ === Block
+            s.line_offset = nodes[i+1].indent
         elseif n.typ === NEWLINE
             s.line_offset = fst.indent
         else


### PR DESCRIPTION
This commit fixes type instabilities found by JET:

> from the root of this package
```julia
julia> using JET

julia> report_package(; target_defined_modules=true)
[...]
```
(I recommend using the nightly for this)

This commit reduces the reported number 187 from 84. There are still some issues remaining, but they are easy to be fixed using the same method or by an alternative like converting all `length(fst.nodes)` to `length(fst)`.