### PR TITLE
Functionality to unindent or noindent a section of code

### DIFF
--- a/src/print.jl
+++ b/src/print.jl
@@ -64,14 +64,21 @@ function print_tree(
     ws = repeat(" ", max(indent, 0))
     for (i, n) in enumerate(nodes)
         if n.typ === NOTCODE
+            noindent = has_noindent_block(s.doc, (n.startline, n.endline))
             if notcode_indent > -1
                 n.indent = notcode_indent
             elseif i + 1 < length(nodes) && is_end(nodes[i+2])
                 n.indent += s.opts.indent
             elseif i + 1 < length(nodes) &&
                    (nodes[i+2].typ === Block || nodes[i+2].typ === Begin)
+                if noindent
+                    add_indent!(nodes[i+2], s, -s.opts.indent)
+                end
                 n.indent = nodes[i+2].indent
             elseif i > 2 && (nodes[i-2].typ === Block || nodes[i-2].typ === Begin)
+                if noindent
+                    add_indent!(nodes[i+2], s, -s.opts.indent)
+                end
                 n.indent = nodes[i-2].indent
             end
         end

--- a/test/options.jl
+++ b/test/options.jl
@@ -2384,5 +2384,48 @@
         end
         """
         @test fmt(s) == s_
+
+        # recursive
+        s = raw"""
+        begin
+        @muladd begin
+            #! format: noindent
+            # dawdawdaw comment
+            a = 10
+            b = 20
+            begin
+               # another inent
+                z = 33
+                        begin
+                #! format: noindent
+                        s = "oh shit here we go again"
+                end
+            end
+
+            a * b
+        end
+                end
+        """
+        s_ = raw"""
+        begin
+            @muladd begin
+            #! format: noindent
+            # dawdawdaw comment
+            a = 10
+            b = 20
+            begin
+                # another inent
+                z = 33
+                begin
+                #! format: noindent
+                s = "oh shit here we go again"
+                end
+            end
+
+            a * b
+            end
+        end
+        """
+        @test fmt(s) == s_
     end
 end

--- a/test/options.jl
+++ b/test/options.jl
@@ -2323,4 +2323,66 @@
         @test fmt("1f0", trailing_zero = false) == "1f0"
         @test fmt("1.", trailing_zero = false) == "1."
     end
+
+    @testset "noindent blocks" begin
+        s = raw"""
+        begin
+        @muladd begin
+            #! format: noindent
+            # dawdawdaw comment
+            a = 10
+            b = 20
+
+            a * b
+        end
+                end
+        """
+        s_ = raw"""
+        begin
+            @muladd begin
+            #! format: noindent
+            # dawdawdaw comment
+            a = 10
+            b = 20
+
+            a * b
+            end
+        end
+        """
+        @test fmt(s) == s_
+
+        s = raw"""
+        begin
+        @muladd begin
+            #! format: noindent
+            # dawdawdaw comment
+            a = 10
+            b = 20
+            begin
+               # another inent
+                z = 33
+            end
+
+            a * b
+        end
+                end
+        """
+        s_ = raw"""
+        begin
+            @muladd begin
+            #! format: noindent
+            # dawdawdaw comment
+            a = 10
+            b = 20
+            begin
+                # another inent
+                z = 33
+            end
+
+            a * b
+            end
+        end
+        """
+        @test fmt(s) == s_
+    end
 end


### PR DESCRIPTION
Done with

```
            #! format: noindent

```

Example

```

        begin
            @muladd begin
            #! format: noindent
            # dawdawdaw comment
            a = 10
            b = 20
            begin
                # another inent
                z = 33
            end

            a * b
            end
        end
```

solves https://github.com/domluna/JuliaFormatter.jl/issues/711, #707 