### PR TITLE
Fix multiline strings & display width interaction

### DIFF
--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,3 +1,7 @@
+# v2.3.3
+
+Fixed a bug with alignment of multiline strings when the first line contains characters whose display width is not equal to the number of bytes.
+
 # v2.3.2
 
 Added compatibility with CommonMark@1.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.3.2"
+version = "2.3.3"
 authors = ["Dominique Luna <dluna132@gmail.com> and contributors"]
 
 [deps]

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -125,7 +125,11 @@ mutable struct FST
     startline::Int
     endline::Int
 
+    # TODO(penelopeysm): This field should be calculated based on display width. I'm not
+    # sure that this is consistently obeyed in the codebase, so it's more of an aspirational
+    # comment rather than a true invariant right now.
     indent::Int
+
     len::Int
     val::String
     nodes::Union{Tuple{},Vector{FST}}

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -525,12 +525,25 @@ function p_stringh(
         return FST(LITERAL, loc[2], startline, startline, val)
     end
 
-    t = FST(StringN, loc[2] - 1)
+    # The indent for the StringN FST should be the width of the first line prior to the
+    # opening quote. The quote is the loc[2]-th byte of line loc[1].
+    opening_quote_col = source_display_line_offset(s.doc, loc[1], loc[2])
+    t = FST(StringN, opening_quote_col - 1)
     t.line_offset = loc[2]
 
     lines = split(val, "\n")
-    sidx = loc[2]
+    # Calculate the display column of the first non-whitespace character in the string
+    # literal.
+    sidx = opening_quote_col  # Display column of the opening quote.
     for l in lines[2:end]
+        # Note that `fc` is actually a byte index, not a display column. This works only
+        # insofar as all whitespace characters (as defined by isspace(c)) have the same
+        # display width and byte width (for example, for a regular space both are 1). This
+        # is not, in general, true: for example, for U+3000 IDEOGRAPHIC SPACE we have that
+        #    isspace('\u3000')     ==>  true
+        #    ncodeunits('\u3000')  ==>  3
+        #    textwidth('\u3000')   ==>  2
+        # However, this is pathological enough to not worry about.
         fc = findfirst(c -> !isspace(c), l)
         if !isnothing(fc)
             sidx = min(sidx, fc)

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -1433,6 +1433,9 @@
 
         @testset "multiline string starting on line with display width != bytes" begin
             # https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/974
+            #
+            # Anonymous function form. Test both the case where the second line begins
+            # after the starting quote of the first line, and the opposite.
             s1a = raw"""
             error_str = Δa -> "Change in activity must be within the valid range: \
                                 Δa ∈ [1, 2], but Δa = $Δa"
@@ -1441,6 +1444,7 @@
             error_str = Δa -> "Change in activity must be within the valid range: \
                   Δa ∈ [1, 2], but Δa = $Δa"
             """
+            # Explicit function definition
             s2a = raw"""
             error_str(Δa) = "Change in activity must be within the valid range: \
                                 Δa ∈ [1, 2], but Δa = $Δa"
@@ -1449,7 +1453,16 @@
             error_str(Δa) = "Change in activity must be within the valid range: \
               Δa ∈ [1, 2], but Δa = $Δa"
             """
-            for s in (s1a, s1b, s2a, s2b)
+            # Using triple quoted strings
+            s3a = raw"""
+            error_str(Δa) = \"""Change in activity must be within the valid range: \
+                                Δa ∈ [1, 2], but Δa = $Δa\"""
+            """
+            s3b = raw"""
+            error_str(Δa) = \"""Change in activity must be within the valid range: \
+              Δa ∈ [1, 2], but Δa = $Δa\"""
+            """
+            for s in (s1a, s1b, s2a, s2b, s3a, s3b)
                 # Need to normalise line endings because \ at the end of a raw_str behaves
                 # weirdly on Windows causing CI to fail.
                 # https://github.com/JuliaLang/julia/issues/38908

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -1450,7 +1450,11 @@
               Δa ∈ [1, 2], but Δa = $Δa"
             """
             for s in (s1a, s1b, s2a, s2b)
-                @test format_text(s) == s
+                # Need to normalise line endings because \ at the end of a raw_str behaves
+                # weirdly on Windows causing CI to fail.
+                # https://github.com/JuliaLang/julia/issues/38908
+                s = replace(s, "\r\n" => "\n")
+                @test fmt(s) == s
             end
         end
 

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -1431,6 +1431,29 @@
         end"""
         @test fmt(str_) == str
 
+        @testset "multiline string starting on line with display width != bytes" begin
+            # https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/974
+            s1a = raw"""
+            error_str = Δa -> "Change in activity must be within the valid range: \
+                                Δa ∈ [1, 2], but Δa = $Δa"
+            """
+            s1b = raw"""
+            error_str = Δa -> "Change in activity must be within the valid range: \
+                  Δa ∈ [1, 2], but Δa = $Δa"
+            """
+            s2a = raw"""
+            error_str(Δa) = "Change in activity must be within the valid range: \
+                                Δa ∈ [1, 2], but Δa = $Δa"
+            """
+            s2b = raw"""
+            error_str(Δa) = "Change in activity must be within the valid range: \
+              Δa ∈ [1, 2], but Δa = $Δa"
+            """
+            for s in (s1a, s1b, s2a, s2b)
+                @test format_text(s) == s
+            end
+        end
+
         str_ = """
         begin
         begin


### PR DESCRIPTION
Closes #974

If a multiline string begins on a line where the byte width is not equal to the display width, this caused the indent for subsequent lines to be calculated incorrectly. This fixes it by using the source to calculate the display width for the contents of the first line up to the opening quote.

The above is really just a one-line fix. But I also took the liberty to add some comments to the parts which I changed. I think there's a balance to be struck between complete absence of comments and over-commenting, but I believe that (1) right now we're too close to the former, and (2) it's better to err on the side of the latter for any compiler-like project that relies on representation of programmes, because there tend to be a ton of edge cases and weird quirks.

[Fun fact: this PR still fails with emojis.](https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/991) However, this is a bigger problem that requires a larger refactor, so I don't want to lump it in here.