### PR TITLE
fix append! ntuple specializations

### DIFF
--- a/src/fst.jl
+++ b/src/fst.jl
@@ -418,7 +418,7 @@ function get_args(args::Union{Vector{Any},Vector{CSTParser.EXPR}})
             continue
         end
         if a.head === :parameters
-            push!(args0, get_args(a)...)
+            append!(args0, get_args(a))
         else
             push!(args0, a)
         end

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -31,16 +31,16 @@ function flatten_binaryopcall(fst::FST; top = true)
     end
 
     if lhs_same_op
-        push!(nodes, flatten_binaryopcall(lhs, top = false)...)
+        append!(nodes, flatten_binaryopcall(lhs, top = false))
     else
         flatten_fst!(lhs)
         push!(nodes, lhs)
     end
     # everything except the indentation placeholder
-    push!(nodes, fst[2:idx-1]...)
+    append!(nodes, fst[2:idx-1])
 
     if rhs_same_op
-        push!(nodes, flatten_binaryopcall(rhs, top = false)...)
+        append!(nodes, flatten_binaryopcall(rhs, top = false))
     else
         flatten_fst!(rhs)
         push!(nodes, rhs)
@@ -53,7 +53,7 @@ function flatten_conditionalopcall(fst::FST)
     nodes = FST[]
     for n in fst.nodes::Vector
         if n.typ === Conditional
-            push!(nodes, flatten_conditionalopcall(n)...)
+            append!(nodes, flatten_conditionalopcall(n))
         else
             push!(nodes, n)
         end


### PR DESCRIPTION
fixes #701 

```julia
julia> methods(Base.append!, (Any, Any))[8].specializations
svec(MethodInstance for append!(::Vector{UInt32}, ::Set{UInt32}), MethodInstance for append!(::Vector{Int64}, ::BitSet), MethodInstance for append!(::Vector{Base.PkgId}, ::Base.KeySet{Base.PkgId, Dict{Base.PkgId, Module}}), MethodInstance for append!(::Vector{String}, ::Tuple{String, String}), MethodInstance for append!(::Vector{Profile.StackFrameTree{UInt64}}, ::Base.ValueIterator{Dict{UInt64, Profile.StackFrameTree{UInt64}}}), MethodInstance for append!(::Vector{NamedTuple{(:indent, :msg), Tuple{Int64, SubString{String}}}}, ::Base.Generator{Vector{SubString{String}}, Logging.var"#5#7"}), MethodInstance for append!(::Vector{String}, ::Set{String}), MethodInstance for append!(::Vector{Profile.StackFrameTree{Base.StackTraces.StackFrame}}, ::Base.ValueIterator{Dict{Base.StackTraces.StackFrame, Profile.StackFrameTree{Base.StackTraces.StackFrame}}}), MethodInstance for append!(::Vector{Any}, ::Core.SimpleVector), MethodInstance for append!(::Vector{CSTParser.EXPR}, ::Nothing), nothing, nothing)
```
