### PR TITLE
Reformat code in docs

### DIFF
--- a/docs/src/sciml_style.md
+++ b/docs/src/sciml_style.md
@@ -56,8 +56,8 @@ Setting it to `true` makes the `SciMLStyle` use the `YASStyle` nesting rules:
 ```julia
 # With `yas_style_nesting = false`
 function my_large_function(argument1, argument2,
-    argument3, argument4,
-    argument5, x, y, z)
+        argument3, argument4,
+        argument5, x, y, z)
     foo(x) + goo(y)
 end
 


### PR DESCRIPTION
This is how it's correctly formatted in newer versions.