### PR TITLE
fix: ignore broken symlinks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
           - '1.10'
           # - 'nightly'
         arch: [x64, x86]
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         exclude:
-          - os: macos-13
+          - os: macos-latest
             arch: x86
           - julia-version: 1.4
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-13]
         exclude:
           - os: macos-13
-          - julia-version: 1.4
+            version: 1.4
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-13]
         exclude:
           - os: macos-13
+            arch: x86
           - julia-version: 1.4
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
           - '1.10'
           # - 'nightly'
         arch: [x64, x86]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13]
         exclude:
-          - os: macos-latest
-            arch: x86
+          - os: macos-13
+          - julia-version: 1.4
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,9 @@ jobs:
           - '1.10'
           # - 'nightly'
         arch: [x64, x86]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13]
         exclude:
-          - os: macos-latest
-            arch: x86
+          - os: macos-13
           - julia-version: 1.4
     steps:
       - uses: actions/checkout@v4

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -441,6 +441,7 @@ function format(path::AbstractString, options::Configuration)
         formatted = Threads.Atomic{Bool}(true)
         Threads.@threads for subpath in readdir(path)
             subpath = joinpath(path, subpath)
+            !ispath(subpath) && continue
             is_formatted = format(subpath, options)
             Threads.atomic_and!(formatted, is_formatted)
         end


### PR DESCRIPTION
Currently formatting breaks if it encounters broken symlink in the directory