### PR TITLE
Change pre-commit hook to run on specific files only

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,6 +2,8 @@
   name: "Julia Formatter"
   entry: "julia -e 'import JuliaFormatter: format; format(\".\")'"
   pass_filenames: false
-  always_run: true
+  always_run: false
+  types: [file]
+  files: \.(jl|[jq]?md)$
   language: "system"
   description: "An opinionated code formatter for Julia. Plot twist - the opinion is your own."


### PR DESCRIPTION
The pre-commit hook should run only on jl, md, jmq, and qmd files, since it only modifies those files.

I'm running the pre-commit a lot on [COPIERTemplate.jl](https://github.com/abelsiqueira/COPIERTemplate.jl), and I've noticed that it runs for any modifications, not just relevant ones. This PR changes that.

@jmuchovej, you created the file, so let me know if you agree with the changes.