### PR TITLE
Fix extra newlines

### DIFF
--- a/src/nest_utils.jl
+++ b/src/nest_utils.jl
@@ -231,7 +231,7 @@ function find_optimal_nest_placeholders(
     max_margin::Int,
 )::Vector{Int}
     placeholder_inds = findall(n -> n.typ === PLACEHOLDER, fst.nodes)
-    if length(placeholder_inds) <= 1 || length(placeholder_inds) >= 50
+    if length(placeholder_inds) <= 1 || length(placeholder_inds) >= 500
         return placeholder_inds
     end
     newline_inds = findall(n -> n.typ === NEWLINE, fst.nodes)


### PR DESCRIPTION
SciML style does not expect new lines to be placed with every argument. This puts it out of reach for almost any compliable Julia function so it essentially only applies to arrays.