### PR TITLE
Try to compat JuliaSyntax v1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 [compat]
 CommonMark = "0.5, 0.6, 0.7, 0.8, 0.9"
 Glob = "1.3"
-JuliaSyntax = "^0.4.10"
+JuliaSyntax = "1"
 PrecompileTools = "1"
 TOML = "1"
 julia = "1.10"

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -7,7 +7,7 @@ end
 
 using PrecompileTools: @setup_workload, @compile_workload
 using JuliaSyntax
-using JuliaSyntax: haschildren, children, span, @K_str, kind, @KSet_str
+using JuliaSyntax: is_leaf, children, span, @K_str, kind, @KSet_str
 using TOML: parsefile
 using Glob
 import CommonMark: block_modifier

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -241,7 +241,7 @@ function InlineComment(line)
 end
 
 # is_leaf(cst::JuliaSyntax.GreenNode) = !haschildren(cst)
-is_leaf(fst::FST) = typeof(fst.nodes) === Tuple{}
+JuliaSyntax.is_leaf(fst::FST) = typeof(fst.nodes) === Tuple{}
 
 function is_punc(cst::JuliaSyntax.GreenNode)
     punctuation = KSet", ( ) [ ] { } @"
@@ -530,9 +530,7 @@ function extract_operator_indices(childs::Vector{JuliaSyntax.GreenNode{T}}) wher
     i = 2
     while i <= length(args)
         push!(op_indices, args[i])
-        if i < length(args) &&
-           kind(childs[args[i]]) === K"." &&
-           is_leaf(childs[args[i]])
+        if i < length(args) && kind(childs[args[i]]) === K"." && is_leaf(childs[args[i]])
             push!(op_indices, args[i+1])
             i += 1
         end

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -240,12 +240,12 @@ function InlineComment(line)
     FST(INLINECOMMENT, line, line, 0, 0, "", (), AllowNest, 0, -1, nothing)
 end
 
-is_leaf(cst::JuliaSyntax.GreenNode) = !haschildren(cst)
+# is_leaf(cst::JuliaSyntax.GreenNode) = !haschildren(cst)
 is_leaf(fst::FST) = typeof(fst.nodes) === Tuple{}
 
 function is_punc(cst::JuliaSyntax.GreenNode)
     punctuation = KSet", ( ) [ ] { } @"
-    return kind(cst) in punctuation || (kind(cst) === K"." && !haschildren(cst))
+    return kind(cst) in punctuation || (kind(cst) === K"." && is_leaf(cst))
 end
 is_punc(fst::FST) = fst.typ === PUNCTUATION
 
@@ -257,7 +257,7 @@ is_colon(x::FST) = x.typ === OPERATOR && x.val == ":"
 is_comma(fst::FST) = fst.typ === TRAILINGCOMMA || (is_punc(fst) && fst.val == ",")
 is_comment(fst::FST) = fst.typ in (INLINECOMMENT, NOTCODE, HASHEQCOMMENT)
 
-is_identifier(x) = kind(x) === K"Identifier" && !haschildren(x)
+is_identifier(x) = kind(x) === K"Identifier" && is_leaf(x)
 
 is_ws(x) = kind(x) in KSet"Whitespace NewlineWs"
 
@@ -290,7 +290,7 @@ end
 function is_func_call(t::JuliaSyntax.GreenNode)::Bool
     if kind(t) in KSet"call dotcall"
         return JuliaSyntax.is_prefix_call(t)
-    elseif kind(t) in KSet":: where parens" && haschildren(t)
+    elseif kind(t) in KSet":: where parens" && !is_leaf(t)
         childs = children(t)
         idx =
             findfirst(n -> !JuliaSyntax.is_whitespace(n) && !(kind(n) in KSet"( )"), childs)
@@ -300,9 +300,9 @@ function is_func_call(t::JuliaSyntax.GreenNode)::Bool
 end
 
 function defines_function(x::JuliaSyntax.GreenNode)
-    if kind(x) in KSet"function macro" && haschildren(x)
+    if kind(x) in KSet"function macro" && !is_leaf(x)
         return true
-    elseif is_assignment(x) && haschildren(x)
+    elseif is_assignment(x) && !is_leaf(x)
         childs = children(x)
         idx = findfirst(n -> !JuliaSyntax.is_whitespace(n), childs)
         return !isnothing(idx) && is_func_call(childs[idx])
@@ -310,10 +310,10 @@ function defines_function(x::JuliaSyntax.GreenNode)
     return false
 end
 
-is_if(cst::JuliaSyntax.GreenNode) = kind(cst) in KSet"if elseif else" && haschildren(cst)
+is_if(cst::JuliaSyntax.GreenNode) = kind(cst) in KSet"if elseif else" && !is_leaf(cst)
 
 function is_try(cst::JuliaSyntax.GreenNode)
-    kind(cst) in KSet"try catch finally" && haschildren(cst)
+    kind(cst) in KSet"try catch finally" && !is_leaf(cst)
 end
 
 function is_custom_leaf(fst::FST)
@@ -328,7 +328,7 @@ end
 
 function get_args(t::JuliaSyntax.GreenNode)
     nodes = JuliaSyntax.GreenNode[]
-    !haschildren(t) && return nodes
+    is_leaf(t) && return nodes
     childs = children(t)
     childs isa Tuple{} && return nodes
 
@@ -475,8 +475,8 @@ end
 function is_block(x::JuliaSyntax.GreenNode)
     is_if(x) ||
         kind(x) in KSet"do try for while let" ||
-        (kind(x) == K"block" && haschildren(x)) ||
-        (kind(x) == K"quote" && haschildren(x) && is_block(x[1]))
+        (kind(x) == K"block" && !is_leaf(x)) ||
+        (kind(x) == K"quote" && !is_leaf(x) && is_block(x[1]))
 end
 
 function is_block(x::FST)
@@ -492,7 +492,7 @@ function is_opcall(x::JuliaSyntax.GreenNode)
     if is_binary(x) || kind(x) == K"comparison" || is_chain(x) || is_unary(x)
         return true
     end
