### PR TITLE
Fix formatting regressions in v2.5.0

### DIFF
--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,3 +1,15 @@
+# v2.5.1
+
+Fix some formatting regressions introduced in v2.5.0.
+In particular, this version:
+
+- no longer aggressively adds spaces around `x=>y` and `x->y` (unless spaces are already present).
+  This matches the behaviour of other operators e.g. `x+y`.
+- no longer adds spaces around assignments in square brackets, for example `a[b=1]` is now left unchanged, rather than being changed to `a[b = 1]`.
+- no longer adds parentheses around field access in ranges, for example `[1:a.b]` is now left unchanged, rather than being changed to `[1:(a.b)]`.
+
+Some of these may be configurable in the future.
+
 # v2.5.0
 
 Added compatibility with JuliaSyntax@1.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.5.0"
+version = "2.5.1"
 authors = ["Dominique Luna <dluna132@gmail.com> and contributors"]
 
 [deps]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,6 +1,6 @@
 # API Documentation
 
 ```@autodocs
-Modules = [JuliaFormatter]
+Modules = [JuliaFormatter, JuliaFormatter.Internal]
 Filter = t -> (t != YASStyle && t != BlueStyle && t != SciMLStyle)  # on their own pages
 ```

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -543,6 +543,8 @@ end
 
 include("app.jl")
 
+include("internal/utils.jl")
+
 @setup_workload let
     dir = joinpath(@__DIR__, "..")
     sandbox_dir = joinpath(tempdir(), join(rand('a':'z', 24)))

