### PR TITLE
FormatBot part 2

### DIFF
--- a/.github/workflows/FormatBot.yml
+++ b/.github/workflows/FormatBot.yml
@@ -143,6 +143,8 @@ jobs:
                   subprocess.run(["find", target_dir, "-name", name, "-delete"])
 
               # Commit clean state so we can branch from it
+              git("config", "user.name", "FormatBot")
+              git("config", "user.email", "noreply@github.com")
               git("checkout", "-b", branch_clean)
               git("add", "-A")
               git("commit", "--allow-empty", "-m", branch_clean)
@@ -232,7 +234,6 @@ jobs:
               sys.exit(1)
 
       - name: Add completion reaction
-        if: always()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/FormatBot.yml
+++ b/.github/workflows/FormatBot.yml
@@ -151,11 +151,22 @@ jobs:
 
               # --- Write Julia format script ---
               # style is a positional arg; extract it from opts if present
-              style = ""
+              style_shortcuts = {
+                  "default": "DefaultStyle()",
+                  "yas": "YASStyle()",
+                  "blue": "BlueStyle()",
+                  "sciml": "SciMLStyle()",
+                  "minimal": "MinimalStyle()",
+              }
+              style = None
               kwargs = []
               for token in opts:
                   if token.startswith("style="):
-                      style = token.split("=", 1)[1]
+                      val = token.split("=", 1)[1]
+                      if val not in style_shortcuts:
+                          post_comment(f"{header}\n**Error:** Unknown style `{val}`. Valid: {', '.join(style_shortcuts)}.")
+                          sys.exit(1)
+                      style = style_shortcuts[val]
                   else:
                       kwargs.append(token)
 


### PR DESCRIPTION
Fixes a bug with formatbot where it didn't have git config set up.

Also changes the specification of style: it now uses `style=sciml` instead of `style=SciMLStyle()`. The former is more consistent with JuliaFormatter.toml.