### PR TITLE
Update docs around Juno.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Check out [the docs](https://domluna.github.io/JuliaFormatter.jl/stable/) for fu
 
 For integration with other editors:
 
-  - [Atom](https://github.com/JunoLab/Atom.jl)
-  - [Emacs](https://codeberg.org/FelipeLema/julia-formatter.el)
   - [VSCode](https://github.com/singularitti/vscode-julia-formatter/)
+  - [Emacs](https://codeberg.org/FelipeLema/julia-formatter.el)
   - [Vim](https://github.com/kdheepak/JuliaFormatter.vim)
+  - [Atom (deprecated)](https://github.com/JunoLab/Atom.jl)

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -12,13 +12,6 @@ When [`format`](@ref) is called, it will look for `.JuliaFormatter.toml` in the 
 and searching _up_ the file tree until a config file is (or isn't) found.
 When found, the configurations in the file will overwrite the given options.
 
-!!! note
-
-    [Juno](https://junolab.org/), a Julia IDE that offers formatting feature using this package, also respects
-    configuration file.
-    When you use `Julia-Client: Format-Code` command, Juno will automatically search for a configuration file with the
-    same rule as `format` does from the directory of current editor.
-
 ## Basic Configuration
 
 In `.JuliaFormatter.toml`, you can specify any of the formatting options shown in [`format_text`](@ref) in TOML, e.g. if you have

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -620,7 +620,7 @@ Notice the contents of `@muladd begin` is not indented.
 
 For integration with other editors:
 
-  - [Atom](https://github.com/JunoLab/Atom.jl)
-  - [Emacs](https://codeberg.org/FelipeLema/julia-formatter.el)
   - [VSCode](https://github.com/singularitti/vscode-julia-formatter/)
+  - [Emacs](https://codeberg.org/FelipeLema/julia-formatter.el)
   - [Vim](https://github.com/kdheepak/JuliaFormatter.vim)
+  - [Atom (deprecated)](https://github.com/JunoLab/Atom.jl)


### PR DESCRIPTION
[Juno.jl](https://github.com/JunoLab/Juno.jl) is currently not well-maintained and has a limited user base; therefore, updating the documentation would be beneficial.