--- a/src/internal/utils.jl
+++ b/src/internal/utils.jl
@@ -1,0 +1,56 @@
+# This module contains helper functions to run formatting up until a certain point and to
+# see the output, as well as some shorthands for test utilities. As the name suggests, these
+# are for internal use only, and can break at any time.
+
+module Internal
+
+import JuliaSyntax as JS
+import ..JuliaFormatter as JF
+
+"""
+    JuliaFormatter.Internal.format_to_stage(
+        stage::Symbol,
+        text::AbstractString,
+        [style=DefaultStyle(),]
+        options...
+    )
+
+Run formatting on a given string up until a certain stage, and return the output of that
+stage.
+
+Available stages:
+
+ - (:gn, :greennode, :parse): the output of the JuliaSyntax parser, which is a
+   `JuliaSyntax.GreenNode`.
+
+This is the only stage currently implemented, but more will be added in the future.
+
+!!! tip
+    For a utility that is meant to be convenient to access, typing the full qualified
+    name can be a bit of a hassle! If you are using this function a lot, you may want
+    to use [BasicAutoloads.jl](https://github.com/LilithHafner/BasicAutoloads.jl) to
+    automatically import it, and possibly even with a shorter name. For example, you
+    can add something like this to your `~/.julia/config/startup.jl`:
+
+    ```julia
+    if isinteractive()
+        import BasicAutoloads
+        BasicAutoloads.register_autoloads([
+            ["fs"] => :(using JuliaFormatter.Internal: format_to_stage as fs),
+        ])
+    end
+    ```
+"""
+function format_to_stage(
+    stage::Symbol,
+    text::AbstractString,
+    style::JF.AbstractStyle = JF.DefaultStyle();
+    options...,
+)
+    parsed = JS.parseall(JS.GreenNode, text)
+    stage in (:gn, :greennode, :parse) && return parsed
+
+    throw(ArgumentError("unknown stage: $stage"))
+end
+
+end # module

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -2183,10 +2183,7 @@ function p_binaryopcall(
         elseif JuliaSyntax.is_whitespace(c)
             add_node!(t, n, s; join_lines = true)
         else
-            if (opkind === K":" &&
-               is_opcall(c) &&
-               !(kind(c) in KSet"parens .")
-            )
+            if (opkind === K":" && is_opcall(c) && !(kind(c) in KSet"parens ."))
                 # Add parentheses around expressions on either side of a range. We manually
                 # exclude field access to avoid parenthesising e.g. [1:a.b] -> [1:(a.b)].
                 # TODO(penelopeysm): Add a config option for this parenthesisation (false

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1,5 +1,10 @@
 @kwdef struct PrettyContext
+    # If true, ensure that no whitespace is added around binary operators.
+    # In general, this can be inferred from the source. However, this is
+    # overridden specifically for macro keyword arguments in SciML style.
+    # See https://github.com/SciML/SciMLStyle/tree/3f6fa61c6cc6fcf1c23177fab187d0c85197acfc#macros
     nospace::Bool = false
+
     nonest::Bool = false
     standalone_binary_circuit::Bool = true
     from_typedef::Bool = false
@@ -2042,7 +2047,7 @@ function p_binaryopcall(
     if opkind === K":"
         nospace = true
         from_colon = true
-    elseif opkind in KSet"::"
+    elseif opkind === K"::"
         nospace = true
     elseif is_short_form_function && opkind === K"="
         nospace = false
@@ -2054,9 +2059,6 @@ function p_binaryopcall(
         nospace = false
     elseif opkind in KSet"in ∈ isa ."
         nospace = false
-    elseif opkind in KSet"=> ->" || (opkind === K"|>" && !(ctx.from_ref || from_colon))
-        nospace = false
-        has_ws = true
     elseif from_typedef && opkind in KSet"<: >:"
         if s.opts.whitespace_typedefs
             nospace = false

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1819,7 +1819,7 @@ function p_try(
                 add_node!(t, n, s; max_padding = 0)
                 t.len = max(len, length(n))
             end
-        elseif kind(c) in KSet"end"
+        elseif kind(c) === K"end"
             s.indent -= s.opts.indent
             add_node!(t, pretty(style, c, s, ctx, lineage), s)
         elseif kind(c) === K"block"
@@ -2012,7 +2012,7 @@ function p_binaryopcall(
             if tt in KSet"parens macrocall return if elseif else" || is_assign
                 standalone_binary_circuit = false
                 break
-            elseif tt in KSet"block"
+            elseif tt === K"block"
                 break
             end
         end
@@ -2189,10 +2189,15 @@ function p_binaryopcall(
         elseif JuliaSyntax.is_whitespace(c)
             add_node!(t, n, s; join_lines = true)
         else
-            if opkind === K":" &&
-               # !s.whitespace_ops_in_indices &&
+            if (opkind === K":" &&
                is_opcall(c) &&
-               kind(c) !== K"parens"
+               !(kind(c) in KSet"parens .")
+            )
+                # Add parentheses around expressions on either side of a range. We manually
+                # exclude field access to avoid parenthesising e.g. [1:a.b] -> [1:(a.b)].
+                # TODO(penelopeysm): Add a config option for this parenthesisation (false
+                # should preserve the original parens, true should add parens if there are
+                # none).
                 add_node!(
                     t,
                     FST(PUNCTUATION, -1, n.startline, n.startline, "("),
@@ -2378,7 +2383,7 @@ function p_unaryopcall(
 
     for (i, c) in enumerate(childs)
         offset = s.offset
-        if i > 1 && kind(c) in KSet"Whitespace"
+        if i > 1 && kind(c) === K"Whitespace"
             add_node!(t, Whitespace(1), s)
         end
         n = pretty(style, c, s, ctx, lineage)

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -2039,9 +2039,6 @@ function p_binaryopcall(
 
     from_colon = ctx.from_colon
     from_typedef = ctx.from_typedef
-    parent_kind = length(lineage) > 1 ? lineage[end-1][1] : K"None"
-    preserve_assignment_spacing =
-        ctx.from_let || ctx.nospace || parent_kind in KSet"global local outer macrocall"
 
     nospace = ctx.nospace
     if opkind === K":"
@@ -2050,9 +2047,6 @@ function p_binaryopcall(
     elseif opkind === K"::"
         nospace = true
     elseif is_short_form_function && opkind === K"="
-        nospace = false
-        has_ws = true
-    elseif is_assignment(cst) && !preserve_assignment_spacing
         nospace = false
         has_ws = true
     elseif kind(cst) === K"comparison"

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -408,6 +408,7 @@
         @test fmt("a: b") == "a:b"
         @test fmt("a :b") == "a:b"
         @test fmt("a +1 :b -1") == "(a+1):(b-1)"
+        @test fmt("a.b:c.d") == "a.b:c.d" # shouldn't add parens
 
         @test fmt("a::b:: c") == "a::b::c"
         @test fmt("a :: b::c") == "a::b::c"
@@ -2512,6 +2513,7 @@
 
         @test fmt("ref[a: (b + c)]") == "ref[a:(b+c)]"
         @test fmt("ref[a in b]") == "ref[a in b]"
+        @test fmt("ref[a:b.c]") == "ref[a:b.c]" # shouldn't add parens
     end
 
     @testset "nesting" begin

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -360,6 +360,41 @@
     end
 
     @testset "binary ops" begin
+
+        @testset "whitespace addition" begin
+            # For these 'operators' whitespace should only be added if there is already some
+            # whitespace around the operator. (Note that the word 'operator' is used here
+            # lightly, because many of these are parsed as infix _function calls_ rather
+            # than infix _operators_ per se -- IMO we need clearer nomenclature.) There are
+            # probably more that we need to test...
+            for op in ("+", "*", "/", "-", "^", "%", "<", ">", "<=", ">=", "=>", "->", "-->", "<--", "~", "<:", ">:")
+                # see below also for <: and >:
+                @test fmt("a$(op)b") == "a$(op)b"
+                @test fmt("a $(op)b") == "a $(op) b"
+                @test fmt("a$(op) b") == "a $(op) b"
+                @test fmt("a $(op) b") == "a $(op) b"
+                @test fmt("a  $(op)  b") == "a $(op) b"
+            end
+            # For these ops there should never be whitespace
+            for op in (":", "::")
+                target = "a$(op)b"
+                @test fmt("a$(op)b") == target
+                @test fmt("a $(op)b") == target
+                @test fmt("a$(op) b") == target
+                @test fmt("a $(op) b") == target
+                @test fmt("a  $(op)  b") == target
+            end
+            # Supertypes / subtypes have special behaviour within typedefs
+            for op in ("<:", ">:")
+                target = "function f() where {a$(op)b} end"
+                @test fmt("function f() where {a$(op)b} end") == target
+                @test fmt("function f() where {a $(op)b} end") == target
+                @test fmt("function f() where {a$(op) b} end") == target
+                @test fmt("function f() where {a $(op) b} end") == target
+                @test fmt("function f() where {a  $(op)  b} end") == target
+            end
+        end
+
         @test fmt("a+b*c") == "a+b*c"
         @test fmt("a +b *c") == "a + b * c"
         @test fmt("a + b      *c") == "a + b * c"

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -367,22 +367,39 @@
             # lightly, because many of these are parsed as infix _function calls_ rather
             # than infix _operators_ per se -- IMO we need clearer nomenclature.) There are
             # probably more that we need to test...
-            for op in ("+", "*", "/", "-", "^", "%", "<", ">", "<=", ">=", "=>", "->", "-->", "<--", "~", "<:", ">:")
-                # see below also for <: and >:
-                @test fmt("a$(op)b") == "a$(op)b"
-                @test fmt("a $(op)b") == "a $(op) b"
-                @test fmt("a$(op) b") == "a $(op) b"
-                @test fmt("a $(op) b") == "a $(op) b"
-                @test fmt("a  $(op)  b") == "a $(op) b"
+            for op in ("+", "*", "/", "-", "^", "%", "<", ">", "<=", ">=", "=>", "->", "-->", "<--", "~", "<:", ">:", "=", "==", "+=", "-=", "&&", "||")
+                # see typedef section below also for <: and >:
+                for (a, b) in (("a", "b"), ("[a", "b]"), ("(a", "b)"))
+                    @test fmt("$a$(op)$b") == "$a$(op)$b"
+                    @test fmt("$a$(op) $b") == "$a $(op) $b"
+                    @test fmt("$a $(op) $b") == "$a $(op) $b"
+                    @test fmt("$a  $(op)  $b") == "$a $(op) $b"
+
+                    # Some of these are unary operators, so [a <op>b] means a 1x2 matrix
+                    # with `a` and `<op>b` as elements, rather than a length-1 vector with
+                    # `a<op>b` as its element. We skip those tests.
+                    if !(op in ("+", "-", "~") && a == "[a")
+                        @test fmt("$a $(op)$b") == "$a $(op) $b"
+                    end
+                end
             end
             # For these ops there should never be whitespace
             for op in (":", "::")
-                target = "a$(op)b"
-                @test fmt("a$(op)b") == target
-                @test fmt("a $(op)b") == target
-                @test fmt("a$(op) b") == target
-                @test fmt("a $(op) b") == target
-                @test fmt("a  $(op)  b") == target
+                for (a, b) in (("a", "b"), ("[a", "b]"), ("(a", "b)"))
+                    target = "$a$(op)$b"
+                    @test fmt("$a$(op)$b") == target
+                    @test fmt("$a$(op) $b") == target
+                    @test fmt("$a $(op) $b") == target
+                    @test fmt("$a  $(op)  $b") == target
+
+                    # Just like above, `[a :b]` means a 1x2 matrix wtih with `a` and `:b`
+                    # (i.e. a symbol) as elements, rather than a length-1 vector with `a:b`
+                    # as its element. We skip those tests.
+                    if !(op == ":" && a == "[a")
+                        @test fmt("$a $(op)$b") == target
+                    end
+
+                end
             end
             # Supertypes / subtypes have special behaviour within typedefs
             for op in ("<:", ">:")


### PR DESCRIPTION
See changelog for info. This PR fixes a few changes in behaviour that were inadvertently introduced in v2.5.0

This PR also adds an internal helper function which will run the formatter up to a certain stage and return the intermediate tree structure. right now it only does the parse stage but I'll expand on it as I go along. This will eventually not only useful for demonstrating things in the built docs, but also just generally for development purposes!