### PR TITLE
fix #703

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "1.0.25"
+version = "1.0.26"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1600,4 +1600,14 @@
         """
         @test fmt(s1, 4, 10, short_to_long_function_def = true) == s2
     end
+
+    @testset "703" begin
+        s = """
+        mutable struct A
+            const a :: Int
+            bcd     :: String
+        end
+        """
+        @test fmt(s, 4, 92, align_struct_field = true) == s
+    end
 end


### PR DESCRIPTION
There's new syntax that allows the const keyword in a struct field. Alignment should work if the keyword is present.