### PR TITLE
Format only files selected by pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: julia-formatter
   name: "Julia Formatter"
-  entry: "julia -e 'import JuliaFormatter: format; format(\".\")'"
-  pass_filenames: false
+  entry: "julia -e 'import JuliaFormatter: format; format(ARGS)'"
+  pass_filenames: true
   always_run: false
   types: [file]
   files: \.(jl|[jq]?md)$


### PR DESCRIPTION
The hook will be more useful if it would work on a list of files given to it by pre-commit. For instance `pre-commit run` will check only files in the staging area, `pre-commit run --all-files` will run on all the files. Additionally the hook should respect the `exclude` directive of pre-commit.

This PR adds support to working on the lists of files provided by pre-commit 