### PR TITLE
Enable separate kwargs with semicolon in pretty.jl

### DIFF
--- a/src/styles/sciml/pretty.jl
+++ b/src/styles/sciml/pretty.jl
@@ -31,7 +31,7 @@ function options(::SciMLStyle)
         trailing_comma = false,
         trailing_zero = true,
         indent_submodule = false,
-        separate_kwargs_with_semicolon = false,
+        separate_kwargs_with_semicolon = true,
         surround_whereop_typeparameters = true,
         variable_call_indent = [],
         yas_style_nesting = false,


### PR DESCRIPTION
The SciML style guide explicitly calls for separating keyword arguments in function calls at all times (see https://docs.sciml.ai/SciMLStyle/dev/?utm_source=chatgpt.com#Functions).