### PR TITLE
Make sure precompilation sandbox files are writable

### DIFF
--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -537,6 +537,7 @@ end
     sandbox_dir = joinpath(tempdir(), join(rand('a':'z', 24)))
     mkdir(sandbox_dir)
     cp(dir, sandbox_dir; force = true)
+    chmod(sandbox_dir, 0o777; recursive = true)
     str = """
     true
     false


### PR DESCRIPTION
I get problems with this when I install using `add` pointed to this repo. It seems to make all the `.jl` files read only with Julia 1.11 on my system. This patch just chmods the sandbox to be writable after copying.