### PR TITLE
Fix function call formatting

### DIFF
--- a/src/styles/sciml/nest.jl
+++ b/src/styles/sciml/nest.jl
@@ -25,24 +25,37 @@ for f in [
     end
 end
 
-# function n_binaryopcall!(ss::SciMLStyle, fst::FST, s::State, lineage::Vector{Tuple{FNode,Union{Nothing,Metadata}}}; indent::Int = -1)
-#     style = getstyle(ss)
-#     line_margin = s.line_offset + length(fst) + fst.extra_margin
-#     if line_margin > s.opts.margin && !isnothing(fst.metadata) && fst.metadata.is_short_form_function
-#         transformed = short_to_long_function_def!(fst, s)
-#         transformed && nest!(style, fst, s, lineage)
-#         return
-#     end
-#
-#     if findfirst(n -> n.typ === PLACEHOLDER, fst.nodes) !== nothing
-#         n_binaryopcall!(DefaultStyle(style), fst, s, lineage; indent = indent)
-#         return
-#     end
-#
-#     start_line_offset = s.line_offset
-#     walk(increment_line_offset!, (fst.nodes::Vector)[1:end-1], s, fst.indent)
-#     nest!(style, fst[end], s, lineage)
-# end
+function n_binaryopcall!(ss::SciMLStyle, fst::FST, s::State, lineage::Vector{Tuple{FNode,Union{Nothing,Metadata}}}; indent::Int = -1)
+    style = getstyle(ss)
+    line_margin = s.line_offset + length(fst) + fst.extra_margin
+    
+    # For assignments with tuple LHS, check if we should keep the LHS intact
+    if !isnothing(fst.metadata) && fst.metadata.is_assignment && length(fst.nodes) >= 3
+        lhs = fst[1]
+        op = fst[2]
+        
+        # If LHS is a tuple, only break at the assignment operator, not within the tuple
+        if lhs.typ === TupleN
+            # Calculate margin if we break after the assignment
+            lhs_length = s.line_offset + length(lhs) + length(op) + 1  # +1 for space after =
+            
+            # If breaking after = keeps us reasonable, do that instead of breaking the tuple
+            if lhs_length <= s.opts.margin * 1.2
+                # Mark the LHS tuple to not nest internally
+                lhs.nest_behavior = NeverNest
+            end
+        end
+    end
+    
+    if line_margin > s.opts.margin && !isnothing(fst.metadata) && fst.metadata.is_short_form_function
+        transformed = short_to_long_function_def!(fst, s, lineage)
+        transformed && nest!(style, fst, s, lineage)
+        return transformed
+    end
+
+    # Use default nesting behavior
+    return n_binaryopcall!(DefaultStyle(style), fst, s, lineage; indent = indent)
+end
 
 function n_functiondef!(
     ss::SciMLStyle,
@@ -155,13 +168,16 @@ function _n_tuple!(
     should_nest = line_margin > s.opts.margin || must_nest(fst) || src_diff_line
     
     # For certain types, be more conservative about nesting
+    # Only nest if we're significantly over the margin
     if should_nest && !must_nest(fst) && !src_diff_line
         total_length = line_margin
-        if (fst.typ === Call && length(placeholder_inds) <= 5 && total_length <= s.opts.margin + 20)
+        
+        # For function calls, only nest if we're over margin by more than 10%
+        if (fst.typ === Call && total_length <= s.opts.margin * 1.1)
             should_nest = false
-        elseif (fst.typ === Binary || fst.typ === Chain) && length(placeholder_inds) <= 6 && total_length <= s.opts.margin + 20
+        elseif (fst.typ === Binary || fst.typ === Chain) && total_length <= s.opts.margin * 1.15
             should_nest = false
-        elseif (fst.typ === RefN && length(placeholder_inds) <= 4 && total_length <= s.opts.margin + 30)
+        elseif (fst.typ === RefN && total_length <= s.opts.margin * 1.2)
             # Keep array indexing together when reasonable (e.g., du[i, j, 1])
             should_nest = false
         end
@@ -276,8 +292,37 @@ function n_ref!(
     end
 end
 
+# Override n_tuple! specifically to handle assignment LHS better
+function n_tuple!(
+    ss::SciMLStyle,
+    fst::FST,
+    s::State,
+    lineage::Vector{Tuple{FNode,Union{Nothing,Metadata}}},
+)
+    # Check if this tuple is the LHS of an assignment
+    if length(lineage) >= 1 && !isnothing(lineage[end][2]) && lineage[end][2].is_assignment
+        # For assignment LHS tuples, be very conservative about nesting
+        line_margin = s.line_offset + length(fst) + fst.extra_margin
+        if line_margin <= s.opts.margin * 1.3
+            # Don't nest if we're only slightly over
+            lo = s.line_offset
+            for n in fst.nodes
+                nest!(ss, n, s, lineage)
+                s.line_offset += length(n)
+            end
+            s.line_offset = lo + length(fst)
+            return false
+        end
+    end
+    
+    if s.opts.yas_style_nesting
+        n_tuple!(YASStyle(getstyle(ss)), fst, s, lineage)
+    else
+        _n_tuple!(getstyle(ss), fst, s, lineage)
+    end
+end
+
 for f in [
-    :n_tuple!,
     :n_call!,
     :n_curly!,
     :n_macrocall!,

--- a/test/debug_assignment.jl
+++ b/test/debug_assignment.jl
@@ -1,0 +1,24 @@
+using JuliaFormatter
+
+# Test case: assignment with tuple on LHS
+code = """
+discrete_modified, saved_in_cb = DiffEqBase.apply_discrete_callback!(integrator, integrator.opts.callback.discrete_callbacks...)
+"""
+
+# Try with different margin settings
+println("With margin = 92 (default):")
+println(format_text(code, SciMLStyle()))
+
+println("\nWith margin = 150 (wide):")
+println(format_text(code, SciMLStyle(), margin=150))
+
+# Test a simpler case
+code2 = """
+a, b = some_function_call(arg1, arg2, arg3)
+"""
+
+println("\nSimpler test:")
+println("Original:")
+println(code2)
+println("Formatted:")
+println(format_text(code2, SciMLStyle()))

--- a/test/debug_line_length.jl
+++ b/test/debug_line_length.jl
@@ -1,0 +1,7 @@
+test1 = "discrete_modified, saved_in_cb = DiffEqBase.apply_discrete_callback!(integrator, integrator.opts.callback.discrete_callbacks...)"
+test2 = "new_rate = (u, p, t) -> rate(u.u, p, t) - min(rate(u.u, p, t), rate_control(u.u_control, p, t))"
+test3 = "@inline function executerx!(speciesvec::AbstractVector{T}, rxidx::S, majump::M) where {T, S, M <: AbstractMassActionJump}"
+
+println("Test 1 length: ", length(test1), " (margin = 92)")
+println("Test 2 length: ", length(test2), " (margin = 92)")
+println("Test 3 length: ", length(test3), " (margin = 92)")

--- a/test/sciml_function_call_test.jl
+++ b/test/sciml_function_call_test.jl
@@ -1,0 +1,46 @@
+using JuliaFormatter
+using Test
+
+# Test cases based on the problematic formatting from JumpProcesses.jl PR #504
+
+test_code1 = """
+discrete_modified, saved_in_cb = DiffEqBase.apply_discrete_callback!(integrator, integrator.opts.callback.discrete_callbacks...)
+"""
+
+test_code2 = """
+new_rate = (u, p, t) -> rate(u.u, p, t) - min(rate(u.u, p, t), rate_control(u.u_control, p, t))
+"""
+
+test_code3 = """
+@inline function executerx!(speciesvec::AbstractVector{T}, rxidx::S, majump::M) where {T, S, M <: AbstractMassActionJump}
+    # function body
+end
+"""
+
+# Format with SciMLStyle
+formatted1 = format_text(test_code1, SciMLStyle())
+formatted2 = format_text(test_code2, SciMLStyle())
+formatted3 = format_text(test_code3, SciMLStyle())
+
+println("Test 1 - Function call with splatted arguments:")
+println("Original:")
+println(test_code1)
+println("Formatted:")
+println(formatted1)
+println()
+
+println("Test 2 - Lambda with long expression:")
+println("Original:")
+println(test_code2)
+println("Formatted:")
+println(formatted2)
+println()
+
+println("Test 3 - Long function signature:")
+println("Original:")
+println(test_code3)
+println("Formatted:")
+println(formatted3)
+
+# The issue is that these should not be split into multiple lines unnecessarily
+# when they fit within the margin (92 characters for SciMLStyle)


### PR DESCRIPTION
A few more cases were specifically found on handling of the left hand side of the equality operator in https://github.com/SciML/Catalyst.jl/pull/1305/files#diff-e539c3f3e0f95bf9a606e52db2ba558cca6a8673c9400083703f73a54f7e40edR104-R107 and https://github.com/SciML/JumpProcesses.jl/pull/504/files#diff-fe3ccdeef7d407479ca0dc74e6e543199c9b3f4cf0f02e1679f59026d0030b1bL170-R174. The style notes are documented in https://github.com/SciML/Catalyst.jl/pull/1306. All of these cases are turned into MWEs which now pretty extensively document the style choices and there is sufficient data that reverting changes through bots is pretty straightforward.