### PR TITLE
fix #817

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "1.0.50"
+version = "1.0.51"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "1.0.50"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
-Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 CommonMark = "a80b9123-70ca-4bc0-993e-6e3bcb318db6"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
@@ -15,7 +14,6 @@ Tokenize = "0796e94c-ce3b-5d07-9a54-7f471281c624"
 
 [compat]
 CSTParser = "^3.4.0"
-Combinatorics = "1"
 CommonMark = "0.5, 0.6, 0.7, 0.8"
 DataStructures = "0.17, 0.18"
 Glob = "1.3"

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -11,7 +11,6 @@ using Pkg.TOML: parsefile
 using Glob
 import CommonMark: block_modifier
 import Base: get, pairs
-using Combinatorics: permutations
 using CommonMark:
     AdmonitionRule,
     CodeBlock,

--- a/src/nest_utils.jl
+++ b/src/nest_utils.jl
@@ -175,6 +175,7 @@ function nest_if_over_margin!(
     return false
 end
 
+# TOOD: further improve the runtime of this function
 function find_all_segment_splits(dp::Matrix{Int}, k::Int, max_margin::Int)
     res = Vector{Int}[]
     n = size(dp, 1)
@@ -230,7 +231,7 @@ function find_optimal_nest_placeholders(
     max_margin::Int,
 )::Vector{Int}
     placeholder_inds = findall(n -> n.typ === PLACEHOLDER, fst.nodes)
-    if length(placeholder_inds) <= 1 || length(placeholder_inds) >= 40
+    if length(placeholder_inds) <= 1 || length(placeholder_inds) >= 30
         return placeholder_inds
     end
     newline_inds = findall(n -> n.typ === NEWLINE, fst.nodes)

--- a/src/nest_utils.jl
+++ b/src/nest_utils.jl
@@ -175,9 +175,9 @@ function nest_if_over_margin!(
     return false
 end
 
-function find_all_segment_splits(n::Int, k::Int, max_margin::Int)
+function find_all_segment_splits(dp::Matrix{Int}, k::Int, max_margin::Int)
     res = Vector{Int}[]
-    # n = size(dp, 1)
+    n = size(dp, 1)
 
     if n == k
         return [fill(1, k)]
@@ -195,15 +195,19 @@ function find_all_segment_splits(n::Int, k::Int, max_margin::Int)
             return
         end
 
-        start_val = 1
-        max_val = n - k + 1
-
-        for i in start_val:min(n, max_val)
+        for i in 1:(n-k+1)
+            if current_sum + i > n
+                break
+            end
             _backtrack([t; i], current_sum + i)
         end
     end
 
     for i in 1:(n-k+1)
+        cm = dp[1, i]
+        if cm > max_margin
+            break
+        end
         _backtrack([i], i)
     end
 
@@ -284,7 +288,7 @@ function find_optimal_nest_placeholders(
         end
     end
 
-    @info "" dp placeholder_inds
+    # @info "" dp placeholder_inds
 
     N = size(dp, 1)
 
@@ -306,7 +310,7 @@ function find_optimal_nest_placeholders(
             ranges
         end
 
-        all_splits = find_all_segment_splits(N, s, max_margin)
+        all_splits = find_all_segment_splits(dp, s, max_margin)
 
         best_split = UnitRange{Int}[]
         min_diff = 1_000_000 # big number!

--- a/src/nest_utils.jl
+++ b/src/nest_utils.jl
@@ -175,7 +175,7 @@ function nest_if_over_margin!(
     return false
 end
 
-function find_all_segment_splits2(n::Int, k::Int, max_margin::Int)
+function find_all_segment_splits(n::Int, k::Int, max_margin::Int)
     res = Vector{Int}[]
     # n = size(dp, 1)
 
@@ -203,7 +203,7 @@ function find_all_segment_splits2(n::Int, k::Int, max_margin::Int)
         end
     end
 
-    for i in 1:(n - k + 1)
+    for i in 1:(n-k+1)
         _backtrack([i], i)
     end
 
@@ -306,7 +306,7 @@ function find_optimal_nest_placeholders(
             ranges
         end
 
-        @time all_splits = find_all_segment_splits(N, s, max_margin)
+        all_splits = find_all_segment_splits(N, s, max_margin)
 
         best_split = UnitRange{Int}[]
         min_diff = 1_000_000 # big number!
@@ -329,7 +329,6 @@ function find_optimal_nest_placeholders(
     segments = Tuple{Int,Int}[]
     for s in 1:N
         segments = find_best_segments(s)
-        @info "" segments
         fits = true
         for (i, s) in enumerate(segments)
             if i == 1

--- a/src/nest_utils.jl
+++ b/src/nest_utils.jl
@@ -175,8 +175,9 @@ function nest_if_over_margin!(
     return false
 end
 
-function find_all_segment_splits(n::Int, k::Int)
+function find_all_segment_splits2(n::Int, k::Int, max_margin::Int)
     res = Vector{Int}[]
+    # n = size(dp, 1)
 
     if n == k
         return [fill(1, k)]
@@ -190,25 +191,23 @@ function find_all_segment_splits(n::Int, k::Int)
                 push!(res, t)
             end
             return
+        elseif current_sum >= n
+            return
         end
 
-        start_val = isempty(t) ? 1 : last(t)
-        max_val = n - current_sum - (k - length(t) - 1)
+        start_val = 1
+        max_val = n - k + 1
 
         for i in start_val:min(n, max_val)
             _backtrack([t; i], current_sum + i)
         end
     end
-    _backtrack(Int[], 0)
 
-    all_splits = Vector{Int}[]
-    for r in res
-        for c in unique(permutations(r))
-            push!(all_splits, c)
-        end
+    for i in 1:(n - k + 1)
+        _backtrack([i], i)
     end
 
-    return all_splits
+    return res
 end
 
 """
@@ -285,7 +284,7 @@ function find_optimal_nest_placeholders(
         end
     end
 
-    # @info "" dp placeholder_inds
+    @info "" dp placeholder_inds
 
     N = size(dp, 1)
 
@@ -307,7 +306,7 @@ function find_optimal_nest_placeholders(
             ranges
         end
 
-        all_splits = find_all_segment_splits(N, s)
+        @time all_splits = find_all_segment_splits(N, s, max_margin)
 
         best_split = UnitRange{Int}[]
         min_diff = 1_000_000 # big number!
@@ -330,6 +329,7 @@ function find_optimal_nest_placeholders(
     segments = Tuple{Int,Int}[]
     for s in 1:N
         segments = find_best_segments(s)
+        @info "" segments
         fits = true
         for (i, s) in enumerate(segments)
             if i == 1

--- a/src/nest_utils.jl
+++ b/src/nest_utils.jl
@@ -219,7 +219,7 @@ function find_optimal_nest_placeholders(
     max_margin::Int,
 )::Vector{Int}
     placeholder_inds = findall(n -> n.typ === PLACEHOLDER, fst.nodes)
-    if length(placeholder_inds) <= 1 || length(placeholder_inds) >= 20
+    if length(placeholder_inds) <= 1 || length(placeholder_inds) >= 40
         return placeholder_inds
     end
     newline_inds = findall(n -> n.typ === NEWLINE, fst.nodes)

--- a/src/nest_utils.jl
+++ b/src/nest_utils.jl
@@ -250,8 +250,6 @@ function find_optimal_nest_placeholders(
     end
     push!(placeholder_groups, current_group)
 
-    # @info "groups" placeholder_groups
-
     optimal_placeholders = Int[]
     for (i, g) in enumerate(placeholder_groups)
         optinds = find_optimal_nest_placeholders(

--- a/src/nest_utils.jl
+++ b/src/nest_utils.jl
@@ -180,9 +180,9 @@ function find_all_segment_splits(dp::Matrix{Int}, k::Int, max_margin::Int)
     n = size(dp, 1)
 
     if n == k
-        return [fill(1, k)]
+        return Int[fill(1, k)]
     elseif k == 1
-        return [[n]]
+        return Int[[n]]
     end
 
     function _backtrack(t::Vector{Int}, current_sum::Int)
@@ -199,6 +199,9 @@ function find_all_segment_splits(dp::Matrix{Int}, k::Int, max_margin::Int)
             if current_sum + i > n
                 break
             end
+            if dp[current_sum+1, current_sum+i] > max_margin
+                break
+            end
             _backtrack([t; i], current_sum + i)
         end
     end
@@ -209,6 +212,10 @@ function find_all_segment_splits(dp::Matrix{Int}, k::Int, max_margin::Int)
             break
         end
         _backtrack([i], i)
+    end
+
+    if length(res) == 0
+        return [[n]]
     end
 
     return res

--- a/src/nest_utils.jl
+++ b/src/nest_utils.jl
@@ -219,7 +219,7 @@ function find_optimal_nest_placeholders(
     max_margin::Int,
 )::Vector{Int}
     placeholder_inds = findall(n -> n.typ === PLACEHOLDER, fst.nodes)
-    if length(placeholder_inds) <= 1
+    if length(placeholder_inds) <= 1 || length(placeholder_inds) >= 20
         return placeholder_inds
     end
     newline_inds = findall(n -> n.typ === NEWLINE, fst.nodes)

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1793,4 +1793,25 @@
         """
         @test format_text(s, SciMLStyle()) == s
     end
+
+    @testset "817" begin
+        s = raw"""
+        a = ["Unknown" => SubRegion.Unknown, "Northern Europe" => SubRegion.Northern_Europe, "Southern Asia" => SubRegion.Southern_Asia, "Western Europe" => SubRegion.Western_Europe, "Sub-Saharan Africa" => SubRegion.Sub_Saharan_Africa, "Western Asia" => SubRegion.Western_Asia, "Eastern Asia" => SubRegion.Eastern_Asia, "Northern America" => SubRegion.Northern_America, "South-eastern Asia" => SubRegion.South_eastern_Asia, "Australia and New Zealand" => SubRegion.Australia_and_New_Zealand, "Eastern Europe" => SubRegion.Eastern_Europe, "Latin America and the Caribbean" => SubRegion.Latin_America_and_the_Caribbean, "Southern Europe" => SubRegion.Southern_Europe, "Central Asia" => SubRegion.Central_Asia]
+        """
+        s2 = raw"""
+        a = ["Unknown" => SubRegion.Unknown, "Northern Europe" => SubRegion.Northern_Europe,
+            "Southern Asia" => SubRegion.Southern_Asia,
+            "Western Europe" => SubRegion.Western_Europe,
+            "Sub-Saharan Africa" => SubRegion.Sub_Saharan_Africa,
+            "Western Asia" => SubRegion.Western_Asia, "Eastern Asia" => SubRegion.Eastern_Asia,
+            "Northern America" => SubRegion.Northern_America,
+            "South-eastern Asia" => SubRegion.South_eastern_Asia,
+            "Australia and New Zealand" => SubRegion.Australia_and_New_Zealand,
+            "Eastern Europe" => SubRegion.Eastern_Europe,
+            "Latin America and the Caribbean" => SubRegion.Latin_America_and_the_Caribbean,
+            "Southern Europe" => SubRegion.Southern_Europe,
+            "Central Asia" => SubRegion.Central_Asia]
+        """
+        @test format_text(s, SciMLStyle()) == s2
+    end
 end


### PR DESCRIPTION
finding an optimal nest for a large list > 12 or so starts to take a noticeable long time - O(n^2) scaling. The bulk of the time was in `find_all_segment_splits`.

_backtrack is refactored so that permutations function is no longer needed and we prune most of the search tree.

`find_all_segment_splits2` is the new function


```julia
julia> for i in 1:12
           @time res1 = JuliaFormatter.find_all_segment_splits(14, i, 100)
           @time res2 = JuliaFormatter.find_all_segment_splits2(14, i, 100)

           @info "compare" i sort(res1) == sort(res2)
       end
  0.000004 seconds (4 allocations: 192 bytes)
  0.000001 seconds (5 allocations: 208 bytes)
┌ Info: compare
│   i = 1
└   sort(res1) == sort(res2) = true
  0.000012 seconds (161 allocations: 12.016 KiB)
  0.008917 seconds (5.10 k allocations: 363.125 KiB, 99.67% compilation time)
┌ Info: compare
│   i = 2
└   sort(res1) == sort(res2) = true
  0.000027 seconds (547 allocations: 40.250 KiB)
  0.000089 seconds (1.10 k allocations: 87.109 KiB)
┌ Info: compare
│   i = 3
└   sort(res1) == sort(res2) = true
  0.000089 seconds (2.10 k allocations: 177.062 KiB)
  0.000239 seconds (4.12 k allocations: 378.000 KiB)
┌ Info: compare
│   i = 4
└   sort(res1) == sort(res2) = true
  0.000412 seconds (8.80 k allocations: 708.828 KiB)
  0.000633 seconds (10.82 k allocations: 1022.234 KiB)
┌ Info: compare
│   i = 5
└   sort(res1) == sort(res2) = true
  0.001804 seconds (43.73 k allocations: 3.662 MiB)
  0.001225 seconds (21.14 k allocations: 2.122 MiB)
┌ Info: compare
│   i = 6
└   sort(res1) == sort(res2) = true
  0.014416 seconds (227.25 k allocations: 18.616 MiB, 35.07% gc time)
  0.001893 seconds (32.14 k allocations: 3.320 MiB)
┌ Info: compare
│   i = 7
└   sort(res1) == sort(res2) = true
  0.061456 seconds (1.33 M allocations: 121.972 MiB, 14.05% gc time)
  0.005739 seconds (39.35 k allocations: 4.300 MiB, 61.07% gc time)
┌ Info: compare
│   i = 8
└   sort(res1) == sort(res2) = true
  0.390723 seconds (7.62 M allocations: 697.825 MiB, 13.59% gc time)
  0.005620 seconds (39.91 k allocations: 4.481 MiB, 59.69% gc time)
┌ Info: compare
│   i = 9
└   sort(res1) == sort(res2) = true
  2.643116 seconds (54.43 M allocations: 5.407 GiB, 13.55% gc time)
  0.001850 seconds (33.99 k allocations: 3.937 MiB)
┌ Info: compare
│   i = 10
└   sort(res1) == sort(res2) = true
 17.714541 seconds (359.25 M allocations: 35.688 GiB, 13.58% gc time)
  0.001282 seconds (23.51 k allocations: 2.781 MiB)
┌ Info: compare
│   i = 11
└   sort(res1) == sort(res2) = true
130.783987 seconds (2.87 G allocations: 314.058 GiB, 5.84% gc time)
  0.000664 seconds (11.17 k allocations: 1.365 MiB)
┌ Info: compare
│   i = 12
└   sort(res1) == sort(res2) = true
```