### PR TITLE
add a maximum length for optimal placeholder nesting. If there are more than 50 arguments in a group it will default to nesting all of them

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
-version = "1.0.57"
+version = "1.0.58"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"

--- a/src/nest_utils.jl
+++ b/src/nest_utils.jl
@@ -231,7 +231,7 @@ function find_optimal_nest_placeholders(
     max_margin::Int,
 )::Vector{Int}
     placeholder_inds = findall(n -> n.typ === PLACEHOLDER, fst.nodes)
-    if length(placeholder_inds) <= 1
+    if length(placeholder_inds) <= 1 || length(placeholder_inds) >= 50
         return placeholder_inds
     end
     newline_inds = findall(n -> n.typ === NEWLINE, fst.nodes)


### PR DESCRIPTION
ref #817 