-    if kind(x) === K"parens" && haschildren(x)
+    if kind(x) === K"parens" && !is_leaf(x)
         childs = children(x)
         idx = findfirst(
             n -> !JuliaSyntax.is_whitespace(kind(n)) && !(kind(n) in KSet"( )"),
@@ -508,7 +508,7 @@ end
 
 function is_prefix_op_call(x::JuliaSyntax.GreenNode)
     is_opcall(x) || return false
-    haschildren(x) || return false
+    !is_leaf(x) || return false
 
     idx = findfirst(!JuliaSyntax.is_whitespace, children(x))
     isnothing(idx) && return false
@@ -532,7 +532,7 @@ function extract_operator_indices(childs::Vector{JuliaSyntax.GreenNode{T}}) wher
         push!(op_indices, args[i])
         if i < length(args) &&
            kind(childs[args[i]]) === K"." &&
-           !haschildren(childs[args[i]])
+           is_leaf(childs[args[i]])
             push!(op_indices, args[i+1])
             i += 1
         end
@@ -542,7 +542,7 @@ function extract_operator_indices(childs::Vector{JuliaSyntax.GreenNode{T}}) wher
 end
 
 function _callinfo(x::JuliaSyntax.GreenNode)
-    if !haschildren(x)
+    if is_leaf(x)
         return 0, 0
     end
     k = kind(x)
@@ -552,7 +552,7 @@ function _callinfo(x::JuliaSyntax.GreenNode)
     for c in children(x)
         if JuliaSyntax.is_whitespace(c) || is_punc(c)
             continue
-        elseif haschildren(c) || (!haschildren(c) && !JuliaSyntax.is_operator(c))
+        elseif !is_leaf(c) || (is_leaf(c) && !JuliaSyntax.is_operator(c))
             n_args += 1
         elseif k == K"dotcall" && JuliaSyntax.is_operator(c) && kind(c) == K"."
             continue
@@ -567,7 +567,7 @@ function is_unary(x::JuliaSyntax.GreenNode)
     if JuliaSyntax.is_unary_op(x)
         return true
     end
-    if kind(x) in KSet"call dotcall" || (JuliaSyntax.is_operator(x) && haschildren(x))
+    if kind(x) in KSet"call dotcall" || (JuliaSyntax.is_operator(x) && !is_leaf(x))
         nops, nargs = _callinfo(x)
         return nops == 1 && nargs == 1
     end
@@ -575,7 +575,7 @@ function is_unary(x::JuliaSyntax.GreenNode)
 end
 
 function is_binary(x)
-    if !JuliaSyntax.is_infix_op_call(x) && !(JuliaSyntax.is_operator(x) && haschildren(x))
+    if !JuliaSyntax.is_infix_op_call(x) && !(JuliaSyntax.is_operator(x) && !is_leaf(x))
         return false
     end
     nops, nargs = _callinfo(x)
@@ -613,7 +613,7 @@ function is_assignment(x::FST)
 end
 
 function is_assignment(t::JuliaSyntax.GreenNode)
-    if JuliaSyntax.is_prec_assignment(kind(t)) && haschildren(t)
+    if JuliaSyntax.is_prec_assignment(kind(t)) && !is_leaf(t)
         return !any(c -> kind(c) in KSet"in ∈", children(t))
     end
     return false
@@ -626,7 +626,7 @@ function is_pairarrow(cst::JuliaSyntax.GreenNode)::Bool
 end
 
 function is_function_or_macro_def(cst::JuliaSyntax.GreenNode)
-    if !haschildren(cst)
+    if is_leaf(cst)
         return false
     end
     k = kind(cst)
@@ -650,7 +650,7 @@ function is_function_like_lhs(node::JuliaSyntax.GreenNode)
     if k in KSet"call dotcall"
         return true
     elseif k == K"where" || k == K"::"
-        return haschildren(node) && is_function_like_lhs(node[1])
+        return !is_leaf(node) && is_function_like_lhs(node[1])
     end
     return false
 end
@@ -659,7 +659,7 @@ function has_leading_whitespace(n::JuliaSyntax.GreenNode)
     if kind(n) === K"Whitespace"
         return true
     end
-    if haschildren(n) && length(children(n)) > 0
+    if !is_leaf(n) && length(children(n)) > 0
         return has_leading_whitespace(n[1])
     end
     return false
@@ -677,7 +677,7 @@ function unnestable_node(cst::JuliaSyntax.GreenNode)
 end
 
 function is_binaryop_nestable(::AbstractStyle, cst::JuliaSyntax.GreenNode)
-    if (is_assignment(cst) || is_pairarrow(cst)) && haschildren(cst)
+    if (is_assignment(cst) || is_pairarrow(cst)) && !is_leaf(cst)
         childs = children(cst)
         idx = findlast(n -> !JuliaSyntax.is_whitespace(n), childs)::Int
         return !is_str_or_cmd(childs[idx])
@@ -686,9 +686,9 @@ function is_binaryop_nestable(::AbstractStyle, cst::JuliaSyntax.GreenNode)
 end
 
 function nest_rhs(cst::JuliaSyntax.GreenNode)::Bool
-    if defines_function(cst) && haschildren(cst)
+    if defines_function(cst) && !is_leaf(cst)
         for c in children(cst)
-            if is_if(c) || kind(c) in KSet"do try for while let" && haschildren(c)
+            if is_if(c) || kind(c) in KSet"do try for while let" && !is_leaf(c)
                 return true
             end
         end
@@ -705,11 +705,11 @@ function get_op(cst::JuliaSyntax.GreenNode)::Union{JuliaSyntax.GreenNode,Nothing
         kind(cst) in KSet"comparison dotcall call" ||
         is_chain(cst) ||
         is_unary(cst)
-    ) && haschildren(cst)
+    ) && !is_leaf(cst)
         for c in children(cst)
             if kind(cst) === K"dotcall" && kind(c) === K"."
                 continue
-            elseif JuliaSyntax.is_operator(c) && !haschildren(c)
+            elseif JuliaSyntax.is_operator(c) && is_leaf(c)
                 return c
             end
         end
