### PR TITLE
Explicitly list the extensions handled by format

### DIFF
--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -396,7 +396,8 @@ end
         options...,
     )::Bool
 
-Recursively descend into files and directories, formatting any `.jl` files.
+Recursively descend into files and directories, formatting any `.jl`, `.md`, `.jmd`,
+or `.qmd` files.
 
 See [`format_file`](@ref) and [`format_text`](@ref) for a description of the options.
 


### PR DESCRIPTION
The format function accepts jl, md, jmd and qmd files. Update the docstring to make that clear.

I hope it's alright that I create the PR directly. 