### PR TITLE
Update to v3.0 since #959 was a breaking change for pre-commit CI

### DIFF
--- a/.github/workflows/PreCommit.yml
+++ b/.github/workflows/PreCommit.yml
@@ -1,0 +1,32 @@
+name: Pre-Commit
+
+# needed to allow julia-actions/cache to delete old caches that it has created
+permissions:
+  actions: write
+  contents: read
+
+on:
+  push:
+    branches:
+      - master
+    tags: ['*']
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/cache@v2
+      - run: mkdir ${HOME}/.julia/environments
+      - run: mkdir ${HOME}/.julia/environments/apps
+      - name: Install local JuliaFormatter as Pkg app
+        run: julia --project -e 'using Pkg; Pkg.instantiate(); Pkg.Apps.develop(; path=pwd())'
+      - uses: astral-sh/setup-uv@v7
+      - run: uv tool install pre-commit
+      - run: pre-commit install
+      - run: |
+          export PATH=$PATH:${HOME}/.julia/bin/
+          pre-commit run --all-files --show-diff-on-failure --color always

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,16 @@
 repos:
 - repo: local
   hooks:
-  - id: "julia-formatter"
+  - id: julia-formatter
+    name: "Julia Formatter"
+    entry: "jlfmt --inplace"
+    pass_filenames: true
+    always_run: false
+    types: [file]
+    files: \.(jl|[jq]?md)$
+    exclude: '^test/'
+    language: "system"
+-   repo: meta
+    hooks:
+    -   id: check-hooks-apply
+    -   id: check-useless-excludes

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 - id: julia-formatter
   name: "Julia Formatter"
-  entry: "julia -e 'import JuliaFormatter: format; format(ARGS)'"
+  entry: "jlfmt --inplace"
   pass_filenames: true
   always_run: false
   types: [file]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.3"
+version = "2.2.2"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.2.2"
+version = "3.0"
 authors = ["Dominique Luna <dluna132@gmail.com>"]
 
 [deps]

