### PR TITLE
add some support for `public` keyword

### DIFF
--- a/src/fst.jl
+++ b/src/fst.jl
@@ -83,6 +83,7 @@
     Const,
     Import,
     Export,
+    Public,
     Using,
     File,
     Quotenode,
@@ -447,7 +448,7 @@ function is_named_iterable(x::FST)
 end
 
 function is_import_expr(x::FST)
-    return x.typ in (Import, Using, Export)
+    return x.typ in (Import, Using, Export, Public)
 end
 
 """

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -426,7 +426,7 @@ is_opener(t::JuliaSyntax.GreenNode) = kind(t) in KSet"{ ( ["
 function is_iterable(t::JuliaSyntax.GreenNode)
     if !(
         kind(t) in
-        KSet"parens tuple vect vcat braces curly comprehension typed_comprehension macrocall ref typed_vcat import using export"
+        KSet"parens tuple vect vcat braces curly comprehension typed_comprehension macrocall ref typed_vcat import using export public"
     )
         is_func_call(t)
     else

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -82,6 +82,8 @@ function nest!(
         n_import!(style, fst, s, lineage)
     elseif fst.typ === Export
         n_export!(style, fst, s, lineage)
+    elseif fst.typ === Public
+        n_public!(style, fst, s, lineage)
     elseif fst.typ === Using
         n_using!(style, fst, s, lineage)
     elseif fst.typ === Where
@@ -295,6 +297,15 @@ function n_using!(
 end
 
 function n_export!(
+    ds::AbstractStyle,
+    fst::FST,
+    s::State,
+    lineage::Vector{Tuple{FNode,Union{Nothing,Metadata}}},
+)
+    n_using!(ds, fst, s, lineage)
+end
+
+function n_public!(
     ds::AbstractStyle,
     fst::FST,
     s::State,

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -244,7 +244,7 @@ function n_do!(
     return nested
 end
 
-# Import,Using,Export
+# Import,Using,Export,Public
 function n_using!(
     ds::AbstractStyle,
     fst::FST,

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -146,6 +146,8 @@ function pretty(
         p_import(style, node, s, ctx, lineage)
     elseif k === K"export"
         p_export(style, node, s, ctx, lineage)
+    elseif k === K"public"
+        p_public(style, node, s, ctx, lineage)
     elseif k === K"using"
         p_using(style, node, s, ctx, lineage)
     elseif k === K"importpath"
@@ -2630,6 +2632,18 @@ function p_export(
 )
     t = p_import(ds, cst, s, ctx, lineage)
     t.typ = Export
+    t
+end
+
+function p_public(
+    ds::AbstractStyle,
+    cst::JuliaSyntax.GreenNode,
+    s::State,
+    ctx::PrettyContext,
+    lineage::Vector{Tuple{JuliaSyntax.Kind,Bool,Bool}},
+)
+    t = p_import(ds, cst, s, ctx, lineage)
+    t.typ = Public
     t
 end
 

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -2600,14 +2600,14 @@ function p_import(
     end
 
     for a in children(cst)
-        if kind(a) in KSet"import export using"
+        if kind(a) in KSet"import export public using"
             add_node!(t, pretty(style, a, s, ctx, lineage), s; join_lines = true)
             add_node!(t, Whitespace(1), s)
         elseif kind(a) === K":" && haschildren(a)
             nodes = children(a)
             for n in nodes
                 add_node!(t, pretty(style, n, s, ctx, lineage), s; join_lines = true)
-                if kind(n) in KSet"import export using"
+                if kind(n) in KSet"import export public using"
                     add_node!(t, Whitespace(1), s)
                 elseif kind(n) in KSet", :"
                     add_node!(t, Placeholder(1), s)

--- a/src/styles/sciml/nest.jl
+++ b/src/styles/sciml/nest.jl
@@ -2,6 +2,7 @@ for f in [
     :n_import!,
     :n_using!,
     :n_export!,
+    :n_public!,
     :n_vcat!,
     :n_ncat!,
     :n_typedvcat!,

--- a/src/styles/sciml/pretty.jl
+++ b/src/styles/sciml/pretty.jl
@@ -66,6 +66,7 @@ for f in [
     :p_import,
     :p_using,
     :p_export,
+    :p_public,
     :p_vcat,
     :p_ncat,
     :p_typedvcat,

--- a/src/styles/yas/nest.jl
+++ b/src/styles/yas/nest.jl
@@ -338,6 +338,14 @@ function n_export!(
 )
     n_using!(ys, fst, s, lineage)
 end
+function n_public!(
+    ys::YASStyle,
+    fst::FST,
+    s::State,
+    lineage::Vector{Tuple{FNode,Union{Nothing,Metadata}}},
+)
+    n_using!(ys, fst, s, lineage)
+end
 function n_import!(
     ys::YASStyle,
     fst::FST,

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -116,6 +116,18 @@ function p_export(
     t
 end
 
+function p_public(
+    ys::YASStyle,
+    cst::JuliaSyntax.GreenNode,
+    s::State,
+    ctx::PrettyContext,
+    lineage::Vector{Tuple{JuliaSyntax.Kind,Bool,Bool}},
+)
+    t = p_import(ys, cst, s, ctx, lineage)
+    t.typ = Public
+    t
+end
+
 function p_curly(
     ys::YASStyle,
     cst::JuliaSyntax.GreenNode,

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -66,14 +66,14 @@ function p_import(
     end
 
     for a in children(cst)
-        if kind(a) in KSet"import export using"
+        if kind(a) in KSet"import export using public"
             add_node!(t, pretty(style, a, s, ctx, lineage), s; join_lines = true)
             add_node!(t, Whitespace(1), s)
         elseif kind(a) === K":" && haschildren(a)
             nodes = children(a)
             for n in nodes
                 add_node!(t, pretty(style, n, s, ctx, lineage), s; join_lines = true)
-                if kind(n) in KSet"import export using :"
+                if kind(n) in KSet"import export using public :"
                     add_node!(t, Whitespace(1), s)
                 elseif kind(n) in KSet","
                     add_node!(t, Placeholder(1), s)

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -4741,6 +4741,23 @@ some_function(
         @test fmt(str, 4, 27; join_lines_based_on_source = true) == str
     end
 
+    @testset "public keyword support" begin
+        str_ = """
+        public    a,b,
+         c
+        """
+        str = """
+        public a, b, c
+        """
+        @test fmt(str_, 4, 14) == str
+        str = """
+        public a,
+            b,
+            c
+        """
+        @test fmt(str_, 4, 1) == str
+    end
+
     @testset "block automatically assume nested when join_lines_based_on_source" begin
         str_ = """
         let y = a, z = b


### PR DESCRIPTION
Currently the `public` prints out a warning and formats in a pretty bad way (the space after `public` is removed, essentially merging the identifiers as `public a` → `publica`).

~~This is an attempt to make it work, but it does not yet. Opening this for tracking; feel free to point out obvious issues that I missed. :)~~  edited, seems to work now.