### PR TITLE
Disable following links

### DIFF
--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -427,7 +427,7 @@ function format(path::AbstractString, options::Configuration)
         formatted = Threads.Atomic{Bool}(true)
         Threads.@threads for subpath in readdir(path)
             subpath = joinpath(path, subpath)
-            if !ispath(subpath)
+            if !ispath(subpath) || islink(subpath)
                 continue
             end
             is_formatted = format(subpath, options)


### PR DESCRIPTION
Thanks for developing and maintaining this project! :slightly_smiling_face: 

Following links resulted on my machine (running [NixOS](https://nixos.org/) and using [devenv](https://devenv.sh/)) in precompilation of JuliaFormatter failing because it attempted to format read-only `.jl` files (because `.devenv/profile` links to readonly `/nix/store/…` directories). Since I don't see a case where I want JuliaFormatter to jump to far-away directories by following links and reformat them (looks rather dangerous to me, actually?), I simply disabled following links. In case you want to integrate this tiny change, I created this PR.

Note that this could be improved by checking whether the link points to a file within the currently-to-be-formatted directory or something like that.