### PR TITLE
Fix CI warnings, make cleanups and improvements to workflows

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,8 +1,10 @@
 name: CompatHelper
+
 on:
   schedule:
     - cron: 0 0 * * *
   workflow_dispatch:
+
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest

--- a/.github/workflows/PreCommit.yml
+++ b/.github/workflows/PreCommit.yml
@@ -16,17 +16,19 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
+
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
-      - uses: julia-actions/cache@v2
-      - run: mkdir ${HOME}/.julia/environments
-      - run: mkdir ${HOME}/.julia/environments/apps
+      - uses: julia-actions/setup-julia@v3
+      - uses: julia-actions/cache@v3
+
+      - run: mkdir -p "${HOME}/.julia/environments/apps"
       - name: Install local JuliaFormatter as Pkg app
         run: julia --project -e 'using Pkg; Pkg.instantiate(); Pkg.Apps.develop(; path=pwd())'
-      - uses: astral-sh/setup-uv@v7
+
+      - uses: astral-sh/setup-uv@v8.1.0
       - run: uv tool install pre-commit
-      - run: pre-commit install
       - run: |
           export PATH=$PATH:${HOME}/.julia/bin/
           pre-commit run --all-files --show-diff-on-failure --color always

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,9 +1,11 @@
 name: TagBot
+
 on:
   issue_comment:
     types:
       - created
   workflow_dispatch:
+
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: CI
+
 on:
   push:
     tags:
@@ -8,10 +9,16 @@ on:
   pull_request:
     branches:
       - 'master'
+  workflow_dispatch:
+
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
+    # The default timeout for each job is 6 hours, we set it to 2 hours instead
+    # Long enough to tell us something's wrong, short enough to catch it early
+    timeout-minutes: 120
+
     strategy:
       fail-fast: false
       matrix:
@@ -22,7 +29,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macos-15 # This is the Intel (x64) runner
+          - macos-15-intel # Intel (x64) runner
         arch:
           - x64
         include:
@@ -34,34 +41,45 @@ jobs:
           - os: macos-latest
             version: '1'
             arch: aarch64
-        exclude:
-          # Clean up any redundant combinations here
-          - os: macos-15
-            arch: x86
+
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: julia-actions/setup-julia@v2
+
+      - uses: julia-actions/setup-julia@v3
         with:
           show-versioninfo: true
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/julia-buildpkg@v1
+
+      - uses: julia-actions/cache@v3
         with:
-          ignore-no-cache: true
+          delete-old-caches: false # avoids extra permissions
+
+      - uses: julia-actions/julia-buildpkg@v1
+
       - uses: julia-actions/julia-runtest@latest
+
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    timeout-minutes: 120
+
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: julia-actions/setup-julia@v2
+
+      - uses: julia-actions/setup-julia@v3
         with:
           show-versioninfo: true
           version: '1'
+
+      - uses: julia-actions/cache@v3
+        with:
+          delete-old-caches: false
+
       - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix the [various warnings](https://github.com/JuliaEditorSupport/JuliaFormatter.jl/actions/runs/25787399735) when running CI, and make some additional improvements.

* Allow manual CI runs with `workflow_dispatch`
* Give each job a 2 hour timeout duration (instead of the default 6 hours)
* `macos-15` is ARM, not Intel, so set the Intel one to the correct `macos-15-intel`
    * This also allows us to upgrade setup-julia from 2 to 3 which was [failing due to this error](https://github.com/JuliaEditorSupport/JuliaFormatter.jl/pull/980) - or rather, aborting redundant runs, since there's already a separate `macos-latest - aarch64` which was the same runner. (Subsumes https://github.com/JuliaEditorSupport/JuliaFormatter.jl/pull/980 )
* Remove an unnecessary `exclude` of `x86` which wasn't included in the first place
* Upgrade `actions/checkout` to v6 (subsumes https://github.com/JuliaEditorSupport/JuliaFormatter.jl/pull/955 )
* Make use of `julia-actions/cache` in CI too, not just PreCommit
* In PreCommit.yaml:
    * Upgrade setup-uv action to v8 and use exact version as [recommended](https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0)
    * Remove `pre-commit install` automatic git hook setup, as we're explicitly running `pre-commit run` and not depending on any automatic hooks
    * Subsume https://github.com/JuliaEditorSupport/JuliaFormatter.jl/pull/981 for cache action upgrade