### PR TITLE
Automate list of differing defaults for styles

### DIFF
--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -138,6 +138,18 @@ include("fst.jl")
 include("passes.jl")
 include("align.jl")
 
+function list_different_defaults(style)
+    options_style = pairs(options(style))
+    options_default = pairs(options(DefaultStyle()))
+    options_changed = setdiff(options_style, options_default)
+    sort!(options_changed; by = first)
+    io = IOBuffer()
+    for (key, val) in options_changed
+        println(io, "- `$key` = $val")
+    end
+    String(take!(io))
+end
+
 include("styles/default/pretty.jl")
 include("styles/default/nest.jl")
 include("styles/yas/pretty.jl")

--- a/src/styles/blue/pretty.jl
+++ b/src/styles/blue/pretty.jl
@@ -1,25 +1,3 @@
-"""
-    BlueStyle()
-
-Formatting style based on [BlueStyle](https://github.com/invenia/BlueStyle)
-and [JuliaFormatter#283](https://github.com/domluna/JuliaFormatter.jl/issues/283).
-
-!!! note
-    This style is still work-in-progress, and does not yet implement all of the
-    BlueStyle guide.
-
-Configurable options with different defaults to [`DefaultStyle`](@ref) are:
-- `always_use_return` = true
-- `short_to_long_function_def` = true
-- `whitespace_ops_in_indices` = true
-- `remove_extra_newlines` = true
-- `always_for_in` = true
-- `import_to_using` = true
-- `pipe_to_function_call` = true
-- `whitespace_in_kwargs` = false
-- `annotate_untyped_fields_with_any` = false
-- `separate_kwargs_with_semicolon` = true
-"""
 struct BlueStyle <: AbstractStyle
     innerstyle::AbstractStyle
 end
@@ -58,6 +36,21 @@ function options(style::BlueStyle)
         yas_style_nesting = false,
     )
 end
+
+@doc """
+    BlueStyle()
+
+Formatting style based on [BlueStyle](https://github.com/invenia/BlueStyle)
+and [JuliaFormatter#283](https://github.com/domluna/JuliaFormatter.jl/issues/283).
+
+!!! note
+    This style is still work-in-progress, and does not yet implement all of the
+    BlueStyle guide.
+
+Configurable options with different defaults to [`DefaultStyle`](@ref) are:
+$(list_different_defaults(BlueStyle()))
+"""
+BlueStyle
 
 function is_binaryop_nestable(::BlueStyle, cst::CSTParser.EXPR)
     is_assignment(cst) && is_iterable(cst[end]) && return false

--- a/src/styles/sciml/pretty.jl
+++ b/src/styles/sciml/pretty.jl
@@ -1,18 +1,3 @@
-"""
-    SciMLStyle()
-
-Formatting style based on [SciMLStyle](https://github.com/SciML/SciMLStyle).
-
-!!! note
-    This style is still work-in-progress.
-
-Configurable options with different defaults to [`DefaultStyle`](@ref) are:
-- `whitespace_ops_in_indices` = true
-- `remove_extra_newlines` = true
-- `always_for_in` = true
-- `whitespace_typedefs` = true,
-- `normalize_line_endings` = "unix"
-"""
 struct SciMLStyle <: AbstractStyle
     innerstyle::AbstractStyle
 end
@@ -52,6 +37,19 @@ function options(style::SciMLStyle)
         disallow_single_arg_nesting = true,
     )
 end
+
+@doc """
+    SciMLStyle()
+
+Formatting style based on [SciMLStyle](https://github.com/SciML/SciMLStyle).
+
+!!! note
+    This style is still work-in-progress.
+
+Configurable options with different defaults to [`DefaultStyle`](@ref) are:
+$(list_different_defaults(SciMLStyle()))
+"""
+SciMLStyle
 
 function is_binaryop_nestable(::SciMLStyle, cst::CSTParser.EXPR)
     (CSTParser.defines_function(cst) || is_assignment(cst)) && return false

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -1,21 +1,3 @@
-"""
-    YASStyle()
-
-Formatting style based on [YASGuide](https://github.com/jrevels/YASGuide)
-and [JuliaFormatter#198](https://github.com/domluna/JuliaFormatter.jl/issues/198).
-
-Configurable options with different defaults to [`DefaultStyle`](@ref) are:
-- `always_for_in` = true
-- `whitespace_ops_in_indices` = true
-- `remove_extra_newlines` = true
-- `import_to_using` = true
-- `pipe_to_function_call` = true
-- `short_to_long_function_def` = true
-- `always_use_return` = true
-- `whitespace_in_kwargs` = false
-- `join_lines_based_on_source` = true
-- `separate_kwargs_with_semicolon` = true
-"""
 struct YASStyle <: AbstractStyle
     innerstyle::AbstractStyle
 end
@@ -54,6 +36,17 @@ function options(style::YASStyle)
         yas_style_nesting = false,
     )
 end
+
+@doc """
+    YASStyle()
+
+Formatting style based on [YASGuide](https://github.com/jrevels/YASGuide)
+and [JuliaFormatter#198](https://github.com/domluna/JuliaFormatter.jl/issues/198).
+
+Configurable options with different defaults to [`DefaultStyle`](@ref) are:
+$(list_different_defaults(YASStyle()))
+"""
+YASStyle
 
 function is_binaryop_nestable(::YASStyle, cst::CSTParser.EXPR)
     (CSTParser.defines_function(cst) || is_assignment(cst)) && return false


### PR DESCRIPTION
Update docstrings of BlueStyle, SciMLStyle, and YASStyle to contain the computed list of options that are different from DefaultStyle.

Would this be something you are interested in? If not, feel free to close. If yes, where should `list_different_defaults` be defined? I am happy to iterate on this PR.