### PR TITLE
Add support for `preserve_single_line_if::Bool`

### DIFF
--- a/src/options.jl
+++ b/src/options.jl
@@ -36,7 +36,7 @@ Base.@kwdef struct Options
     yas_style_nesting::Bool = false
     short_circuit_to_if::Bool = false
     disallow_single_arg_nesting::Bool = false
-    preserve_single_line_if::Bool = true
+    preserve_single_line_if::Bool = false
 
     function Options(args...)
         opts = new(args...)

--- a/src/options.jl
+++ b/src/options.jl
@@ -36,6 +36,7 @@ Base.@kwdef struct Options
     yas_style_nesting::Bool = false
     short_circuit_to_if::Bool = false
     disallow_single_arg_nesting::Bool = false
+    preserve_single_line_if::Bool = true
 
     function Options(args...)
         opts = new(args...)

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1622,9 +1622,14 @@ function p_if(
             add_node!(t, pretty(style, c, s, ctx, lineage), s)
         elseif kind(c) === K"block"
             s.indent += s.opts.indent
+            block_ctx = if s.opts.preserve_single_line_if
+                ctx
+            else
+                newctx(ctx; ignore_single_line = true)
+            end
             add_node!(
                 t,
-                pretty(style, c, s, newctx(ctx; ignore_single_line = true), lineage),
+                pretty(style, c, s, block_ctx, lineage),
                 s;
                 max_padding = s.opts.indent,
             )

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1852,32 +1852,68 @@ function p_if(
         return t
     end
 
+    preserve_single_line =
+        s.opts.preserve_single_line_if &&
+        on_same_line(s, s.offset, s.offset + span(cst) - 1)
+
+    is_first = true
+
     for c in children(cst)
         if kind(c) in KSet"if elseif else"
             if !haschildren(c)
-                add_node!(t, pretty(style, c, s, ctx, lineage), s; max_padding = 0)
+                if preserve_single_line && !is_first
+                    add_node!(t, Whitespace(1), s)
+                end
+                add_node!(
+                    t,
+                    pretty(style, c, s, ctx, lineage),
+                    s;
+                    max_padding = if preserve_single_line
+                        -1
+                    else
+                        0
+                    end,
+                    join_lines = preserve_single_line && !is_first,
+                )
             else
                 len = length(t)
                 n = pretty(style, c, s, ctx, lineage)
-                add_node!(t, n, s)
+                if preserve_single_line && !is_first
+                    add_node!(t, Whitespace(1), s)
+                end
+                add_node!(t, n, s; join_lines = preserve_single_line && !is_first)
                 t.len = max(len, length(n))
             end
+            is_first = false
         elseif kind(c) === K"end"
-            add_node!(t, pretty(style, c, s, ctx, lineage), s)
-        elseif kind(c) === K"block"
-            s.indent += s.opts.indent
-            block_ctx = if s.opts.preserve_single_line_if
-                ctx
-            else
-                newctx(ctx; ignore_single_line = true)
+            if preserve_single_line
+                add_node!(t, Whitespace(1), s)
             end
             add_node!(
                 t,
-                pretty(style, c, s, block_ctx, lineage),
+                pretty(style, c, s, ctx, lineage),
                 s;
-                max_padding = s.opts.indent,
+                join_lines = preserve_single_line,
             )
-            s.indent -= s.opts.indent
+        elseif kind(c) === K"block"
+            if preserve_single_line
+                add_node!(t, Whitespace(1), s)
+                add_node!(
+                    t,
+                    pretty(style, c, s, ctx, lineage),
+                    s;
+                    join_lines = true,
+                )
+            else
+                s.indent += s.opts.indent
+                add_node!(
+                    t,
+                    pretty(style, c, s, newctx(ctx; ignore_single_line = true), lineage),
+                    s;
+                    max_padding = s.opts.indent,
+                )
+                s.indent -= s.opts.indent
+            end
         elseif !JuliaSyntax.is_whitespace(c)
             add_node!(t, Whitespace(1), s)
             add_node!(t, pretty(style, c, s, ctx, lineage), s; join_lines = true)

--- a/test/options.jl
+++ b/test/options.jl
@@ -2644,4 +2644,75 @@
         """
         @test fmt(s1, 2, 1; disallow_single_arg_nesting = true) == s2
     end
+
+    @testset "preserve single line if" begin
+        # Basic single-line if is preserved
+        str = "if x > 0 return 1 end"
+        @test fmt(str; preserve_single_line_if = true) == str
+
+        # Single-line if is expanded when option is false (default)
+        str_ = "if x > 0 return 1 end"
+        str = """
+        if x > 0
+            return 1
+        end"""
+        @test fmt(str_; preserve_single_line_if = false) == str
+        @test fmt(str_) == str
+
+        # Multi-line if is not affected by the option
+        str = """
+        if x > 0
+            return 1
+        end
+        """
+        @test fmt(str; preserve_single_line_if = true) == str
+
+        # Single-line if-else
+        str = "if x > 0 1 else 2 end"
+        @test fmt(str; preserve_single_line_if = true) == str
+
+        # Single-line if-elseif-else
+        str = "if x > 0 1 elseif x < 0 2 else 0 end"
+        @test fmt(str; preserve_single_line_if = true) == str
+
+        # Multi-line if-else is not affected
+        str = """
+        if x > 0
+            return 1
+        else
+            return 2
+        end
+        """
+        @test fmt(str; preserve_single_line_if = true) == str
+
+        # Nested single-line if
+        str = "if x > 0 if y > 0 return 1 end end"
+        @test fmt(str; preserve_single_line_if = true) == str
+
+        # Inside a function
+        str = """
+        function f()
+            if rand() < 0.5 return 2 end
+            0
+        end
+        """
+        @test fmt(str; preserve_single_line_if = true) == str
+
+        # Inside a function, expanded when option is false
+        str_ = """
+        function f()
+            if rand() < 0.5 return 2 end
+            0
+        end
+        """
+        str = """
+        function f()
+            if rand() < 0.5
+                return 2
+            end
+            0
+        end
+        """
+        @test fmt(str_; preserve_single_line_if = false) == str
+    end
 end


### PR DESCRIPTION
Before formatting (or with `preserve_single_line_if = true`):
```jl
function f()
    if rand() < 0.5 return 2 end
    0
end
```

After formatting with `preserve_single_line_if = false` (default):
```jl
function f()
    if rand() < 0.5
        return 2
    end
    0
end
```

Resolves https://github.com/domluna/JuliaFormatter.jl/issues/516.