### PR TITLE
Fix vector nesting with `SciMLStyle` and `yas_style_nesting = true`

### DIFF
--- a/src/styles/sciml/nest.jl
+++ b/src/styles/sciml/nest.jl
@@ -183,7 +183,7 @@ for f in [
     :n_curly!,
     :n_macrocall!,
     :n_ref!,
-    :n_vect!,
+    # :n_vect!, don't use YAS style vector formatting with `yas_style_nesting = true`
     :n_braces!,
     :n_parameters!,
     :n_invisbrackets!,

--- a/src/styles/sciml/nest.jl
+++ b/src/styles/sciml/nest.jl
@@ -81,10 +81,6 @@ function _n_tuple!(ss::SciMLStyle, fst::FST, s::State)
     has_closer = is_closer(fst[end])
     start_line_offset = s.line_offset
 
-    if s.opts.yas_style_nesting && length(nodes) > 0 && is_opener(fst[1])
-        fst.indent += 1
-    end
-
     if has_closer
         fst[end].indent = fst.indent
     end
@@ -182,7 +178,7 @@ function _n_tuple!(ss::SciMLStyle, fst::FST, s::State)
 end
 
 for f in [
-    # :n_tuple!,
+    :n_tuple!,
     :n_call!,
     :n_curly!,
     :n_macrocall!,
@@ -201,11 +197,6 @@ for f in [
             _n_tuple!(style, fst, s)
         end
     end
-end
-
-function n_tuple!(ss::SciMLStyle, fst::FST, s::State)
-    style = getstyle(ss)
-    _n_tuple!(style, fst, s)
 end
 
 for f in [:n_chainopcall!, :n_comparison!, :n_for!]

--- a/src/styles/sciml/nest.jl
+++ b/src/styles/sciml/nest.jl
@@ -183,7 +183,7 @@ for f in [
     :n_curly!,
     :n_macrocall!,
     :n_ref!,
-    # :n_vect!, don't use YAS style vector formatting with `yas_style_nesting = true`
+    # :n_vect!,
     :n_braces!,
     :n_parameters!,
     :n_invisbrackets!,
@@ -196,6 +196,16 @@ for f in [
         else
             _n_tuple!(style, fst, s)
         end
+    end
+end
+
+function n_vect!(ss::SciMLStyle, fst::FST, s::State)
+    style = getstyle(ss)
+    if s.opts.yas_style_nesting
+        # Allow a line break after the opening brackets without aligning
+        n_vect!(DefaultStyle(style), fst, s)
+    else
+        _n_tuple!(style, fst, s)
     end
 end
 

--- a/src/styles/sciml/nest.jl
+++ b/src/styles/sciml/nest.jl
@@ -81,6 +81,10 @@ function _n_tuple!(ss::SciMLStyle, fst::FST, s::State)
     has_closer = is_closer(fst[end])
     start_line_offset = s.line_offset
 
+    if s.opts.yas_style_nesting && length(nodes) > 0 && is_opener(fst[1])
+        fst.indent += 1
+    end
+
     if has_closer
         fst[end].indent = fst.indent
     end
@@ -178,7 +182,7 @@ function _n_tuple!(ss::SciMLStyle, fst::FST, s::State)
 end
 
 for f in [
-    :n_tuple!,
+    # :n_tuple!,
     :n_call!,
     :n_curly!,
     :n_macrocall!,
@@ -197,6 +201,11 @@ for f in [
             _n_tuple!(style, fst, s)
         end
     end
+end
+
+function n_tuple!(ss::SciMLStyle, fst::FST, s::State)
+    style = getstyle(ss)
+    _n_tuple!(style, fst, s)
 end
 
 for f in [:n_chainopcall!, :n_comparison!, :n_for!]

--- a/src/styles/sciml/pretty.jl
+++ b/src/styles/sciml/pretty.jl
@@ -89,7 +89,7 @@ for f in [
     :p_curly,
     :p_ref,
     :p_braces,
-    :p_vect,
+    # :p_vect, don't use YAS style vector formatting with `yas_style_nesting = true`
     :p_parameters,
     :p_invisbrackets,
     :p_bracescat,

--- a/src/styles/sciml/pretty.jl
+++ b/src/styles/sciml/pretty.jl
@@ -106,11 +106,7 @@ end
 
 function p_tuple(ss::SciMLStyle, cst::CSTParser.EXPR, s::State; kwargs...)
     style = getstyle(ss)
-    if s.opts.yas_style_nesting
-        p_tuple(YASStyle(style), cst, s; kwargs...)
-    else
-        p_tuple(DefaultStyle(style), cst, s; kwargs...)
-    end
+    p_tuple(DefaultStyle(style), cst, s; kwargs...)
 end
 
 function p_tuple(ss::SciMLStyle, nodes::Vector{CSTParser.EXPR}, s::State; kwargs...)

--- a/src/styles/sciml/pretty.jl
+++ b/src/styles/sciml/pretty.jl
@@ -106,7 +106,11 @@ end
 
 function p_tuple(ss::SciMLStyle, cst::CSTParser.EXPR, s::State; kwargs...)
     style = getstyle(ss)
-    p_tuple(DefaultStyle(style), cst, s; kwargs...)
+    if s.opts.yas_style_nesting
+        p_tuple(YASStyle(style), cst, s; kwargs...)
+    else
+        p_tuple(DefaultStyle(style), cst, s; kwargs...)
+    end
 end
 
 function p_tuple(ss::SciMLStyle, nodes::Vector{CSTParser.EXPR}, s::State; kwargs...)

--- a/test/sciml_style.jl
+++ b/test/sciml_style.jl
@@ -430,62 +430,144 @@
     @test format_text(str_, SciMLStyle(), margin = 1) == str
 
     @testset "optimal nesting" begin
-        str = """
-        function foo(arg1, arg2, arg3, arg4, arg5)
-            body
-        end
-        """
+        @testset "function definition" begin
+            str = """
+            function foo(arg1, arg2, arg3, arg4, arg5)
+                body
+            end
+            """
 
-        fstr = """
-        function foo(
-                arg1, arg2, arg3, arg4, arg5)
-            body
-        end
-        """
-        @test format_text(str, SciMLStyle(), margin = 41) == fstr
-        @test format_text(str, SciMLStyle(), margin = 37) == fstr
+            fstr = """
+            function foo(
+                    arg1, arg2, arg3, arg4, arg5)
+                body
+            end
+            """
+            @test format_text(str, SciMLStyle(), margin = 41) == fstr
+            @test format_text(str, SciMLStyle(), margin = 37) == fstr
 
-        fstr = """
-        function foo(arg1, arg2, arg3,
-                arg4, arg5)
-            body
-        end
-        """
-        @test format_text(str, SciMLStyle(), margin = 36) == fstr
-        # should be 30? might be a unnesting off by 1 error
-        @test format_text(str, SciMLStyle(), margin = 31) == fstr
+            fstr = """
+            function foo(arg1, arg2, arg3,
+                    arg4, arg5)
+                body
+            end
+            """
+            @test format_text(str, SciMLStyle(), margin = 36) == fstr
+            # should be 30? might be a unnesting off by 1 error
+            @test format_text(str, SciMLStyle(), margin = 31) == fstr
 
-        fstr = """
-        function foo(
+            fstr = """
+            function foo(
+                    arg1, arg2, arg3,
+                    arg4, arg5)
+                body
+            end
+            """
+            @test format_text(str, SciMLStyle(), margin = 29) == fstr
+            @test format_text(str, SciMLStyle(), margin = 25) == fstr
+
+            fstr = """
+            function foo(
+                    arg1, arg2,
+                    arg3,
+                    arg4, arg5)
+                body
+            end
+            """
+            @test format_text(str, SciMLStyle(), margin = 24) == fstr
+
+            fstr = """
+            function foo(
+                    arg1,
+                    arg2,
+                    arg3,
+                    arg4,
+                    arg5)
+                body
+            end
+            """
+            @test format_text(str, SciMLStyle(), margin = 18) == fstr
+        end
+
+        @testset "vector definition" begin
+            str = """
+            test = [arg1, arg2, arg3, arg4, arg5]
+            """
+
+            # Fits within the margin
+            @test format_text(str, SciMLStyle(), margin = 41) == str
+            @test format_text(str, SciMLStyle(), margin = 37) == str
+
+            fstr = """
+            test = [
+                arg1, arg2, arg3, arg4, arg5]
+            """
+            @test format_text(str, SciMLStyle(), margin = 36) == fstr
+            @test format_text(str, SciMLStyle(), margin = 33) == fstr
+
+            fstr = """
+            test = [arg1, arg2, arg3,
+                arg4, arg5]
+            """
+            @test format_text(str, SciMLStyle(), margin = 32) == fstr
+            # should be 25? might be a unnesting off by 1 error
+            @test format_text(str, SciMLStyle(), margin = 26) == fstr
+
+            fstr = """
+            test = [
                 arg1, arg2, arg3,
-                arg4, arg5)
-            body
-        end
-        """
-        @test format_text(str, SciMLStyle(), margin = 29) == fstr
-        @test format_text(str, SciMLStyle(), margin = 25) == fstr
+                arg4, arg5]
+            """
+            @test format_text(str, SciMLStyle(), margin = 25) == fstr
+            @test format_text(str, SciMLStyle(), margin = 21) == fstr
 
-        fstr = """
-        function foo(
+            fstr = """
+            test = [arg1, arg2,
+                arg3,
+                arg4, arg5]
+            """
+            @test format_text(str, SciMLStyle(), margin = 20) == fstr
+            # should be 19? might be a unnesting off by 1 error
+            # @test format_text(str, SciMLStyle(), margin = 19) == fstr
+
+            fstr = """
+            test = [
                 arg1, arg2,
                 arg3,
-                arg4, arg5)
-            body
-        end
-        """
-        @test format_text(str, SciMLStyle(), margin = 24) == fstr
+                arg4, arg5]
+            """
+            @test format_text(str, SciMLStyle(), margin = 19) == fstr
+            # should be 15? might be a unnesting off by 1 error
+            @test format_text(str, SciMLStyle(), margin = 16) == fstr
 
-        fstr = """
-        function foo(
+            fstr = """
+            test = [
+                arg1, arg2,
+                arg3,
+                arg4,
+                arg5]
+            """
+            @test format_text(str, SciMLStyle(), margin = 15) == fstr
+
+            fstr = """
+            test = [arg1,
+                arg2,
+                arg3,
+                arg4,
+                arg5]
+            """
+            @test format_text(str, SciMLStyle(), margin = 14) == fstr
+
+            fstr = """
+            test = [
                 arg1,
                 arg2,
                 arg3,
                 arg4,
-                arg5)
-            body
+                arg5]
+            """
+            @test format_text(str, SciMLStyle(), margin = 13) == fstr
         end
-        """
-        @test format_text(str, SciMLStyle(), margin = 18) == fstr
     end
 
     str = raw"""

--- a/test/sciml_style.jl
+++ b/test/sciml_style.jl
@@ -488,6 +488,40 @@
         @test format_text(str, SciMLStyle(), margin = 18) == fstr
     end
 
+    @testset "optimal nesting with `yas_style_nesting = true`" begin
+        str = """
+        x = (arg1, arg2, arg3, arg4, arg5)
+        """
+
+        # Fits within the margin
+        @test format_text(str, SciMLStyle(), yas_style_nesting = true, margin = 50) == str
+        @test format_text(str, SciMLStyle(), yas_style_nesting = true, margin = 34) == str
+
+        fstr = """
+        x = (arg1, arg2, arg3,
+             arg4, arg5)
+        """
+        @test format_text(str, SciMLStyle(), yas_style_nesting = true, margin = 33) == fstr
+        @test format_text(str, SciMLStyle(), yas_style_nesting = true, margin = 23) == fstr
+
+        fstr = """
+        x = (arg1, arg2,
+             arg3,
+             arg4, arg5)
+        """
+        @test format_text(str, SciMLStyle(), yas_style_nesting = true, margin = 21) == fstr
+        @test format_text(str, SciMLStyle(), yas_style_nesting = true, margin = 17) == fstr
+
+        fstr = """
+        x = (arg1,
+             arg2,
+             arg3,
+             arg4,
+             arg5)
+        """
+        @test format_text(str, SciMLStyle(), yas_style_nesting = true, margin = 15) == fstr
+    end
+
     str = raw"""
     x = [
         1, 2, 3

--- a/test/sciml_style.jl
+++ b/test/sciml_style.jl
@@ -488,40 +488,6 @@
         @test format_text(str, SciMLStyle(), margin = 18) == fstr
     end
 
-    @testset "optimal nesting with `yas_style_nesting = true`" begin
-        str = """
-        x = (arg1, arg2, arg3, arg4, arg5)
-        """
-
-        # Fits within the margin
-        @test format_text(str, SciMLStyle(), yas_style_nesting = true, margin = 50) == str
-        @test format_text(str, SciMLStyle(), yas_style_nesting = true, margin = 34) == str
-
-        fstr = """
-        x = (arg1, arg2, arg3,
-             arg4, arg5)
-        """
-        @test format_text(str, SciMLStyle(), yas_style_nesting = true, margin = 33) == fstr
-        @test format_text(str, SciMLStyle(), yas_style_nesting = true, margin = 23) == fstr
-
-        fstr = """
-        x = (arg1, arg2,
-             arg3,
-             arg4, arg5)
-        """
-        @test format_text(str, SciMLStyle(), yas_style_nesting = true, margin = 21) == fstr
-        @test format_text(str, SciMLStyle(), yas_style_nesting = true, margin = 17) == fstr
-
-        fstr = """
-        x = (arg1,
-             arg2,
-             arg3,
-             arg4,
-             arg5)
-        """
-        @test format_text(str, SciMLStyle(), yas_style_nesting = true, margin = 15) == fstr
-    end
-
     str = raw"""
     x = [
         1, 2, 3

--- a/test/sciml_style.jl
+++ b/test/sciml_style.jl
@@ -487,4 +487,14 @@
         """
         @test format_text(str, SciMLStyle(), margin = 18) == fstr
     end
+
+    str = raw"""
+    x = [
+        1, 2, 3
+    ]
+    """
+
+    # This should be valid with and without `yas_style_nesting`
+    @test format_text(str, SciMLStyle()) == str
+    @test format_text(str, SciMLStyle(), yas_style_nesting = true) == str
 end


### PR DESCRIPTION
Before #792, default style `p_vect` and `n_vect!` have always been used in `SciMLStyle`, even with `yas_style_nesting = true`. I restored this behavior.

Closes #806.