### PR TITLE
fix multithreading in jlfmt app

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.3.0"
+version = "2.3.1"
 authors = ["Dominique Luna <dluna132@gmail.com> and contributors"]
 
 [deps]

--- a/src/app.jl
+++ b/src/app.jl
@@ -560,7 +560,7 @@ function main(argv::Vector{String})
     print_progress = verbose && !(input_is_stdin || output_is_stdout)
 
     nfiles_str = string(length(inputfiles))
-    options_list = (
+    options_list = [
         ProcessFileArgs(
             inputfile,
             file_counter,
@@ -577,7 +577,7 @@ function main(argv::Vector{String})
             format_markdown,
             config_priority,
         ) for (file_counter, inputfile) in enumerate(inputfiles)
-    )
+    ]
 
     # Use multithreading for multiple files (only if multiple threads available)
     # Single file or stdin or single thread: process sequentially

--- a/test/jlfmt_app.jl
+++ b/test/jlfmt_app.jl
@@ -1,0 +1,51 @@
+@testset "Test jlfmt app" begin
+    if VERSION < v"1.12"
+        @info "Skipping jlfmt app tests for pre-v1.12 Julia."
+        return
+    end
+
+    @testset "Test app with threads" begin
+        mktempdir(; prefix = "jlfmt_threads_") do sandbox_dir
+            write(
+                joinpath(sandbox_dir, "spacing_and_call.jl"),
+                """
+                f( x,y )=x+y
+                z=f( 1,2 )
+                """,
+            )
+
+            write(
+                joinpath(sandbox_dir, "control_flow_and_collection.jl"),
+                """
+                function g(xs)
+                ys=[ x*2 for x in xs if x>0 ]
+                return ys
+                end
+                """,
+            )
+
+            write(
+                joinpath(sandbox_dir, "struct_and_keywords.jl"),
+                """
+                struct Foo
+                x::Int
+                y::String
+                end
+
+                h(;a=1,b=2)=a+b
+                """,
+            )
+
+            project = dirname(Base.active_project())
+
+            check_before_cmd = `$(Base.julia_cmd()) --threads=3 --project=$project -m JuliaFormatter --check $sandbox_dir`
+            @test !success(check_before_cmd)
+
+            format_cmd = `$(Base.julia_cmd()) --threads=3 --project=$project -m JuliaFormatter --inplace $sandbox_dir`
+            @test success(format_cmd)
+
+            check_after_cmd = `$(Base.julia_cmd()) --threads=3 --project=$project -m JuliaFormatter --check $sandbox_dir`
+            @test success(check_after_cmd)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,4 +77,5 @@ end
     include("interface.jl")
     include("config.jl")
     include("format_repo.jl")
+    include("jlfmt_app.jl")
 end


### PR DESCRIPTION
Currently, running `jlfmt` with `--threads` set to more than one thread leads to an error:

```
ERROR: TaskFailedException

    nested task error: MethodError: no method matching firstindex(::Base.Generator{Base.Iterators.Enumerate{Vector{String}}, JuliaFormatter.var"#main##0#main##1"{String, Bool, Dict{Symbol, Any}}})
```

This fixes it and makes `jlfmt` capable of using multithreading. 

A minimal test against future regression in this is added too.

(Resolves #953)