### PR TITLE
Add option `yas_style_nesting` to use `YASStyle` nesting rules with `SciMLStyle`

### DIFF
--- a/docs/src/sciml_style.md
+++ b/docs/src/sciml_style.md
@@ -33,18 +33,38 @@ format("file.jl", SciMLStyle(), remove_extra_newlines=false)
 
 ## Additional Options
 
-The `SciMLStyle` supports the additional option `variable_call_indent`,
-which is set to `[]` by default.
+The `SciMLStyle` supports the additional options `variable_call_indent` and `yas_style_nesting`.
+
+The option `variable_call_indent` is set to `[]` by default.
 It allows calls without aligning to the opening parenthesis:
 
 ```julia
 # Allowed with and without `Dict in variable_call_indent`
 Dict{Int, Int}(1 => 2,
-               3 => 4)
+    3 => 4)
 
 # Allowed when `Dict in variable_call_indent`, but
 # will be changed to the first example when `Dict ∉ variable_call_indent`.
 Dict{Int, Int}(
     1 => 2,
     3 => 4)
+```
+
+The option `yas_style_nesting` is set to `false` by default.
+Setting it to `true` makes the `SciMLStyle` use the `YASStyle` nesting rules:
+
+```julia
+# With `yas_style_nesting = false`
+function my_large_function(argument1, argument2,
+    argument3, argument4,
+    argument5, x, y, z)
+    foo(x) + goo(y)
+end
+
+# With `yas_style_nesting = true`
+function my_large_function(argument1, argument2,
+                           argument3, argument4,
+                           argument5, x, y, z)
+    foo(x) + goo(y)
+end
 ```

--- a/src/options.jl
+++ b/src/options.jl
@@ -32,6 +32,7 @@ Base.@kwdef struct Options
     config_applied::Bool = false
     ignore::Vector{String} = String[]
     variable_call_indent::Vector{String} = []
+    yas_style_nesting::Bool = false
 end
 
 function needs_alignment(opts::Options)

--- a/src/styles/blue/pretty.jl
+++ b/src/styles/blue/pretty.jl
@@ -55,6 +55,7 @@ function options(style::BlueStyle)
         trailing_zero = true,
         surround_whereop_typeparameters = true,
         variable_call_indent = [],
+        yas_style_nesting = false,
     )
 end
 

--- a/src/styles/minimal/pretty.jl
+++ b/src/styles/minimal/pretty.jl
@@ -36,5 +36,6 @@ function options(style::MinimalStyle)
         separate_kwargs_with_semicolon = false,
         surround_whereop_typeparameters = false,
         variable_call_indent = [],
+        yas_style_nesting = false,
     )
 end

--- a/src/styles/sciml/nest.jl
+++ b/src/styles/sciml/nest.jl
@@ -1,3 +1,38 @@
+for f in [
+    :n_call!,
+    :n_curly!,
+    :n_ref!,
+    :n_macrocall!,
+    :n_typedcomprehension!,
+    :n_typedvcat!,
+    :n_tuple!,
+    :n_braces!,
+    :n_parameters!,
+    :n_invisbrackets!,
+    :n_comprehension!,
+    :n_vcat!,
+    :n_bracescat!,
+    :n_generator!,
+    :n_filter!,
+    :n_flatten!,
+    :n_using!,
+    :n_export!,
+    :n_import!,
+    :n_chainopcall!,
+    :n_comparison!,
+    :n_for!,
+    #:n_vect!
+]
+    @eval function $f(ss::SciMLStyle, fst::FST, s::State)
+        style = getstyle(ss)
+        if s.opts.yas_style_nesting
+            $f(YASStyle(style), fst, s)
+        else
+            $f(DefaultStyle(style), fst, s)
+        end
+    end
+end
+
 function n_binaryopcall!(ss::SciMLStyle, fst::FST, s::State; indent::Int = -1)
     style = getstyle(ss)
     line_margin = s.line_offset + length(fst) + fst.extra_margin

--- a/src/styles/sciml/pretty.jl
+++ b/src/styles/sciml/pretty.jl
@@ -48,6 +48,7 @@ function options(style::SciMLStyle)
         separate_kwargs_with_semicolon = false,
         surround_whereop_typeparameters = true,
         variable_call_indent = [],
+        yas_style_nesting = false,
     )
 end
 

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -51,6 +51,7 @@ function options(style::YASStyle)
         indent_submodule = false,
         surround_whereop_typeparameters = true,
         variable_call_indent = [],
+        yas_style_nesting = false,
     )
 end
 

--- a/test/sciml_style.jl
+++ b/test/sciml_style.jl
@@ -76,7 +76,16 @@
     end
     """
 
-    @test format_text(str, SciMLStyle()) == formatted_str
+    formatted_str_yas_nesting = raw"""
+    function my_large_function(argument1, argument2,
+                               argument3, argument4,
+                               argument5, x, y, z)
+        foo(x) + goo(y)
+    end
+    """
+
+    @test format_text(str, SciMLStyle(), yas_style_nesting = true) ==
+          formatted_str_yas_nesting
 
     str = raw"""
     Dict{Int, Int}(1 => 2,
@@ -151,8 +160,15 @@
         3 => 4)
     """
 
+    formatted_str_yas_nesting = raw"""
+    Dict{Int, Int}(1 => 2,
+                   3 => 4)
+    """
+
     # This is already valid with `variable_call_indent`
     @test format_text(str, SciMLStyle()) == formatted_str
+    @test format_text(str, SciMLStyle(), yas_style_nesting = true) ==
+          formatted_str_yas_nesting
     @test format_text(str, SciMLStyle(), variable_call_indent = ["Dict"]) == str
 
     str = raw"""


### PR DESCRIPTION
I added a new option `yas_style_nesting`, which makes `SciMLStyle` use `YASStyle` nesting rules.
Suggestions for a better name for this option welcome.

Closes #730.