--- a/docs/src/integrations.md
+++ b/docs/src/integrations.md
@@ -18,6 +18,12 @@ repos:
 # ... other repos you may have
 ```
 
+Note that it requires the `jlfmt` Pkg app to be installed with
+
+```julia
+pkg> app add JuliaFormatter
+```
+
 You can find a list of releases [here](https://github.com/domluna/JuliaFormatter.jl/releases).
 **Be sure to use the entire version string!** (You can double-check this by opening the
 release and looking at the part of the URL that follows `.../releases/tag/VERSION`.)

--- a/src/app.jl
+++ b/src/app.jl
@@ -31,9 +31,9 @@ function scandir!(files, root)
         elseif (@tryx(isfile(jf), false) || @tryx(islink(jf), false))
             # Check for .jl, .md, .jmd, .qmd files
             if endswith(jf, ".jl") ||
-                    endswith(jf, ".md") ||
-                    endswith(jf, ".jmd") ||
-                    endswith(jf, ".qmd")
+               endswith(jf, ".md") ||
+               endswith(jf, ".jmd") ||
+               endswith(jf, ".qmd")
                 push!(files, jf)
             end
         end
@@ -45,10 +45,10 @@ function scandir!(files, root)
 end
 
 function panic(
-        msg::String,
-        err::Union{Exception, Nothing} = nothing,
-        bt::Union{Vector{Base.StackFrame}, Nothing} = nothing,
-    )
+    msg::String,
+    err::Union{Exception,Nothing} = nothing,
+    bt::Union{Vector{Base.StackFrame},Nothing} = nothing,
+)
     printstyled(stderr, "ERROR: "; color = :red, bold = true)
     print(stderr, msg)
     if err !== nothing
@@ -315,7 +315,7 @@ function main(argv::Vector{String})
     format_markdown = false
     config_priority = false
     style_name = "default"
-    format_options = Dict{Symbol, Any}()
+    format_options = Dict{Symbol,Any}()
     ignore_patterns = String[]
 
     paths = String[]
@@ -355,7 +355,7 @@ function main(argv::Vector{String})
             if i >= length(argv)
                 return panic("expected output file argument after `-o`")
             end
-            outputfile = argv[i + 1]
+            outputfile = argv[i+1]
             i += 2
         elseif startswith(x, "--output=")
             m = match(r"^--output=(.+)$", x)
@@ -562,21 +562,21 @@ function main(argv::Vector{String})
     nfiles_str = string(length(inputfiles))
     options_list = (
         ProcessFileArgs(
-                inputfile,
-                file_counter,
-                nfiles_str,
-                print_progress,
-                check,
-                inplace,
-                outputfile,
-                input_is_stdin,
-                stdin_filename,
-                config_dir,
-                format_options,
-                diff,
-                format_markdown,
-                config_priority,
-            ) for (file_counter, inputfile) in enumerate(inputfiles)
+            inputfile,
+            file_counter,
+            nfiles_str,
+            print_progress,
+            check,
+            inplace,
+            outputfile,
+            input_is_stdin,
+            stdin_filename,
+            config_dir,
+            format_options,
+            diff,
+            format_markdown,
+            config_priority,
+        ) for (file_counter, inputfile) in enumerate(inputfiles)
     )
 
     # Use multithreading for multiple files (only if multiple threads available)
@@ -629,7 +629,7 @@ struct ProcessFileArgs
     input_is_stdin::Bool
     stdin_filename::String
     config_dir::String
-    format_options::Dict{Symbol, Any}
+    format_options::Dict{Symbol,Any}
     diff::Bool
     format_markdown::Bool
     config_priority::Bool
@@ -739,8 +739,8 @@ function process_file(args::ProcessFileArgs)
         if args.outputfile == "" || args.outputfile == "-"
             Output(:stdout, "", stdout, false, false)
         elseif isfile(args.outputfile) &&
-                !args.input_is_stdin &&
-                samefile(args.outputfile, args.inputfile)
+               !args.input_is_stdin &&
+               samefile(args.outputfile, args.inputfile)
             if args.print_progress
                 @lock print_lock begin
                     buf = IOBuffer()
@@ -764,7 +764,7 @@ function process_file(args::ProcessFileArgs)
     effective_options = if args.inputfile != "-"
         # Find and load .JuliaFormatter.toml config
         config_nt = find_config_file(args.inputfile)
-        config_dict = Dict{Symbol, Any}(Symbol(k) => v for (k, v) in pairs(config_nt))
+        config_dict = Dict{Symbol,Any}(Symbol(k) => v for (k, v) in pairs(config_nt))
         # Merge: by default, command line options override config file
         # If --prioritize-config-file is set, config file options override command line
         if args.config_priority
@@ -781,7 +781,7 @@ function process_file(args::ProcessFileArgs)
             # Try to find config file recursively from the directory
             find_config_file(args.config_dir)
         end
-        config_dict = Dict{Symbol, Any}(Symbol(k) => v for (k, v) in pairs(config_nt))
+        config_dict = Dict{Symbol,Any}(Symbol(k) => v for (k, v) in pairs(config_nt))
         if args.config_priority
             merge(args.format_options, config_dict)
         else
@@ -795,9 +795,9 @@ function process_file(args::ProcessFileArgs)
     if args.inputfile != "-"
         ignore_patterns = get(effective_options, :ignore, String[])
         if any(
-                pattern -> occursin(Glob.FilenameMatch("*$pattern"), args.inputfile),
-                ignore_patterns,
-            )
+            pattern -> occursin(Glob.FilenameMatch("*$pattern"), args.inputfile),
+            ignore_patterns,
+        )
             # Skip ignored files
             if args.print_progress
                 @lock print_lock begin


### PR DESCRIPTION
This is not a breaking change for the formatter itself. But for the formatter precommit CI which now uses the jlfmt app.