@@ -871,11 +871,11 @@ function needs_placeholder(
 end
 
 function next_node_is(k::JuliaSyntax.Kind, nn::JuliaSyntax.GreenNode)
-    kind(nn) === k || (haschildren(nn) && next_node_is(k, nn[1]))
+    kind(nn) === k || (!is_leaf(nn) && next_node_is(k, nn[1]))
 end
 
 function next_node_is(f::Function, nn::JuliaSyntax.GreenNode)
-    f(nn) || (haschildren(nn) && next_node_is(f, nn[1]))
+    f(nn) || (!is_leaf(nn) && next_node_is(f, nn[1]))
 end
 
 """

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -274,16 +274,15 @@ function is_macrodoc(fst::FST)::Bool
 end
 
 function is_macrostr(t::JuliaSyntax.GreenNode)::Bool
-    kind(t) == K"macrocall" && haschildren(t) && contains_macrostr(t[1])
-end
+    # 1. First, confirm the node is a macro call with children.
+    #    A string macro must have a name (child 1) and an argument (child 2).
+    if kind(t) == K"macrocall" && length(children(t)) >= 2
+        # 2. Get the second child, which is the argument to the macro.
+        arg_node = t[2]
 
-function contains_macrostr(t::JuliaSyntax.GreenNode)::Bool
-    if kind(t) in KSet"StringMacroName CmdMacroName core_@cmd"
-        return true
-    elseif kind(t) === "quote" && haschildren(t)
-        return contains_macrostr(t[1])
-    elseif kind(t) === K"." && haschildren(t)
-        return any(contains_macrostr, reverse(children(t)))
+        # 3. Check if the argument is a literal string or command string.
+        #    This correctly identifies `mac"..."` (K"String") and `mac`...`` (K"CmdString").
+        return kind(arg_node) in KSet"String CmdString"
     end
     return false
 end

--- a/src/styles/blue/pretty.jl
+++ b/src/styles/blue/pretty.jl
@@ -39,7 +39,7 @@ function options(::BlueStyle)
 end
 
 function is_binaryop_nestable(::BlueStyle, cst::JuliaSyntax.GreenNode)
-    if is_assignment(cst) && haschildren(cst) && is_iterable(cst[end])
+    if is_assignment(cst) && !is_leaf(cst) && is_iterable(cst[end])
         return false
     end
     return is_binaryop_nestable(DefaultStyle(), cst)
@@ -69,7 +69,7 @@ function p_return(
 )
     style = getstyle(bs)
     t = FST(Return, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -60,7 +60,7 @@ function pretty(
         p_block(style, node, s, ctx, lineage)
     elseif k === K"function"
         p_functiondef(style, node, s, ctx, lineage)
-    elseif k in K"macrocall"
+    elseif k in KSet"macrocall"
         p_macrocall(style, node, s, ctx, lineage)
     elseif k === K"macro"
         p_macro(style, node, s, ctx, lineage)
@@ -1561,7 +1561,7 @@ function p_try(
             )
         elseif !JuliaSyntax.is_whitespace(c)
             # "catch" vs "catch ..."
-            if !(kind(cst) === K"catch" && any(n -> kind(n) === K"false", childs))
+            if !(kind(cst) === K"catch" && any(n -> kind(n) === K"Bool", childs))
                 add_node!(t, Whitespace(1), s)
             end
             add_node!(t, pretty(style, c, s, ctx, lineage), s; join_lines = true)

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -102,7 +102,7 @@ function pretty(
         p_bracescat(style, node, s, ctx, lineage)
     elseif k === K"tuple"
         p_tuple(style, node, s, ctx, lineage)
-    elseif k === K"cartesian_iterator"
+    elseif k === K"iteration"
         p_cartesian_iterator(style, node, s, ctx, lineage)
     elseif k === K"parens"
         p_invisbrackets(style, node, s, ctx, lineage)
@@ -1404,7 +1404,7 @@ function p_for(
             add_node!(t, pretty(style, c, s, ctx, lineage), s)
         else
             add_node!(t, Whitespace(1), s)
-            n = if kind(c) === K"cartesian_iterator"
+            n = if kind(c) === K"iteration"
                 s.indent += s.opts.indent
                 n = pretty(style, c, s, newctx(ctx; from_for = true), lineage)
                 s.indent -= s.opts.indent

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -509,7 +509,7 @@ function p_stringh(
     if !haschildren(cst)
         return FST(StringN, loc[2] - 1)
     end
-    loc2 = cursor_loc(s, s.offset+span(cst)-1)
+    loc2 = cursor_loc(s, s.offset + span(cst) - 1)
 
     val = getsrcval(s.doc, s.offset:(s.offset+span(cst)-1))
     startline = loc[1]
@@ -637,11 +637,12 @@ function p_macrocall(
     else
         # It's a space-separated macro call, like `@testset "..." begin ... end`
         # We format each argument and separate them with a space.
-        for (i, arg) in enumerate(args)
+        t.typ = MacroBlock
+
+        # **FIX:** The space is ONLY added for this case.
+        for arg in args
+            add_node!(t, Whitespace(1), s)
             add_node!(t, pretty(style, arg, s, ctx, lineage), s; join_lines = true)
-            if i < length(args)
-                add_node!(t, Whitespace(1), s)
-            end
         end
     end
 

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -60,8 +60,8 @@ function pretty(
         p_block(style, node, s, ctx, lineage)
     elseif k === K"function"
         p_functiondef(style, node, s, ctx, lineage)
-    elseif k in KSet"MacroName StringMacroName CmdMacroName core_@cmd"
-        p_macroname(style, node, s, ctx, lineage)
+    elseif k in K"macrocall"
+        p_macrocall(style, node, s, ctx, lineage)
     elseif k === K"macro"
         p_macro(style, node, s, ctx, lineage)
     elseif k === K"struct" && !JuliaSyntax.has_flags(node, JuliaSyntax.MUTABLE_FLAG)
@@ -585,6 +585,7 @@ function p_globalrefdoc(
 end
 
 # MacroCall
+# New p_macrocall for JuliaSyntax v1.0
 function p_macrocall(
     ds::AbstractStyle,
     cst::JuliaSyntax.GreenNode,
@@ -594,80 +595,57 @@ function p_macrocall(
 )
     style = getstyle(ds)
     t = FST(MacroCall, nspaces(s))
+    childs = children(cst)
 
-    if !haschildren(cst)
+    if isempty(childs)
         return t
     end
 
-    args = get_args(cst)
-    nest =
-        length(args) > 0 && !(
-            length(args) == 1 &&
-            (unnestable_node(args[1]) || s.opts.disallow_single_arg_nesting)
-        )
-    childs = children(cst)
+    # The macro name is *always* the first child.
+    name_node = childs[1]
+    name_fst = pretty(style, name_node, s, ctx, lineage)
 
-    has_closer = is_closer(childs[end])
-    is_macroblock = !has_closer
+    # This part from your original code is still good. It handles `@Mod.foo`.
+    name_fst = move_at_sign_to_the_end(name_fst, s)
+    add_node!(t, name_fst, s; join_lines = true)
 
+    # All subsequent children are arguments.
+    args = childs[2:end]
+    if isempty(args)
+        return t
+    end
+
+    # This is the key change: instead of checking for parens, we check if the
+    # single argument is a 'call' or 'tuple', which implies parens in the source.
+    is_paren_macro = length(args) == 1 && kind(args[1]) in KSet"call tuple"
+
+    # A "macro block" is a style like `@test "foo" begin ... end`
+    # It has multiple space-separated arguments.
+    is_macroblock = !is_paren_macro
     if is_macroblock
         t.typ = MacroBlock
     end
 
-    ctx = newctx(ctx; can_separate_kwargs = false)
-    for (i, a) in enumerate(childs)
-        n = pretty(style, a, s, ctx, lineage)::FST
-        if JuliaSyntax.is_macro_name(a)
-            add_node!(t, n, s; join_lines = true)
-        elseif kind(a) === K"("
-            add_node!(t, n, s; join_lines = true)
-            if nest
-                add_node!(t, Placeholder(0), s)
-            else
-                false
-            end
-        elseif kind(a) === K")"
-            if nest
-                add_node!(t, Placeholder(0), s)
-            else
-                false
-            end
-            add_node!(t, n, s; join_lines = true)
-        elseif kind(a) === K","
-            add_node!(t, n, s; join_lines = true)
-            if needs_placeholder(childs, i + 1, K")")
-                add_node!(t, Placeholder(1), s)
-            end
-        elseif JuliaSyntax.is_whitespace(a)
-            add_node!(t, n, s; join_lines = true)
-        elseif is_macroblock
-            if n.typ === MacroBlock && t[end].typ === WHITESPACE
-                t[end] = Placeholder(length(t[end].val))
-            end
+    # Add a space before the first argument.
+    add_node!(t, Whitespace(1), s)
 
-            max_padding = is_block(n) ? 0 : -1
-            join_lines = t.endline == n.startline
-
-            if join_lines && (i > 1 && kind(childs[i-1]) in KSet"NewlineWs Whitespace") ||
-               next_node_is(nn -> kind(nn) in KSet"NewlineWs Whitespace", childs[i])
+    if is_paren_macro
+        # If it's a parenthesized macro, we just need to format the single
+        # 'call' or 'tuple' node. The `p_call` or `p_tuple` function
+        # will handle the parentheses, commas, and nesting for us.
+        add_node!(t, pretty(style, args[1], s, ctx, lineage), s; join_lines = true)
+    else
+        # It's a space-separated macro call, like `@testset "..." begin ... end`
+        # We format each argument and separate them with a space.
+        for (i, arg) in enumerate(args)
+            add_node!(t, pretty(style, arg, s, ctx, lineage), s; join_lines = true)
+            if i < length(args)
                 add_node!(t, Whitespace(1), s)
-            end
-            add_node!(t, n, s; join_lines, max_padding)
-        else
-            if has_closer
-                add_node!(t, n, s; join_lines = true)
-            else
-                padding = is_block(n) ? 0 : -1
-                add_node!(t, n, s; join_lines = true, max_padding = padding)
             end
         end
     end
 
-    # move placement of @ to the end
-    #
-    # @Module.macro -> Module.@macro
-    t[1] = move_at_sign_to_the_end(t[1], s)
-    t
+    return t
 end
 
 # Block
@@ -730,7 +708,7 @@ function p_block(
         elseif single_line
             if kind(a) in KSet", ;"
                 add_node!(t, n, s; join_lines = true)
-                if needs_placeholder(childs, i+1, K")")
+                if needs_placeholder(childs, i + 1, K")")
                     add_node!(t, Placeholder(1), s)
                 end
             else

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -32,9 +32,9 @@ function pretty(
     style = getstyle(ds)
     push!(lineage, (k, is_iterable(node), is_assignment(node)))
 
-    ret = if k == K"Identifier" && !haschildren(node)
+    ret = if k == K"Identifier" && is_leaf(node)
         p_identifier(style, node, s, ctx, lineage)
-    elseif JuliaSyntax.is_operator(node) && !haschildren(node)
+    elseif JuliaSyntax.is_operator(node) && is_leaf(node)
         p_operator(style, node, s, ctx, lineage)
     elseif k == K"Comment"
         p_comment(style, node, s, ctx, lineage)
@@ -42,9 +42,9 @@ function pretty(
         p_whitespace(style, node, s, ctx, lineage)
     elseif k == K";"
         p_semicolon(style, node, s, ctx, lineage)
-    elseif is_punc(node) && !haschildren(node)
+    elseif is_punc(node) && is_leaf(node)
         p_punctuation(style, node, s, ctx, lineage)
-    elseif JuliaSyntax.is_keyword(node) && !haschildren(node)
+    elseif JuliaSyntax.is_keyword(node) && is_leaf(node)
         p_keyword(style, node, s, ctx, lineage)
     elseif k in KSet"string cmdstring char"
         p_stringh(style, node, s, ctx, lineage)
@@ -52,7 +52,7 @@ function pretty(
         p_literal(style, node, s, ctx, lineage)
     elseif k == K"as"
         p_as(style, node, s, ctx, lineage)
-    elseif k === K"." && haschildren(node)
+    elseif k === K"." && !is_leaf(node)
         p_accessor(style, node, s, ctx, lineage)
     elseif k === K"block" && length(children(node)) > 1 && kind(node[1]) === K"begin"
         p_begin(style, node, s, ctx, lineage)
@@ -84,9 +84,9 @@ function pretty(
         p_if(style, node, s, ctx, lineage)
     elseif k === K"toplevel"
         p_toplevel(style, node, s, ctx, lineage)
-    elseif k === K"quote" && haschildren(node) && kind(node[1]) === K":"
+    elseif k === K"quote" && !is_leaf(node) && kind(node[1]) === K":"
         p_quotenode(style, node, s, ctx, lineage)
-    elseif k === K"quote" && haschildren(node)
+    elseif k === K"quote" && !is_leaf(node)
         p_quote(style, node, s, ctx, lineage)
     elseif k === K"let"
         p_let(style, node, s, ctx, lineage)
@@ -119,7 +119,7 @@ function pretty(
         p_macrocall(style, node, s, ctx, lineage)
     elseif k === K"where"
         p_whereopcall(style, node, s, ctx, lineage)
-    elseif k === K"?" && haschildren(node)
+    elseif k === K"?" && !is_leaf(node)
         p_conditionalopcall(style, node, s, ctx, lineage)
     elseif is_binary(node)
         p_binaryopcall(style, node, s, ctx, lineage)
@@ -131,7 +131,7 @@ function pretty(
         p_call(style, node, s, ctx, lineage)
     elseif k === K"comparison"
         p_comparison(style, node, s, ctx, lineage)
-    elseif JuliaSyntax.is_operator(node) && haschildren(node)
+    elseif JuliaSyntax.is_operator(node) && !is_leaf(node)
         p_binaryopcall(style, node, s, ctx, lineage)
     elseif k in KSet"dotcall call"
         p_binaryopcall(style, node, s, ctx, lineage)
@@ -335,7 +335,7 @@ function p_juxtapose(
 )
     style = getstyle(ds)
     t = FST(Juxtapose, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -355,7 +355,7 @@ function p_continue(
 )
     style = getstyle(ds)
     t = FST(Continue, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -375,7 +375,7 @@ function p_break(
 )
     style = getstyle(ds)
     t = FST(Break, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -396,7 +396,7 @@ function p_inert(
 )
     style = getstyle(ds)
     t = FST(Inert, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -416,7 +416,7 @@ function p_macrostr(
 )
     style = getstyle(ds)
     t = FST(MacroStr, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -489,7 +489,7 @@ function p_accessor(
 )
     style = getstyle(ds)
     t = FST(Accessor, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -509,7 +509,7 @@ function p_stringh(
 )
     style = getstyle(ds)
     loc = cursor_loc(s)
-    if !haschildren(cst)
+    if is_leaf(cst)
         return FST(StringN, loc[2] - 1)
     end
     loc2 = cursor_loc(s, s.offset + span(cst) - 1)
@@ -564,7 +564,7 @@ function p_globalrefdoc(
 )
     style = getstyle(ds)
     t = FST(GlobalRefDoc, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -598,7 +598,7 @@ function p_macrocall(
     style = getstyle(ds)
     t = FST(MacroCall, nspaces(s))
 
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -672,7 +672,7 @@ function p_block(
 )
     style = getstyle(ds)
     t = FST(Block, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -786,7 +786,7 @@ function p_abstract(
 )
     style = getstyle(ds)
     t = FST(Abstract, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -809,7 +809,7 @@ function p_primitive(
 )
     style = getstyle(ds)
     t = FST(Primitive, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -831,7 +831,7 @@ function p_var(
 )
     style = getstyle(ds)
     t = FST(NonStdIdentifier, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -851,7 +851,7 @@ function p_functiondef(
 )
     style = getstyle(ds)
     t = FST(FunctionN, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -878,7 +878,7 @@ function p_functiondef(
                 add_node!(t, Whitespace(1), s)
                 add_node!(t, n, s; join_lines = true)
             end
-        elseif kind(c) === K"block" && haschildren(c)
+        elseif kind(c) === K"block" && !is_leaf(c)
             block_has_contents =
                 length(filter(cc -> !JuliaSyntax.is_whitespace(cc), children(c))) > 0
 
@@ -922,7 +922,7 @@ function p_struct(
 )
     style = getstyle(ds)
     t = FST(Struct, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -949,7 +949,7 @@ function p_struct(
                 add_node!(t, Whitespace(1), s)
                 add_node!(t, n, s; join_lines = true)
             end
-        elseif kind(c) === K"block" && haschildren(c)
+        elseif kind(c) === K"block" && !is_leaf(c)
             block_has_contents =
                 length(filter(cc -> !JuliaSyntax.is_whitespace(cc), children(c))) > 0
             s.indent += s.opts.indent
@@ -976,7 +976,7 @@ function p_mutable(
 )
     style = getstyle(ds)
     t = FST(Mutable, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -1003,7 +1003,7 @@ function p_mutable(
                 add_node!(t, Whitespace(1), s)
                 add_node!(t, n, s; join_lines = true)
             end
-        elseif kind(c) === K"block" && haschildren(c)
+        elseif kind(c) === K"block" && !is_leaf(c)
             block_has_contents =
                 length(filter(cc -> !JuliaSyntax.is_whitespace(cc), children(c))) > 0
             s.indent += s.opts.indent
@@ -1030,7 +1030,7 @@ function p_module(
 )
     style = getstyle(ds)
     t = FST(ModuleN, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -1040,7 +1040,7 @@ function p_module(
     indent_module = s.opts.indent_submodule && from_module
 
     for c in childs
-        if kind(c) in KSet"module baremodule" && !haschildren(c)
+        if kind(c) in KSet"module baremodule" && is_leaf(c)
             n = pretty(style, c, s, ctx, lineage)
             add_node!(t, n, s; join_lines = true)
             add_node!(t, Whitespace(1), s)
@@ -1060,7 +1060,7 @@ function p_module(
                 add_node!(t, Whitespace(1), s)
                 add_node!(t, n, s; join_lines = true)
             end
-        elseif kind(c) === K"block" && haschildren(c)
+        elseif kind(c) === K"block" && !is_leaf(c)
             block_has_contents =
                 length(filter(cc -> !JuliaSyntax.is_whitespace(cc), children(c))) > 0
 
@@ -1126,7 +1126,7 @@ function p_const(
 )
     style = getstyle(ds)
     t = FST(Const, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -1134,7 +1134,7 @@ function p_const(
         if kind(c) === K","
         elseif !JuliaSyntax.is_whitespace(c) && !JuliaSyntax.is_keyword(c)
             add_node!(t, Whitespace(1), s)
-        elseif !JuliaSyntax.is_whitespace(c) && JuliaSyntax.is_keyword(c) && haschildren(c)
+        elseif !JuliaSyntax.is_whitespace(c) && JuliaSyntax.is_keyword(c) && !is_leaf(c)
             add_node!(t, Whitespace(1), s)
         end
         add_node!(t, pretty(style, c, s, ctx, lineage), s; join_lines = true)
@@ -1187,7 +1187,7 @@ function p_toplevel(
 )
     style = getstyle(ds)
     t = FST(TopLevel, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -1211,7 +1211,7 @@ function p_begin(
 )
     style = getstyle(ds)
     t = FST(Begin, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -1250,7 +1250,7 @@ function p_quote(
 )
     style = getstyle(ds)
     t = FST(Quote, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -1278,7 +1278,7 @@ function p_quotenode(
 )
     style = getstyle(ds)
     t = FST(Quotenode, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -1316,7 +1316,7 @@ function p_let(
 )
     style = getstyle(ds)
     t = FST(Let, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
     block_id = 1
@@ -1329,7 +1329,7 @@ function p_let(
             s.indent += s.opts.indent
             if block_id == 1
                 has_let_args =
-                    haschildren(c) &&
+                    !is_leaf(c) &&
                     any(n -> kind(n) === K"," || is_iterable(n), children(c))
                 add_node!(
                     t,
@@ -1393,14 +1393,14 @@ function p_for(
 )
     style = getstyle(ds)
     t = FST(For, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
     ends_in_iterable = false
 
     for c in children(cst)
-        if kind(c) in KSet"for while" && !haschildren(c)
+        if kind(c) in KSet"for while" && is_leaf(c)
             add_node!(t, pretty(style, c, s), s)
         elseif kind(c) === K"end"
             add_node!(t, pretty(style, c, s), s)
@@ -1448,7 +1448,7 @@ function p_cartesian_iterator(
 )
     style = getstyle(ds)
     t = FST(CartesianIterator, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -1496,13 +1496,13 @@ function p_do(
 )
     style = getstyle(ds)
     t = FST(Do, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
     childs = children(cst)
     for (i, c) in enumerate(childs)
-        if kind(c) === K"do" && !haschildren(c)
+        if kind(c) === K"do" && is_leaf(c)
             add_node!(t, Whitespace(1), s)
             add_node!(t, pretty(style, c, s, ctx, lineage), s; join_lines = true)
             if !next_node_is(K"NewlineWs", childs[i+1])
@@ -1535,7 +1535,7 @@ function p_try(
 )
     style = getstyle(ds)
     t = FST(Try, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -1550,7 +1550,7 @@ function p_try(
     childs = children(cst)
     for c in childs
         if kind(c) in KSet"try catch finally else"
-            if !haschildren(c)
+            if is_leaf(c)
                 if kind(c) in KSet"catch finally else"
                     s.indent -= s.opts.indent
                 end
@@ -1595,13 +1595,13 @@ function p_if(
 )
     style = getstyle(ds)
     t = FST(If, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
     for c in children(cst)
         if kind(c) in KSet"if elseif else"
-            if !haschildren(c)
+            if is_leaf(c)
                 add_node!(t, pretty(style, c, s, ctx, lineage), s; max_padding = 0)
             else
                 len = length(t)
@@ -1667,7 +1667,7 @@ function p_kw(
 )
     style = getstyle(ds)
     t = FST(Kw, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -1715,7 +1715,7 @@ function p_binaryopcall(
 )
     style = getstyle(ds)
     t = FST(Binary, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -1827,7 +1827,7 @@ function p_binaryopcall(
         )
 
         is_dot = kind(c) === K"."
-        if is_dot && haschildren(c) && length(children(c)) == 2
+        if is_dot && !is_leaf(c) && length(children(c)) == 2
             # [.]
             #   .
             #   <=
@@ -1847,8 +1847,8 @@ function p_binaryopcall(
                 end
             end
             after_op = true
-            # elseif (kind(c) === opkind || kind(c) === K".") && !haschildren(c)
-        elseif JuliaSyntax.is_operator(c) && !haschildren(c) && i in op_indices
+            # elseif (kind(c) === opkind || kind(c) === K".") && is_leaf(c)
+        elseif JuliaSyntax.is_operator(c) && is_leaf(c) && i in op_indices
             # there are some weird cases where we can assign an operator a value so that
             # the arguments are operators as well.
             #
@@ -1859,7 +1859,7 @@ function p_binaryopcall(
             if ns > 0 && i > 1
                 if kind(childs[i-1]) !== K"."  # Don't add space if previous was a dot
                     add_node!(t, Whitespace(ns), s)
-                elseif kind(childs[i-1]) === K"." && haschildren(childs[i-1])  # Don't add space if previous was a dot
+                elseif kind(childs[i-1]) === K"." && !is_leaf(childs[i-1])  # Don't add space if previous was a dot
                     add_node!(t, Whitespace(ns), s)
                 end
             end
@@ -1943,7 +1943,7 @@ function p_whereopcall(
 )
     style = getstyle(ds)
     t = FST(Where, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -1955,7 +1955,7 @@ function p_whereopcall(
         )
 
     childs = children(cst)
-    where_idx = findfirst(c -> kind(c) === K"where" && !haschildren(c), childs)
+    where_idx = findfirst(c -> kind(c) === K"where" && is_leaf(c), childs)
     curly_ctx = if where_idx === nothing
         ctx.from_typedef
     else
@@ -1971,7 +1971,7 @@ function p_whereopcall(
 
     after_where = false
     for (i, a) in enumerate(childs)
-        if kind(a) === K"where" && !haschildren(a)
+        if kind(a) === K"where" && is_leaf(a)
             add_node!(t, Whitespace(1), s)
             add_node!(t, pretty(style, a, s, ctx, lineage), s; join_lines = true)
             add_node!(t, Whitespace(1), s)
@@ -2021,12 +2021,12 @@ function p_conditionalopcall(
 )
     style = getstyle(ds)
     t = FST(Conditional, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
     for c in children(cst)
-        if kind(c) in KSet"? :" && !haschildren(c)
+        if kind(c) in KSet"? :" && is_leaf(c)
             add_node!(t, Whitespace(1), s)
             add_node!(t, pretty(style, c, s, ctx, lineage), s; join_lines = true)
             add_node!(t, Placeholder(1), s)
@@ -2047,7 +2047,7 @@ function p_unaryopcall(
 )
     style = getstyle(ds)
     t = FST(Unary, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -2074,7 +2074,7 @@ function p_curly(
 )
     style = getstyle(ds)
     t = FST(Curly, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -2123,7 +2123,7 @@ function p_call(
 )
     style = getstyle(ds)
     t = FST(Call, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -2137,7 +2137,7 @@ function p_call(
     childs = children(cst)
     for (i, a) in enumerate(childs)
         k = kind(a)
-        n = if k == K"=" && haschildren(a)
+        n = if k == K"=" && !is_leaf(a)
             p_kw(style, a, s, ctx, lineage)
         else
             pretty(style, a, s, ctx, lineage)
@@ -2182,7 +2182,7 @@ function p_invisbrackets(
 )
     style = getstyle(ds)
     t = FST(Brackets, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -2190,7 +2190,7 @@ function p_invisbrackets(
     nest = if length(args) > 0
         arg = args[1]
         if is_block(arg) ||
-           (kind(arg) === K"generator" && haschildren(arg) && is_block(arg[1]))
+           (kind(arg) === K"generator" && !is_leaf(arg) && is_block(arg[1]))
             t.nest_behavior = AlwaysNest
         end
         if !ctx.nonest && !s.opts.disallow_single_arg_nesting
@@ -2243,7 +2243,7 @@ function p_tupleblock(
 )
     style = getstyle(ds)
     t = FST(TupleBlock, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -2256,7 +2256,7 @@ function p_tupleblock(
 
     childs = children(cst)
     for (i, a) in enumerate(childs)
-        n = if kind(a) === K"=" && haschildren(a)
+        n = if kind(a) === K"=" && !is_leaf(a)
             p_kw(style, a, s, ctx, lineage)
         else
             pretty(style, a, s, ctx, lineage)
@@ -2292,7 +2292,7 @@ function p_tuple(
 )
     style = getstyle(ds)
     t = FST(TupleN, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -2305,7 +2305,7 @@ function p_tuple(
 
     childs = children(cst)
     for (i, a) in enumerate(childs)
-        n = if kind(a) === K"=" && haschildren(a)
+        n = if kind(a) === K"=" && !is_leaf(a)
             p_kw(style, a, s, ctx, lineage)
         else
             pretty(style, a, s, ctx, lineage)
@@ -2351,7 +2351,7 @@ function p_braces(
 )
     style = getstyle(ds)
     t = FST(Braces, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -2402,7 +2402,7 @@ function p_bracescat(
 )
     style = getstyle(ds)
     t = FST(BracesCat, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -2452,7 +2452,7 @@ function p_vect(
 )
     style = getstyle(ds)
     t = FST(Vect, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -2501,7 +2501,7 @@ function p_comprehension(
 )
     style = getstyle(ds)
     t = FST(Comprehension, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -2514,7 +2514,7 @@ function p_comprehension(
 
     if is_block(arg)
         t.nest_behavior = AlwaysNest
-    elseif kind(arg) === K"generator" && haschildren(arg)
+    elseif kind(arg) === K"generator" && !is_leaf(arg)
         idx = findfirst(n -> !JuliaSyntax.is_whitespace(kind(n)), children(arg))
         if !isnothing(idx) && is_block(arg[idx])
             t.nest_behavior = AlwaysNest
@@ -2558,7 +2558,7 @@ function p_parameters(
 )
     style = getstyle(ds)
     t = FST(Parameters, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -2566,7 +2566,7 @@ function p_parameters(
 
     childs = children(cst)
     for (i, a) in enumerate(childs)
-        n = if kind(a) === K"=" && haschildren(a)
+        n = if kind(a) === K"=" && !is_leaf(a)
             p_kw(style, a, s, ctx, lineage)
         else
             pretty(style, a, s, ctx, lineage)
@@ -2593,7 +2593,7 @@ function p_import(
 )
     style = getstyle(ds)
     t = FST(Import, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -2601,7 +2601,7 @@ function p_import(
         if kind(a) in KSet"import export public using"
             add_node!(t, pretty(style, a, s, ctx, lineage), s; join_lines = true)
             add_node!(t, Whitespace(1), s)
-        elseif kind(a) === K":" && haschildren(a)
+        elseif kind(a) === K":" && !is_leaf(a)
             nodes = children(a)
             for n in nodes
                 add_node!(t, pretty(style, n, s, ctx, lineage), s; join_lines = true)
@@ -2666,7 +2666,7 @@ function p_importpath(
 )
     style = getstyle(ds)
     t = FST(ImportPath, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -2686,7 +2686,7 @@ function p_as(
 )
     style = getstyle(ds)
     t = FST(As, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -2713,7 +2713,7 @@ function p_ref(
 )
     style = getstyle(ds)
     t = FST(RefN, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -2763,7 +2763,7 @@ function p_vcat(
 )
     style = getstyle(ds)
     t = FST(Vcat, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -2845,7 +2845,7 @@ function p_hcat(
 )
     style = getstyle(ds)
     t = FST(Hcat, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -2914,7 +2914,7 @@ function p_row(
 )
     style = getstyle(ds)
     t = FST(Row, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -2964,7 +2964,7 @@ function p_generator(
 )
     style = getstyle(ds)
     t = FST(Generator, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -2985,7 +2985,7 @@ function p_generator(
 
     for (i, a) in enumerate(childs)
         n = pretty(style, a, s, newctx(ctx; from_for = has_for_kw), lineage)
-        if JuliaSyntax.is_keyword(a) && !haschildren(a)
+        if JuliaSyntax.is_keyword(a) && is_leaf(a)
             # for keyword can only be on the following line
             # if this expression is within an iterable expression
             if kind(a) === K"for" && from_iterable

--- a/src/styles/sciml/pretty.jl
+++ b/src/styles/sciml/pretty.jl
@@ -135,7 +135,7 @@ function p_macrocall(
 )
     style = getstyle(ss)
     t = FST(MacroCall, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -152,7 +152,7 @@ function p_macrocall(
         idx === nothing ? -1 : findnext(a -> !JuliaSyntax.is_whitespace(a), childs, idx + 1)
 
     # https://github.com/SciML/SciMLStyle?tab=readme-ov-file#macros
-    n_kw_args = count(a -> kind(a) === K"=" && haschildren(a), childs)
+    n_kw_args = count(a -> kind(a) === K"=" && !is_leaf(a), childs)
     nospace = n_kw_args > 1
 
     for (i, a) in enumerate(childs)

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -61,7 +61,7 @@ function p_import(
 )
     style = getstyle(ds)
     t = FST(Import, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -69,7 +69,7 @@ function p_import(
         if kind(a) in KSet"import export using public"
             add_node!(t, pretty(style, a, s, ctx, lineage), s; join_lines = true)
             add_node!(t, Whitespace(1), s)
-        elseif kind(a) === K":" && haschildren(a)
+        elseif kind(a) === K":" && !is_leaf(a)
             nodes = children(a)
             for n in nodes
                 add_node!(t, pretty(style, n, s, ctx, lineage), s; join_lines = true)
@@ -138,7 +138,7 @@ function p_curly(
     style = getstyle(ys)
     nws = s.opts.whitespace_typedefs ? 1 : 0
     t = FST(Curly, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -178,7 +178,7 @@ function p_braces(
 )
     style = getstyle(ys)
     t = FST(Braces, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
     from_typedef = ctx.from_typedef
@@ -221,7 +221,7 @@ function p_bracescat(
 )
     style = getstyle(ys)
     t = FST(BracesCat, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
     from_typedef = ctx.from_typedef
@@ -264,7 +264,7 @@ function p_tupleblock(
 )
     style = getstyle(ys)
     t = FST(TupleBlock, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -275,7 +275,7 @@ function p_tupleblock(
         isnothing(idx) ? -1 : findnext(n -> !JuliaSyntax.is_whitespace(n), childs, idx + 1)
 
     for (i, a) in enumerate(childs)
-        n = if kind(a) === K"=" && haschildren(a)
+        n = if kind(a) === K"=" && !is_leaf(a)
             p_kw(style, a, s, ctx, lineage)
         else
             pretty(style, a, s, ctx, lineage)
@@ -312,7 +312,7 @@ function p_tuple(
 )
     style = getstyle(ys)
     t = FST(TupleN, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -323,7 +323,7 @@ function p_tuple(
         isnothing(idx) ? -1 : findnext(n -> !JuliaSyntax.is_whitespace(n), childs, idx + 1)
 
     for (i, a) in enumerate(childs)
-        n = if kind(a) === K"=" && haschildren(a)
+        n = if kind(a) === K"=" && !is_leaf(a)
             p_kw(style, a, s, ctx, lineage)
         else
             pretty(style, a, s, ctx, lineage)
@@ -361,7 +361,7 @@ function p_invisbrackets(
 )
     style = getstyle(ys)
     t = FST(Brackets, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -369,7 +369,7 @@ function p_invisbrackets(
     if length(args) > 0
         arg = args[1]
         if is_block(arg) ||
-           (kind(arg) === K"generator" && haschildren(arg) && is_block(arg[1]))
+           (kind(arg) === K"generator" && !is_leaf(arg) && is_block(arg[1]))
             t.nest_behavior = AlwaysNest
         end
     end
@@ -395,7 +395,7 @@ function p_call(
 )
     style = getstyle(ys)
     t = FST(Call, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -406,7 +406,7 @@ function p_call(
     # and use `p_call` from `DefaultStyle` instead to allow both
     # `caller(something,...)` and `caller(\n,...)`.
     if length(s.opts.variable_call_indent) > 0
-        offset = if kind(childs[1]) === K"curly" && haschildren(childs[1])
+        offset = if kind(childs[1]) === K"curly" && !is_leaf(childs[1])
             childs2 = children(childs[1])::Vector{JuliaSyntax.GreenNode{JuliaSyntax.SyntaxHead}}
             if length(childs2) > 0
                 span(childs2[1]) + span(childs[2]) - 2
@@ -429,7 +429,7 @@ function p_call(
 
     for (i, a) in enumerate(childs)
         k = kind(a)
-        n = if k == K"=" && haschildren(a)
+        n = if k == K"=" && !is_leaf(a)
             p_kw(style, a, s, ctx, lineage)
         else
             pretty(style, a, s, ctx, lineage)
@@ -470,7 +470,7 @@ function p_vect(
 )
     style = getstyle(ys)
     t = FST(Vect, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -511,7 +511,7 @@ function p_vcat(
 )
     style = getstyle(ys)
     t = FST(Vcat, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -599,7 +599,7 @@ function p_ref(
 )
     style = getstyle(ys)
     t = FST(RefN, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -643,7 +643,7 @@ function p_comprehension(
 )
     style = getstyle(ys)
     t = FST(Comprehension, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -654,7 +654,7 @@ function p_comprehension(
     )
     arg = childs[idx]
 
-    if is_block(arg) || (kind(arg) === K"generator" && haschildren(arg) && is_block(arg[1]))
+    if is_block(arg) || (kind(arg) === K"generator" && !is_leaf(arg) && is_block(arg[1]))
         t.nest_behavior = AlwaysNest
     end
 
@@ -697,7 +697,7 @@ function p_macrocall(
 )
     style = getstyle(ys)
     t = FST(MacroCall, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -766,14 +766,14 @@ function p_whereopcall(
 )
     style = getstyle(ys)
     t = FST(Where, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
     from_typedef = ctx.from_typedef
 
     childs = children(cst)
-    where_idx = findfirst(c -> kind(c) === K"where" && !haschildren(c), childs)
+    where_idx = findfirst(c -> kind(c) === K"where" && is_leaf(c), childs)
     curly_ctx = if where_idx === nothing
         from_typedef
     else
@@ -793,7 +793,7 @@ function p_whereopcall(
 
     after_where = false
     for (i, a) in enumerate(childs)
-        if kind(a) === K"where" && !haschildren(a)
+        if kind(a) === K"where" && is_leaf(a)
             add_node!(t, Whitespace(1), s)
             add_node!(t, pretty(style, a, s, ctx, lineage), s; join_lines = true)
             add_node!(t, Whitespace(1), s)
@@ -853,7 +853,7 @@ function p_generator(
 )
     style = getstyle(ys)
     t = FST(Generator, nspaces(s))
-    if !haschildren(cst)
+    if is_leaf(cst)
         return t
     end
 
@@ -875,7 +875,7 @@ function p_generator(
 
     for (i, a) in enumerate(childs)
         n = pretty(style, a, s, newctx(ctx; from_for = has_for_kw), lineage)
-        if JuliaSyntax.is_keyword(a) && !haschildren(a)
+        if JuliaSyntax.is_keyword(a) && is_leaf(a)
             idx = findprev(n -> !JuliaSyntax.is_whitespace(n), childs, i - 1)
             if !isnothing(idx) && is_block(childs[idx])
                 add_node!(t, Newline(), s)


### PR DESCRIPTION
Disclaimer: I'm in no way familiar with JuliaSyntax, just play with Gemini and try to make it not error.
related to #901 #928 
No error on the kinds part now, I fixed the lost API of `core_@cmd` (macro is now parsed to a tree), `false` (this is `Bool` now), `cartesian_iteration` (maybe it's `iteraction` now? https://github.com/JuliaLang/JuliaSyntax.jl/issues/432)   

changed deprecated `has_children` to `!is_leaf`.

I would admit I don't fully understand the change, but I hope it would be a good starting point? 