### PR TITLE
Add support for alignment in lines with zero-width characters

### DIFF
--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -237,7 +237,7 @@ function format_text(node::JuliaSyntax.GreenNode, style::AbstractStyle, s::State
     end
 
     if needs_alignment(s.opts)
-        align_fst!(fst, s.opts)
+        align_fst!(fst, s.doc, s.opts)
     end
 
     nest!(style, fst, s)

--- a/src/align.jl
+++ b/src/align.jl
@@ -1,4 +1,13 @@
-function align_fst!(fst::FST, opts::Options)
+"""
+    align_fst!(fst::FST, doc::Document, opts::Options)
+
+Walk `fst` and apply the alignment passes enabled by `opts`.
+
+`doc` is the original source document and is used to translate parser line offsets into
+display columns before padding is adjusted. This keeps alignment stable for source text
+containing combining and other zero-width characters.
+"""
+function align_fst!(fst::FST, doc::Document, opts::Options)
     if is_leaf(fst)
         return
     end
@@ -9,15 +18,15 @@ function align_fst!(fst::FST, opts::Options)
         if is_leaf(n)
             continue
         elseif opts.align_struct_field && (n.typ === Struct || n.typ === Mutable)
-            align_struct!(n)
+            align_struct!(doc, n)
         elseif opts.align_conditional && n.typ === Conditional
-            align_conditional!(n)
+            align_conditional!(doc, n)
         elseif opts.align_matrix && (
             n.typ === Vcat || n.typ === TypedVcat || n.typ === Ncat || n.typ === TypedNcat
         )
-            align_matrix!(n)
+            align_matrix!(doc, n)
         else
-            align_fst!(n, opts)
+            align_fst!(n, doc, opts)
         end
 
         if opts.align_assignment && (is_assignment(n) || n.typ === Kw)
@@ -29,8 +38,8 @@ function align_fst!(fst::FST, opts::Options)
         end
     end
 
-    align_binaryopcalls!(fst, assignment_inds)
-    align_binaryopcalls!(fst, pair_arrow_inds)
+    align_binaryopcalls!(doc, fst, assignment_inds)
+    align_binaryopcalls!(doc, fst, pair_arrow_inds)
 end
 
 """
@@ -40,8 +49,8 @@ Group of FST node indices and required metadata to potentially align them.
 
 - `node_inds`. Indices of FST nodes affected by alignment.
 - `nodes`. FST nodes affected by alignment.
-- `line_offsets`. Line offset of the character nodes may be aligned to
-  in the source file.
+- `line_offsets`. Display line offset of the character nodes may be aligned
+  to in the source file.
 - `lens`. Length of the FST node prior to the alignment character. Used
   to calculate extra whitespace padding.
 - `whitespaces`. Number of whitespaces between the alignment character and
@@ -56,6 +65,28 @@ struct AlignGroup
     whitespaces::Vector{Int}
 end
 AlignGroup() = AlignGroup(FST[], Int[], Int[], Int[], Int[])
+
+"""
+    source_display_line_offset(doc::Document, line::Int, line_offset::Int) -> Int
+
+Convert a 1-based source line offset into a 1-based display column for `line` in `doc`.
+
+`line_offset` follows the offsets recorded in the parsed source and therefore advances
+through the original text representation. Alignment, however, needs display width semantics
+so that combining marks and other zero-width codepoints do not consume extra padding. This
+helper measures the source line prefix with `textwidth` and returns the corresponding
+display column.
+"""
+function source_display_line_offset(doc::Document, line::Int, line_offset::Int)
+    line_offset <= 1 && return 1
+
+    code       = JuliaSyntax.sourcetext(doc.srcfile)
+    line_start = doc.srcfile.line_starts[line]
+    offset     = line_start + line_offset - 1
+    prefix_end = prevind(code, offset)
+
+    return textwidth(code[line_start:prefix_end]) + 1
+end
 
 function Base.push!(g::AlignGroup, n::FST, ind::Int, line_offset::Int, len::Int, ws::Int)
     push!(g.nodes, n)
@@ -113,10 +144,9 @@ function align_binaryopcall!(fst::FST, diff::Int)
     end
 end
 
-# we need to use ncodeunits
 function node_align_length(n::FST)
     if is_leaf(n)
-        return ncodeunits(n.val)
+        return textwidth(n.val)
     end
     margin = 0
     for nn in n.nodes
@@ -134,14 +164,15 @@ function node_align_length(nodes::Vector{FST})
 end
 
 """
-    align_binaryopcalls!(fst::FST, op_inds::Vector{Int})
+    align_binaryopcalls!(doc::Document, fst::FST, op_inds::Vector{Int})
 
 Aligns binary operator expressions.
 
-Additionally handles the case where a keyword such as `const` is used
-prior to the binary op call.
+Additionally handles the case where a keyword such as `const` is used prior to the binary op
+call. `doc` is used to compare source locations in display columns rather than raw source
+offsets.
 """
-function align_binaryopcalls!(fst::FST, op_inds::Vector{Int})
+function align_binaryopcalls!(doc::Document, fst::FST, op_inds::Vector{Int})
     if !(length(op_inds) > 1)
         return
     end
@@ -158,7 +189,10 @@ function align_binaryopcalls!(fst::FST, op_inds::Vector{Int})
 
         binop, nlen, ws = if n.typ === Binary || n.typ === Kw
             nlen = node_align_length(n[1])
-            n, nlen, (n[3].line_offset - n.line_offset) - nlen
+            start_offset = source_display_line_offset(doc, n.startline, n.line_offset)
+            op_offset = source_display_line_offset(doc, n[3].startline, n[3].line_offset)
+
+            n, nlen, op_offset - start_offset - nlen
         else
             binop::Union{FST,Nothing} = nothing
             sn = n
@@ -175,7 +209,15 @@ function align_binaryopcalls!(fst::FST, op_inds::Vector{Int})
                 else
                     binop = (sn.nodes::Vector{FST})[binop_ind]
                     nlen += node_align_length(binop[1])
-                    ws = (binop[3].line_offset - n.line_offset) - nlen
+                    start_offset = source_display_line_offset(doc, n.startline, n.line_offset)
+
+                    op_offset = source_display_line_offset(
+                        doc,
+                        binop[3].startline,
+                        binop[3].line_offset,
+                    )
+
+                    ws = op_offset - start_offset - nlen
                     break
                 end
             end
@@ -189,7 +231,10 @@ function align_binaryopcalls!(fst::FST, op_inds::Vector{Int})
 
         push!(g.nodes, binop)
         push!(g.node_inds, i)
-        push!(g.line_offsets, binop[3].line_offset)
+        push!(
+            g.line_offsets,
+            source_display_line_offset(doc, binop[3].startline, binop[3].line_offset),
+        )
         push!(g.lens, nlen)
         push!(g.whitespaces, ws)
 
@@ -214,11 +259,14 @@ function align_binaryopcalls!(fst::FST, op_inds::Vector{Int})
 end
 
 """
-    align_struct!(fst::FST)
+    align_struct!(doc::Document, fst::FST)
 
 Aligns struct fields.
+
+`doc` supplies the original source text so field and type operator columns can be measured
+using display width.
 """
-function align_struct!(fst::FST)
+function align_struct!(doc::Document, fst::FST)
     ind = findfirst(n -> n.typ === Block, fst.nodes)
     if isnothing(ind) || length(fst[ind]) == 0
         return
@@ -248,11 +296,13 @@ function align_struct!(fst::FST)
                 continue
             end
 
-            ws = n[ind].line_offset - (n.line_offset + nlen)
+            start_offset = source_display_line_offset(doc, n.startline, n.line_offset)
+            op_offset = source_display_line_offset(doc, n[ind].startline, n[ind].line_offset)
+            ws = op_offset - start_offset - nlen
 
             push!(g.nodes, n)
             push!(g.node_inds, i)
-            push!(g.line_offsets, n[ind].line_offset)
+            push!(g.line_offsets, op_offset)
             push!(g.lens, nlen)
             push!(g.whitespaces, ws)
 
@@ -270,11 +320,17 @@ function align_struct!(fst::FST)
             if ind === nothing
                 continue
             end
-            ws = binop[ind].line_offset - (n.line_offset + nlen)
+            start_offset = source_display_line_offset(doc, n.startline, n.line_offset)
+            op_offset = source_display_line_offset(
+                doc,
+                binop[ind].startline,
+                binop[ind].line_offset,
+            )
+            ws = op_offset - start_offset - nlen
 
             push!(g.nodes, binop)
             push!(g.node_inds, i)
-            push!(g.line_offsets, binop[ind].line_offset)
+            push!(g.line_offsets, op_offset)
             push!(g.lens, nlen)
             push!(g.whitespaces, ws)
 
@@ -297,11 +353,14 @@ function align_struct!(fst::FST)
 end
 
 """
-    align_conditional!(fst::FST)
+    align_conditional!(doc::Document, fst::FST)
 
 Aligns a conditional expression.
+
+`doc` supplies the original source text so `?` and `:` alignment is computed using display
+columns.
 """
-function align_conditional!(fst::FST)
+function align_conditional!(doc::Document, fst::FST)
     nodes = flatten_conditionalopcall(fst)
 
     cond_group = AlignGroup()
@@ -314,11 +373,17 @@ function align_conditional!(fst::FST)
         if n.typ === OPERATOR && n.val == "?"
             if cond_prev_endline != n.endline
                 nlen = node_align_length(nodes[i-2])
-                ws = n.line_offset - (nodes[i-2].line_offset + nlen)
+                start_offset = source_display_line_offset(
+                    doc,
+                    nodes[i-2].startline,
+                    nodes[i-2].line_offset,
+                )
+                op_offset = source_display_line_offset(doc, n.startline, n.line_offset)
+                ws = op_offset - start_offset - nlen
 
                 push!(cond_group.nodes, n)
                 push!(cond_group.node_inds, i)
-                push!(cond_group.line_offsets, n.line_offset)
+                push!(cond_group.line_offsets, op_offset)
                 push!(cond_group.lens, nlen)
                 push!(cond_group.whitespaces, ws)
             end
@@ -326,11 +391,17 @@ function align_conditional!(fst::FST)
         elseif n.typ === OPERATOR && n.val == ":"
             if colon_prev_endline != n.endline
                 nlen = node_align_length(nodes[i-2])
-                ws = n.line_offset - (nodes[i-2].line_offset + nlen)
+                start_offset = source_display_line_offset(
+                    doc,
+                    nodes[i-2].startline,
+                    nodes[i-2].line_offset,
+                )
+                op_offset = source_display_line_offset(doc, n.startline, n.line_offset)
+                ws = op_offset - start_offset - nlen
 
                 push!(colon_group.nodes, n)
                 push!(colon_group.node_inds, i)
-                push!(colon_group.line_offsets, n.line_offset)
+                push!(colon_group.line_offsets, op_offset)
                 push!(colon_group.lens, nlen)
                 push!(colon_group.whitespaces, ws)
             end
@@ -376,24 +447,30 @@ function align_conditional!(fst::FST)
 end
 
 """
-Adjust whitespace in between matrix elements such that it's the same as the original source file.
+    align_matrix!(doc::Document, fst::FST)
+
+Adjust whitespace between matrix elements so it matches the original source layout.
+
+`doc` is used to recover the source display columns for each element, which avoids
+overpadding when the source contains zero-width characters.
 """
-function align_matrix!(fst::FST)
+function align_matrix!(doc::Document, fst::FST)
     rows = filter(n -> n.typ === Row, fst.nodes::Vector{FST})
     if length(rows) == 0
         return
     end
 
     min_offset = minimum(map(rows) do r
-        r[1].line_offset
+        source_display_line_offset(doc, r[1].startline, r[1].line_offset)
     end)
 
     line = 0
     # add whitespace prior to initial element if elements are aligned to the right and
     # it's the first row on that line.
     for r in rows
-        if r[1].line_offset > min_offset && line != r.startline
-            diff = r[1].line_offset - min_offset
+        row_offset = source_display_line_offset(doc, r[1].startline, r[1].line_offset)
+        if row_offset > min_offset && line != r.startline
+            diff = row_offset - min_offset
             if diff > 0
                 insert!(r.nodes::Vector{FST}, 1, Whitespace(diff))
             end
@@ -408,7 +485,9 @@ function align_matrix!(fst::FST)
                 n1 = r[i-1]
                 n2 = r[i+1]
 
-                diff = n2.line_offset - n1.line_offset - node_align_length(n1)
+                diff = source_display_line_offset(doc, n2.startline, n2.line_offset) -
+                       source_display_line_offset(doc, n1.startline, n1.line_offset) -
+                       node_align_length(n1)
 
                 # fix #694 and #713
                 if diff > 0

--- a/src/align.jl
+++ b/src/align.jl
@@ -80,9 +80,9 @@ display column.
 function source_display_line_offset(doc::Document, line::Int, line_offset::Int)
     line_offset <= 1 && return 1
 
-    code       = JuliaSyntax.sourcetext(doc.srcfile)
+    code = JuliaSyntax.sourcetext(doc.srcfile)
     line_start = doc.srcfile.line_starts[line]
-    offset     = line_start + line_offset - 1
+    offset = line_start + line_offset - 1
     prefix_end = prevind(code, offset)
 
     return textwidth(code[line_start:prefix_end]) + 1
@@ -190,7 +190,8 @@ function align_binaryopcalls!(doc::Document, fst::FST, op_inds::Vector{Int})
         binop, nlen, ws = if n.typ === Binary || n.typ === Kw
             nlen = node_align_length(n[1])
             start_offset = source_display_line_offset(doc, n.startline, n.line_offset)
-            op_offset = source_display_line_offset(doc, n[3].startline, n[3].line_offset)
+            op_offset =
+                source_display_line_offset(doc, n[3].startline, n[3].line_offset)
 
             n, nlen, op_offset - start_offset - nlen
         else
@@ -209,7 +210,8 @@ function align_binaryopcalls!(doc::Document, fst::FST, op_inds::Vector{Int})
                 else
                     binop = (sn.nodes::Vector{FST})[binop_ind]
                     nlen += node_align_length(binop[1])
-                    start_offset = source_display_line_offset(doc, n.startline, n.line_offset)
+                    start_offset =
+                        source_display_line_offset(doc, n.startline, n.line_offset)
 
                     op_offset = source_display_line_offset(
                         doc,
@@ -297,7 +299,8 @@ function align_struct!(doc::Document, fst::FST)
             end
 
             start_offset = source_display_line_offset(doc, n.startline, n.line_offset)
-            op_offset = source_display_line_offset(doc, n[ind].startline, n[ind].line_offset)
+            op_offset =
+                source_display_line_offset(doc, n[ind].startline, n[ind].line_offset)
             ws = op_offset - start_offset - nlen
 
             push!(g.nodes, n)
@@ -485,9 +488,10 @@ function align_matrix!(doc::Document, fst::FST)
                 n1 = r[i-1]
                 n2 = r[i+1]
 
-                diff = source_display_line_offset(doc, n2.startline, n2.line_offset) -
-                       source_display_line_offset(doc, n1.startline, n1.line_offset) -
-                       node_align_length(n1)
+                diff =
+                    source_display_line_offset(doc, n2.startline, n2.line_offset) -
+                    source_display_line_offset(doc, n1.startline, n1.line_offset) -
+                    node_align_length(n1)
 
                 # fix #694 and #713
                 if diff > 0

--- a/test/options.jl
+++ b/test/options.jl
@@ -1212,6 +1212,13 @@
         @test fmt(str, 4, 1; align_assignment = true) == str
 
         str = """
+        eclipse  = true
+        s̄_b      = SVector{3,T}(0, 0, 0)
+        css_axes = :css_axes_eclipse
+        """
+        @test fmt(str; align_assignment = true) == str
+
+        str = """
         vcat(X::T...) where {T}         = T[X[i] for i = 1:length(X)]
         vcat(X::T...) where {T<:Number} = T[X[i] for i = 1:length(X)]
         hcat(X::T...) where {T}         = T[X[j] for i = 1:1, j = 1:length(X)]


### PR DESCRIPTION
Hi @domluna !

This commit should address the problem with alignment in lines with zero-width characters.

Closes #975 