### PR TITLE
use Aqua in tests, fix ambiguties and missing compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ CommonMark = "0.5, 0.6, 0.7, 0.8, 0.9"
 Glob = "1.3"
 JuliaSyntax = "^0.4.10"
 PrecompileTools = "1"
+Test = "1"
 TOML = "1"
 julia = "1.10"
 

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -458,7 +458,7 @@ end
 """
     format(path, style::AbstractStyle; options...)::Bool
 """
-function format(path, style::AbstractStyle; options...)
+function format(path::AbstractString, style::AbstractStyle; options...)
     formatted = format(path; style = style, options...)
     formatted
 end
@@ -466,7 +466,12 @@ end
 """
     format(mod::Module, args...; options...)
 """
-function format(mod::Module, args...; options...)
+format(mod::Module; options...) = _format_module(mod; options...)
+format(mod::Module, style::AbstractStyle; options...) = _format_module(mod, style; options...)
+format(mod::Module, config::Configuration; options...) = _format_module(mod, config; options...)
+
+# This separate is needed to remove ambiguity in `format` without code duplication
+function _format_module(mod::Module, args...; options...)
     path = pkgdir(mod)
     if path === nothing
         throw(ArgumentError("couldn't find a directory of module `$mod`"))


### PR DESCRIPTION
I noticed `format` is ambiguous in a number of useful cases, like `format(::Module, ::AbstractStyle)`

This PR add Aqua.jl to testing so this cant happen in future, and fixes the ambiguity and a missing compat entry for the Test package