### PR TITLE
Refactor `is_unary` and `p_kw`, improve consistency of kwarg parenthesisation

### DIFF
--- a/.github/workflows/FormatBot.yml
+++ b/.github/workflows/FormatBot.yml
@@ -118,7 +118,7 @@ jobs:
               "| Description | Value |",
               "|---|---|",
               f"| **FormatBot workflow run** | [workflow run]({run_url}) |",
-              f"| **Target repo** | `{repo_display}` |",
+              f"| **Target repo** | [`{repo_display}`](https://github.com/{repo}{f'/tree/{rev}' if rev else ''}) |",
               f"| **JuliaFormatter base** | [`{base_sha[:7]}`]({repo_url}/commit/{base_sha}) |",
               f"| **JuliaFormatter PR** | [`{head_sha[:7]}`]({repo_url}/commit/{head_sha}) |",
           ]

--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,3 +1,9 @@
+# v2.5.3
+
+Fixed a bug where postfix operators (e.g. transpose) were not being recognised as unary operators, causing formatting to output unparseable code in some circumstances (#1011).
+
+Improved consistency when parenthesising the value of a keyword argument with `whitespace_in_kwargs=false`, e.g., `(; x=-pi/2)` is now formatted as `(; x=(-pi/2))` (#1011).
+
 # v2.5.2
 
 Fixed a bug where, under SciML style, indentations of bracketed expressions on the RHS of assignments were being removed for anything on the second line onwards (#935, #1006).

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.5.2"
+version = "2.5.3"
 authors = ["Dominique Luna <dluna132@gmail.com> and contributors"]
 
 [deps]

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -560,8 +560,11 @@ end
 
 function is_unary(x::JuliaSyntax.GreenNode)
     if JuliaSyntax.is_unary_op(x) && !haschildren(x)
+        # Note that this only returns true for a bare operator, such as
+        # `<:` or `.+`
         return true
     end
+    # This catches the actual unary operators applied to an argument
     if kind(x) in KSet"call dotcall" || (JuliaSyntax.is_operator(x) && haschildren(x))
         nops, nargs = _callinfo(x)
         return nops == 1 && nargs == 1

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -574,7 +574,7 @@ function unary_info(x::JuliaSyntax.GreenNode)
         # `+x`
         true
     elseif JuliaSyntax.is_postfix_op_call(x)
-        # `x'` or `x'ᵀ'
+        # `x'` or `x'ᵀ`
         false
     elseif JuliaSyntax.is_operator(x) && haschildren(x)
         # `<:x` or `x...`

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -496,7 +496,7 @@ function is_typedef(fst::FST)
 end
 
 function is_opcall(x::JuliaSyntax.GreenNode)
-    if is_binary(x) || kind(x) == K"comparison" || is_chain(x) || is_unary(x)
+    if is_binary(x) || kind(x) == K"comparison" || is_chain(x) || unary_info(x) !== nothing
         return true
     end
     if kind(x) === K"parens" && haschildren(x)
@@ -558,18 +558,43 @@ function _callinfo(x::JuliaSyntax.GreenNode)
     return n_operators, n_args
 end
 
-function is_unary(x::JuliaSyntax.GreenNode)
-    if JuliaSyntax.is_unary_op(x) && !haschildren(x)
-        # Note that this only returns true for a bare operator, such as
-        # `<:` or `.+`
-        return true
+"""
+    unary_info(x::JuliaSyntax.GreenNode)::Union{Bool,Nothing}
+
+Returns:
+
+- `true` if `x` is a prefix unary operator application, such as `+x` or `<:x`
+
+- `false` if `x` is a postfix unary operator application, such as `x'` or `x...`;
+
+- `nothing` if `x` is not an application of a unary operator.
+"""
+function unary_info(x::JuliaSyntax.GreenNode)
+    return if JuliaSyntax.is_prefix_op_call(x)
+        # `+x`
+        true
+    elseif JuliaSyntax.is_postfix_op_call(x)
+        # `x'` or `x'ᵀ'
+        false
+    elseif JuliaSyntax.is_operator(x) && haschildren(x)
+        # `<:x` or `x...`
+        childs_no_whitespace = filter(c -> !JuliaSyntax.is_whitespace(c), children(x))
+        if length(childs_no_whitespace) != 2
+            # Not unary at all
+            nothing
+        elseif JuliaSyntax.is_operator(childs_no_whitespace[1])
+            # `<:x`
+            true
+        elseif JuliaSyntax.is_operator(childs_no_whitespace[end])
+            # `x...`
+            false
+        else
+            error("unreachable: unary operation node with no child operator")
+        end
+    else
+        # Not unary at all
+        nothing
     end
-    # This catches the actual unary operators applied to an argument
-    if kind(x) in KSet"call dotcall" || (JuliaSyntax.is_operator(x) && haschildren(x))
-        nops, nargs = _callinfo(x)
-        return nops == 1 && nargs == 1
-    end
-    return false
 end
 
 function is_binary(x)
@@ -706,7 +731,7 @@ function get_op(cst::JuliaSyntax.GreenNode)::Union{JuliaSyntax.GreenNode,Nothing
         is_binary(cst) ||
         kind(cst) in KSet"comparison dotcall call" ||
         is_chain(cst) ||
-        is_unary(cst)
+        unary_info(cst) !== nothing
     ) && haschildren(cst)
         for c in children(cst)
             if kind(cst) === K"dotcall" && kind(c) === K"."

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -796,7 +796,7 @@ function p_stringh(
     if !haschildren(cst)
         return FST(StringN, loc[2] - 1)
     end
-    loc2 = cursor_loc(s, s.offset+span(cst)-1)
+    loc2 = cursor_loc(s, s.offset + span(cst) - 1)
 
     val = getsrcval(s.doc, (s.offset):(s.offset+span(cst)-1))
     startline = loc[1]
@@ -1030,7 +1030,7 @@ function p_block(
         elseif single_line
             if kind(a) in KSet", ;"
                 add_node!(t, n, s; join_lines = true)
-                if needs_placeholder(childs, i+1, K")")
+                if needs_placeholder(childs, i + 1, K")")
                     add_node!(t, Placeholder(1), s)
                 end
             else
@@ -2032,39 +2032,43 @@ function p_kw(
 
     push!(lineage, (kind(cst), false, true))
 
+    # We need to process the LHS and RHS slightly differently in the loop below.
+    is_rhs_of_equal = false
+
     for c in children(cst)
-        if kind(c) === K"=" && s.opts.whitespace_in_kwargs
-            add_node!(t, Whitespace(1), s)
+        if kind(c) === K"="
+            s.opts.whitespace_in_kwargs && add_node!(t, Whitespace(1), s)
             add_node!(t, pretty(style, c, s, ctx, lineage), s; join_lines = true)
-            add_node!(t, Whitespace(1), s)
+            s.opts.whitespace_in_kwargs && add_node!(t, Whitespace(1), s)
+            # Now that we've seen the equal, we know that what comes after it must
+            # be the RHS.
+            is_rhs_of_equal = true
         else
+            child_offset = s.offset
+            n = pretty(style, c, s, ctx, lineage)
             # Check if the value of the kwarg begins with an operator, or if the name ends
             # with an exclamation mark. If so, then we should parenthesise it to avoid
-            # ambiguity. (Note that unary_info(c) === true indicates that c is a prefix
-            # operator call.)
-            #
-            # TODO(penelopeysm): These checks could definitely be done better, by
-            # specifically targeting the LHS and the RHS of the (=) node.
-            begins_with_op = unary_info(c) === true
-            n = pretty(style, c, s, ctx, lineage)
-            if !s.opts.whitespace_in_kwargs &&
-               ((n.typ === IDENTIFIER && endswith(n.val, "!")) || begins_with_op)
-                add_node!(
-                    t,
-                    FST(PUNCTUATION, -1, n.startline, n.startline, "("),
-                    s;
-                    join_lines = true,
-                )
-                add_node!(t, n, s; join_lines = true)
-                add_node!(
-                    t,
-                    FST(PUNCTUATION, -1, n.startline, n.startline, ")"),
-                    s;
-                    join_lines = true,
-                )
-            else
-                add_node!(t, n, s; join_lines = true)
-            end
+            # ambiguity.
+            lhs_ends_with_bang =
+                !is_rhs_of_equal && kind(c) === K"Identifier" && endswith(n.val, "!")
+            rhs_begins_with_op =
+                is_rhs_of_equal && source_begins_with_op(s, c, child_offset)
+            parenthesise =
+                (lhs_ends_with_bang || rhs_begins_with_op) && !s.opts.whitespace_in_kwargs
+
+            parenthesise && add_node!(
+                t,
+                FST(PUNCTUATION, -1, n.startline, n.startline, "("),
+                s;
+                join_lines = true,
+            )
+            add_node!(t, n, s; join_lines = true)
+            parenthesise && add_node!(
+                t,
+                FST(PUNCTUATION, -1, n.startline, n.startline, ")"),
+                s;
+                join_lines = true,
+            )
         end
     end
 

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -139,7 +139,7 @@ function source_begins_with_op(s::State, cst::JuliaSyntax.GreenNode, offset::Int
     # Check if it's an operator.
     leaf, extra_offset = result
     opkind = source_op_kind_from_offset(s, leaf, offset + extra_offset)
-    return opkind !== nothing && JuliaSyntax.is_operator(opkind)
+    return opkind !== nothing && JuliaSyntax.is_operator(opkind) && opkind !== K":"
 end
 
 function is_source_operator(s::State, cst::JuliaSyntax.GreenNode, offset::Integer)

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -26,46 +26,120 @@ function newctx(s::PrettyContext; kwargs...)
     PrettyContext(values...)
 end
 
-function source_kind(s::State, cst::JuliaSyntax.GreenNode, offset::Integer)
-    span(cst) == 0 && return nothing
-    offset = Int(offset)
-    n = Int(span(cst))
-    val = getsrcval(s.doc, offset:(offset+n-1))
-    try
-        return JuliaSyntax.Kind(val)
-    catch
-        # There are some operators for which JuliaSyntax does not actually have a dedicated
-        # kind. For example, `a'ᵀ` is a postfix operator `'ᵀ`, and
-        # JuliaSyntax.is_postfix_op_call will correctly return true. Specifically, the '
-        # postfix operator can be followed by any Unicode modifier:
-        # https://github.com/JuliaLang/julia/pull/37247
-        #
-        # However, the operator is stored as Identifier and calling Kind("'ᵀ") throws an
-        # error. We catch such instances here. Thankfully, Base gives us a function
-        # (albeit unexported) to detect these.
-        return if kind(cst) === K"Identifier" && Base.ispostfixoperator(val)
-            K"Identifier"
-        else
-            nothing
-        end
-    end
-end
+"""
+    source_op_kind_from_offset(s, cst, offset)::Union{Nothing,JuliaSyntax.Kind}
 
-# JuliaSyntax v1 can encode source operators as Identifier leaves in call
-# forms, e.g. `a + b`, `x .+ y`, `+(x)`, and `>=(x)`. The parent call flags
-# describe the shape, but the leaf itself is not `is_operator`, and the exact
-# operator kind is only recoverable from the source span.
+Return the operator kind of `cst`, using the source text at `offset` if necessary to help
+determine this. If `cst` is not an operator, returns `nothing`.
+
+Note that this function may still return a K"Identifier"! This is because Julia allows some
+weird postfix operators. See the comments in the function for more info.
+
+The check against the source is needed because JuliaSyntax v1 can encode source operators as
+Identifier leaves in call forms. For example:
+
+```julia
+julia> JuliaSyntax.parseall(JuliaSyntax.GreenNode, "+y")
+     1:2      │[toplevel]
+     1:2      │  [call]
+     1:1      │    Identifier           ✔
+     2:2      │    Identifier           ✔
+```
+
+See https://github.com/JuliaLang/JuliaSyntax.jl/issues/548 for more information.
+"""
 function source_op_kind_from_offset(s::State, cst::JuliaSyntax.GreenNode, offset::Integer)
     return if JuliaSyntax.is_operator(cst) && !haschildren(cst)
         # Already have the right kind stored in the GreenNode
         kind(cst)
     elseif kind(cst) === K"Identifier" && !haschildren(cst)
         # The operator was reduced to an Identifier (this happens in JuliaSyntax v1).
-        # Attempt to recover the original kind.
-        source_kind(s, cst, offset)
+        # Attempt to recover the original kind from the source.
+        span(cst) == 0 && return nothing
+        source_text = getsrcval(s.doc, offset:(offset+span(cst)-1))
+        try
+            # Parse the source text and check whether it's a valid operator.
+            k = JuliaSyntax.Kind(source_text)
+            return if JuliaSyntax.is_operator(k)
+                # This is the happy path. It's hit for things like e.g. "+x".
+                k
+            else
+                # There are a lot of Identifiers which can be parsed as kinds, but aren't
+                # operators. For example, the `string` in `string(x)` will be converted to
+                # K"string" here, which is totally not what we want. Hence we return
+                # nothing.
+                nothing
+            end
+        catch
+            # There are some operators for which JuliaSyntax does not actually have a
+            # dedicated kind. For example, `a'ᵀ` is a postfix operator `'ᵀ`, and
+            # JuliaSyntax.is_postfix_op_call will correctly return true. Specifically, the '
+            # postfix operator can be followed by any Unicode modifier:
+            # https://github.com/JuliaLang/julia/pull/37247
+            #
+            # However, the operator is stored as Identifier and calling Kind("'ᵀ") throws an
+            # error. We catch such instances here. Thankfully, Base gives us a function
+            # (albeit unexported) to detect these. If this function returns K"Identifier",
+            # then we know that it's one of these odd postfix operators.
+            return if kind(cst) === K"Identifier" && Base.ispostfixoperator(source_text)
+                K"Identifier"
+            else
+                nothing
+            end
+        end
     else
+        # Can't be an operator at all
         nothing
     end
+end
+
+"""
+    first_nonws_leaf_and_offset(
+        node::JuliaSyntax.GreenNode,
+    )::Union{Nothing,Tuple{JuliaSyntax.GreenNode,Int}
+
+Return the first non-whitespace leaf node in `node` plus its offset from the beginning of
+`node`, or `nothing` if there are no non-whitespace leaves.
+"""
+function first_nonws_leaf_and_offset(
+    node::JuliaSyntax.GreenNode,
+    # Callers should not set _acc, this is only used in this function to recurse
+    _acc::Int=0
+)::Union{Nothing,Tuple{JuliaSyntax.GreenNode,Int}}
+    if JuliaSyntax.is_leaf(node)
+        return JuliaSyntax.is_whitespace(node) ? nothing : (node, _acc)
+    end
+    # Recursively search children
+    for c in children(node)
+        result = first_nonws_leaf_and_offset(c, _acc)
+        if result !== nothing
+            return result
+        end
+        _acc += span(c)
+    end
+    return nothing
+end
+
+"""
+   source_begins_with_op(s, cst, offset) 
+
+Check whether the first token of `cst` is an operator. Used in `p_kw`: if the value on the
+rhs of `kwarg=value` begins with an operator, then we parenthesise `value` to avoid
+ambiguity.
+
+Note that the behaviour of this differs from `unary_info(cst)`: for example,
+`unary_info(cst)` does not pick up  expressions such as `>=(1)`, which is interpreted as a
+function call, not an application of a unary operator. However, these are exactly the sort
+of things that we want to parenthesise in `p_kw` -- hence this function.
+"""
+function source_begins_with_op(s::State, cst::JuliaSyntax.GreenNode, offset::Integer)
+    # Get the first leaf of `cst` that isn't whitespace.
+    result = first_nonws_leaf_and_offset(cst)
+    result === nothing && return false
+    # Check if it's an operator.
+    leaf, extra_offset = result
+    opkind = source_op_kind_from_offset(s, leaf, offset + extra_offset)
+    return opkind !== nothing && JuliaSyntax.is_operator(opkind)
 end
 
 function is_source_operator(s::State, cst::JuliaSyntax.GreenNode, offset::Integer)
@@ -1965,11 +2039,12 @@ function p_kw(
         else
             # Check if the value of the kwarg begins with an operator, or if the name ends
             # with an exclamation mark. If so, then we should parenthesise it to avoid
-            # ambiguity.
+            # ambiguity. (Note that unary_info(c) === true indicates that c is a prefix
+            # operator call.)
             #
             # TODO(penelopeysm): These checks could definitely be done better, by
             # specifically targeting the LHS and the RHS of the (=) node.
-            begins_with_op = !isnothing(source_unary_operator_index(true, c, s))
+            begins_with_op = unary_info(c) === true
             n = pretty(style, c, s, ctx, lineage)
             if !s.opts.whitespace_in_kwargs &&
                ((n.typ === IDENTIFIER && endswith(n.val, "!")) || begins_with_op)

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -34,7 +34,20 @@ function source_kind(s::State, cst::JuliaSyntax.GreenNode, offset::Integer)
     try
         return JuliaSyntax.Kind(val)
     catch
-        return nothing
+        # There are some operators for which JuliaSyntax does not actually have a dedicated
+        # kind. For example, `a'ᵀ` is a postfix operator `'ᵀ`, and
+        # JuliaSyntax.is_postfix_op_call will correctly return true. Specifically, the '
+        # postfix operator can be followed by any Unicode modifier:
+        # https://github.com/JuliaLang/julia/pull/37247
+        #
+        # However, the operator is stored as Identifier and calling Kind("'ᵀ") throws an
+        # error. We catch such instances here. Thankfully, Base gives us a function
+        # (albeit unexported) to detect these.
+        return if kind(cst) === K"Identifier" && Base.ispostfixoperator(val)
+            K"Identifier"
+        else
+            nothing
+        end
     end
 end
 
@@ -43,15 +56,16 @@ end
 # describe the shape, but the leaf itself is not `is_operator`, and the exact
 # operator kind is only recoverable from the source span.
 function source_op_kind_from_offset(s::State, cst::JuliaSyntax.GreenNode, offset::Integer)
-    if JuliaSyntax.is_operator(cst) && !haschildren(cst)
-        return kind(cst)
+    return if JuliaSyntax.is_operator(cst) && !haschildren(cst)
+        # Already have the right kind stored in the GreenNode
+        kind(cst)
     elseif kind(cst) === K"Identifier" && !haschildren(cst)
-        k = source_kind(s, cst, offset)
-        if !isnothing(k) && JuliaSyntax.is_operator(k)
-            return k
-        end
+        # The operator was reduced to an Identifier (this happens in JuliaSyntax v1).
+        # Attempt to recover the original kind.
+        source_kind(s, cst, offset)
+    else
+        nothing
     end
-    return nothing
 end
 
 function is_source_operator(s::State, cst::JuliaSyntax.GreenNode, offset::Integer)
@@ -59,7 +73,12 @@ function is_source_operator(s::State, cst::JuliaSyntax.GreenNode, offset::Intege
 end
 
 function source_unary_operator_index(is_prefix::Bool, cst::JuliaSyntax.GreenNode, s::State)
-    kind(cst) in KSet"call dotcall" && haschildren(cst) || return nothing
+    if (!JuliaSyntax.is_operator(cst)
+        && !(kind(cst) in KSet"call dotcall" && haschildren(cst))
+    )
+        # Can't even be a unary operator call.
+        return nothing
+    end
     childs = children(cst)
     args = findall(n -> !JuliaSyntax.is_whitespace(n), childs)
     isempty(args) && return nothing

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -140,12 +140,18 @@ function source_begins_with_op_needing_parens(
     # Get the first leaf of `cst` that isn't whitespace.
     result = first_nonws_leaf_and_offset(cst)
     result === nothing && return false
-    # Check if it's an operator.
+    # Check if it's an operator and specifically one that we care about putting
+    # parentheses around.
     leaf, extra_offset = result
     opkind = source_op_kind_from_offset(s, leaf, offset + extra_offset)
-    # Ignore `K":"` as that indicates the beginning of a symbol, which we don't care
-    # about parenthesising.
-    return opkind !== nothing && JuliaSyntax.is_operator(opkind) && opkind !== K":"
+    return (opkind !== nothing
+        && JuliaSyntax.is_operator(opkind)
+        # is_word_operator filters out things like `isa`.
+        && !JuliaSyntax.is_word_operator(opkind)
+        # Ignore `K":"` as that indicates the beginning of a symbol, which we don't care
+        # about parenthesising.
+        && opkind !== K":"
+    )
 end
 
 function is_source_operator(s::State, cst::JuliaSyntax.GreenNode, offset::Integer)

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -104,7 +104,7 @@ Return the first non-whitespace leaf node in `node` plus its offset from the beg
 function first_nonws_leaf_and_offset(
     node::JuliaSyntax.GreenNode,
     # Callers should not set _acc, this is only used in this function to recurse
-    _acc::Int = 0,
+    _acc::Integer = 0,
 )::Union{Nothing,Tuple{JuliaSyntax.GreenNode,Int}}
     if JuliaSyntax.is_leaf(node)
         return JuliaSyntax.is_whitespace(node) ? nothing : (node, _acc)
@@ -149,6 +149,7 @@ function source_begins_with_op_needing_parens(
 end
 
 function is_source_operator(s::State, cst::JuliaSyntax.GreenNode, offset::Integer)
+    # TODO(penelopeysm): do we need to check JuliaSyntax.is_operator as well?
     !isnothing(source_op_kind_from_offset(s, cst, offset))
 end
 

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -104,7 +104,7 @@ Return the first non-whitespace leaf node in `node` plus its offset from the beg
 function first_nonws_leaf_and_offset(
     node::JuliaSyntax.GreenNode,
     # Callers should not set _acc, this is only used in this function to recurse
-    _acc::Int=0
+    _acc::Int = 0,
 )::Union{Nothing,Tuple{JuliaSyntax.GreenNode,Int}}
     if JuliaSyntax.is_leaf(node)
         return JuliaSyntax.is_whitespace(node) ? nothing : (node, _acc)
@@ -147,7 +147,8 @@ function is_source_operator(s::State, cst::JuliaSyntax.GreenNode, offset::Intege
 end
 
 function source_unary_operator_index(is_prefix::Bool, cst::JuliaSyntax.GreenNode, s::State)
-    if !haschildren(cst) || !(JuliaSyntax.is_operator(cst) || kind(cst) in KSet"call dotcall")
+    if !haschildren(cst) ||
+       !(JuliaSyntax.is_operator(cst) || kind(cst) in KSet"call dotcall")
         return nothing
     end
 

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -58,7 +58,7 @@ function is_source_operator(s::State, cst::JuliaSyntax.GreenNode, offset::Intege
     !isnothing(source_op_kind_from_offset(s, cst, offset))
 end
 
-function source_prefix_operator_index(cst::JuliaSyntax.GreenNode, s::State)
+function source_unary_operator_index(is_prefix::Bool, cst::JuliaSyntax.GreenNode, s::State)
     kind(cst) in KSet"call dotcall" && haschildren(cst) || return nothing
     childs = children(cst)
     args = findall(n -> !JuliaSyntax.is_whitespace(n), childs)
@@ -202,6 +202,8 @@ function pretty(
     do_block_idx = has_do_block_call(node)
     push!(lineage, (k, is_iterable(node), is_assignment(node)))
 
+    _unaryinfo = unary_info(node)
+
     ret = if k == K"Identifier" && !haschildren(node)
         p_identifier(style, node, s, ctx, lineage)
         # Example: `try f() catch g() end` has a zero-width Placeholder
@@ -300,17 +302,14 @@ function pretty(
         # Example: `map(xs) do x; x + 1; end` is a call node with a do child.
     elseif !isnothing(do_block_idx)
         p_do_call(style, node, s, ctx, lineage, do_block_idx)
-        # Example: `+(x)` parses as a prefix-op call.
-    elseif JuliaSyntax.is_prefix_op_call(node)
-        p_unaryopcall(style, node, s, ctx, lineage)
-    elseif JuliaSyntax.is_postfix_op_call(node)
-        p_unaryopcall(style, node, s, ctx, lineage)
+    elseif _unaryinfo !== nothing
+        # _unaryinfo === nothing means that it's not unary; true/false indicates whether
+        # it's a prefix/postfix.
+        p_unaryopcall(style, node, s, ctx, lineage, _unaryinfo)
     elseif is_binary(node)
         p_binaryopcall(style, node, s, ctx, lineage)
     elseif is_chain(node)
         p_chainopcall(style, node, s, ctx, lineage)
-    elseif is_unary(node)
-        p_unaryopcall(style, node, s, ctx, lineage)
     elseif is_func_call(node)
         p_call(style, node, s, ctx, lineage)
     elseif k === K"comparison"
@@ -1941,13 +1940,10 @@ function p_kw(
             add_node!(t, pretty(style, c, s, ctx, lineage), s; join_lines = true)
             add_node!(t, Whitespace(1), s)
         else
-            # Need to explicitly check source_prefix rather than relying on
-            # JuliaSyntax.is_prefix_op_call, as the latter doesn't identify e.g.
-            # `>=(x)` as operators.
-            source_prefix = !isnothing(source_prefix_operator_index(c, s))
+            is_prefix_unaryop = unary_info(c) === true
             n = pretty(style, c, s, ctx, lineage)
             if !s.opts.whitespace_in_kwargs &&
-               ((n.typ === IDENTIFIER && endswith(n.val, "!")) || source_prefix)
+               ((n.typ === IDENTIFIER && endswith(n.val, "!")) || is_prefix_unaryop)
                 add_node!(
                     t,
                     FST(PUNCTUATION, -1, n.startline, n.startline, "("),
@@ -2358,6 +2354,7 @@ function p_unaryopcall(
     s::State,
     ctx::PrettyContext,
     lineage::Vector{Tuple{JuliaSyntax.Kind,Bool,Bool}},
+    is_prefix::Bool,
 )
     style = getstyle(ds)
     t = FST(Unary, nspaces(s))
@@ -2367,7 +2364,7 @@ function p_unaryopcall(
 
     childs = children(cst)
     first_idx = findfirst(n -> !JuliaSyntax.is_whitespace(n), childs)
-    op_idx = source_prefix_operator_index(cst, s)
+    op_idx = source_unary_operator_index(is_prefix, cst, s)
     if isnothing(op_idx)
         op_idx = first_idx
     end

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -65,12 +65,14 @@ function source_prefix_operator_index(cst::JuliaSyntax.GreenNode, s::State)
     isempty(args) && return nothing
 
     op_arg =
-        if kind(cst) === K"dotcall" &&
+        if (kind(cst) === K"dotcall" &&
            length(args) >= 2 &&
            kind(childs[args[1]]) === K"." &&
-           !haschildren(childs[args[1]])
+           !haschildren(childs[args[1]]))
+            # e.g. `.+x`
             args[2]
         else
+            # e.g. `+x`
             args[1]
         end
     offset = s.offset + sum(span, childs[1:(op_arg-1)]; init = 0)
@@ -300,6 +302,8 @@ function pretty(
         p_do_call(style, node, s, ctx, lineage, do_block_idx)
         # Example: `+(x)` parses as a prefix-op call.
     elseif JuliaSyntax.is_prefix_op_call(node)
+        p_unaryopcall(style, node, s, ctx, lineage)
+    elseif JuliaSyntax.is_postfix_op_call(node)
         p_unaryopcall(style, node, s, ctx, lineage)
     elseif is_binary(node)
         p_binaryopcall(style, node, s, ctx, lineage)

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -121,7 +121,7 @@ function first_nonws_leaf_and_offset(
 end
 
 """
-   source_begins_with_op(s, cst, offset) 
+   source_begins_with_op_needing_parens(s, cst, offset) 
 
 Check whether the first token of `cst` is an operator. Used in `p_kw`: if the value on the
 rhs of `kwarg=value` begins with an operator, then we parenthesise `value` to avoid
@@ -132,13 +132,19 @@ Note that the behaviour of this differs from `unary_info(cst)`: for example,
 function call, not an application of a unary operator. However, these are exactly the sort
 of things that we want to parenthesise in `p_kw` -- hence this function.
 """
-function source_begins_with_op(s::State, cst::JuliaSyntax.GreenNode, offset::Integer)
+function source_begins_with_op_needing_parens(
+    s::State,
+    cst::JuliaSyntax.GreenNode,
+    offset::Integer,
+)
     # Get the first leaf of `cst` that isn't whitespace.
     result = first_nonws_leaf_and_offset(cst)
     result === nothing && return false
     # Check if it's an operator.
     leaf, extra_offset = result
     opkind = source_op_kind_from_offset(s, leaf, offset + extra_offset)
+    # Ignore `K":"` as that indicates the beginning of a symbol, which we don't care
+    # about parenthesising.
     return opkind !== nothing && JuliaSyntax.is_operator(opkind) && opkind !== K":"
 end
 
@@ -2052,7 +2058,7 @@ function p_kw(
             lhs_ends_with_bang =
                 !is_rhs_of_equal && kind(c) === K"Identifier" && endswith(n.val, "!")
             rhs_begins_with_op =
-                is_rhs_of_equal && source_begins_with_op(s, c, child_offset)
+                is_rhs_of_equal && source_begins_with_op_needing_parens(s, c, child_offset)
             parenthesise =
                 (lhs_ends_with_bang || rhs_begins_with_op) && !s.opts.whitespace_in_kwargs
 

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1944,10 +1944,16 @@ function p_kw(
             add_node!(t, pretty(style, c, s, ctx, lineage), s; join_lines = true)
             add_node!(t, Whitespace(1), s)
         else
-            is_prefix_unaryop = unary_info(c) === true
+            # Check if the value of the kwarg begins with an operator, or if the name ends
+            # with an exclamation mark. If so, then we should parenthesise it to avoid
+            # ambiguity.
+            #
+            # TODO(penelopeysm): These checks could definitely be done better, by
+            # specifically targeting the LHS and the RHS of the (=) node.
+            begins_with_op = !isnothing(source_unary_operator_index(true, c, s))
             n = pretty(style, c, s, ctx, lineage)
             if !s.opts.whitespace_in_kwargs &&
-               ((n.typ === IDENTIFIER && endswith(n.val, "!")) || is_prefix_unaryop)
+               ((n.typ === IDENTIFIER && endswith(n.val, "!")) || begins_with_op)
                 add_node!(
                     t,
                     FST(PUNCTUATION, -1, n.startline, n.startline, "("),

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -64,7 +64,7 @@ function source_unary_operator_index(is_prefix::Bool, cst::JuliaSyntax.GreenNode
     args = findall(n -> !JuliaSyntax.is_whitespace(n), childs)
     isempty(args) && return nothing
 
-    op_arg =
+    op_arg = if is_prefix
         if (kind(cst) === K"dotcall" &&
            length(args) >= 2 &&
            kind(childs[args[1]]) === K"." &&
@@ -75,6 +75,10 @@ function source_unary_operator_index(is_prefix::Bool, cst::JuliaSyntax.GreenNode
             # e.g. `+x`
             args[1]
         end
+    else
+        # postfix operator
+        args[end]
+    end
     offset = s.offset + sum(span, childs[1:(op_arg-1)]; init = 0)
     return is_source_operator(s, childs[op_arg], offset) ? op_arg : nothing
 end

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -65,10 +65,12 @@ function source_unary_operator_index(is_prefix::Bool, cst::JuliaSyntax.GreenNode
     isempty(args) && return nothing
 
     op_arg = if is_prefix
-        if (kind(cst) === K"dotcall" &&
-           length(args) >= 2 &&
-           kind(childs[args[1]]) === K"." &&
-           !haschildren(childs[args[1]]))
+        if (
+            kind(cst) === K"dotcall" &&
+            length(args) >= 2 &&
+            kind(childs[args[1]]) === K"." &&
+            !haschildren(childs[args[1]])
+        )
             # e.g. `.+x`
             args[2]
         else

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -73,12 +73,10 @@ function is_source_operator(s::State, cst::JuliaSyntax.GreenNode, offset::Intege
 end
 
 function source_unary_operator_index(is_prefix::Bool, cst::JuliaSyntax.GreenNode, s::State)
-    if (!JuliaSyntax.is_operator(cst)
-        && !(kind(cst) in KSet"call dotcall" && haschildren(cst))
-    )
-        # Can't even be a unary operator call.
+    if !haschildren(cst) || !(JuliaSyntax.is_operator(cst) || kind(cst) in KSet"call dotcall")
         return nothing
     end
+
     childs = children(cst)
     args = findall(n -> !JuliaSyntax.is_whitespace(n), childs)
     isempty(args) && return nothing

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -144,13 +144,16 @@ function source_begins_with_op_needing_parens(
     # parentheses around.
     leaf, extra_offset = result
     opkind = source_op_kind_from_offset(s, leaf, offset + extra_offset)
-    return (opkind !== nothing
-        && JuliaSyntax.is_operator(opkind)
+    return (
+        opkind !== nothing &&
+        JuliaSyntax.is_operator(opkind)
         # is_word_operator filters out things like `isa`.
-        && !JuliaSyntax.is_word_operator(opkind)
+        &&
+        !JuliaSyntax.is_word_operator(opkind)
         # Ignore `K":"` as that indicates the beginning of a symbol, which we don't care
         # about parenthesising.
-        && opkind !== K":"
+        &&
+        opkind !== K":"
     )
 end
 

--- a/src/styles/sciml/pretty.jl
+++ b/src/styles/sciml/pretty.jl
@@ -40,13 +40,9 @@ function options(::SciMLStyle)
 end
 
 function is_binaryop_nestable(::SciMLStyle, cst::JuliaSyntax.GreenNode)
-    if (defines_function(cst) || is_assignment(cst))
-        return false
-    else
-        false
-    end
-    !(op_kind(cst) in KSet"=> -> in")
+    !defines_function(cst) && !is_assignment(cst) && !(op_kind(cst) in KSet"=> -> in")
 end
+
 @doc """
     SciMLStyle()
 

--- a/test/internal_utils.jl
+++ b/test/internal_utils.jl
@@ -28,16 +28,15 @@
         @test JuliaFormatter.source_op_kind(state, node) === JuliaSyntax.Kind("<")
     end
 
-    @testset "source_unary_operator_index" for text in (
+    @testset "source_unary_operator_index $text" for text in (
         "+(y)",
         "-(y)",
         ">=(y)",
         "+y",
         "-y",
-        ">=y",
+        "!y",
     )
         _, state, node = parsed_node(text)
-        @test JuliaSyntax.is_prefix_op_call(node) # Sanity check
         @test JuliaFormatter.source_unary_operator_index(true, node, state) == 1
     end
 

--- a/test/internal_utils.jl
+++ b/test/internal_utils.jl
@@ -26,16 +26,19 @@
         _, state, node = parsed_node("x < y < z")
         @test JuliaFormatter.source_operator_indices(node) == [3, 7]
         @test JuliaFormatter.source_op_kind(state, node) === JuliaSyntax.Kind("<")
+    end
 
-        # Prefix operator calls should be treated as unary only when the recovered
-        # source operator is valid in unary position.
-        _, state, node = parsed_node("+(y)")
-        @test JuliaFormatter.source_prefix_operator_index(node, state) == 1
-        @test JuliaSyntax.is_prefix_op_call(node)
-
-        _, state, node = parsed_node(">=(y)")
-        @test JuliaFormatter.source_prefix_operator_index(node, state) == 1
-        @test !JuliaSyntax.is_prefix_op_call(node)
+    @testset "source_unary_operator_index" for text in (
+        "+(y)",
+        "-(y)",
+        ">=(y)",
+        "+y",
+        "-y",
+        ">=y",
+    )
+        _, state, node = parsed_node(text)
+        @test JuliaSyntax.is_prefix_op_call(node) # Sanity check
+        @test JuliaFormatter.source_unary_operator_index(true, node, state) == 1
     end
 
     @testset "short-form function utilities" begin

--- a/test/internal_utils.jl
+++ b/test/internal_utils.jl
@@ -28,7 +28,7 @@
         @test JuliaFormatter.source_op_kind(state, node) === JuliaSyntax.Kind("<")
     end
 
-    @testset "source_unary_operator_index $text" for text in (
+    @testset "source_unary_operator_index prefix $text" for text in (
         "+(y)",
         "-(y)",
         ">=(y)",
@@ -38,6 +38,17 @@
     )
         _, state, node = parsed_node(text)
         @test JuliaFormatter.source_unary_operator_index(true, node, state) == 1
+    end
+
+    @testset "source_unary_operator_index postfix $text" for text in (
+        "y...",
+        "y'",
+        "x'ᵀ",
+        "(y)...",
+        "[1, 2]'"
+    )
+        _, state, node = parsed_node(text)
+        @test JuliaFormatter.source_unary_operator_index(false, node, state) == length(JuliaSyntax.children(node))
     end
 
     @testset "short-form function utilities" begin

--- a/test/internal_utils.jl
+++ b/test/internal_utils.jl
@@ -1,31 +1,36 @@
+module InternalUtilsTests
+
+import Test: @testset, @test
+import JuliaFormatter as JF
+import JuliaSyntax as JS
+
 @testset "Internal utilities" begin
     # Build the same parser/document/state objects the formatter utilities consume.
     function parsed_node(text)
-        doc = JuliaFormatter.Document(text)
-        state = JuliaFormatter.State(doc, Options())
-        root = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text)
-        nodes = filter(n -> !JuliaSyntax.is_whitespace(n), JuliaSyntax.children(root))
+        doc = JF.Document(text)
+        state = JF.State(doc, JF.Options())
+        root = JS.parseall(JS.GreenNode, text)
+        nodes = filter(n -> !JS.is_whitespace(n), JS.children(root))
         return doc, state, only(nodes)
     end
 
     @testset "source operator recovery" begin
-        # JuliaSyntax v1 can represent source operators as Identifier leaves; recover
+        # JS v1 can represent source operators as Identifier leaves; recover
         # the actual operator kind from the original source text.
         _, state, node = parsed_node("a + b")
-        op_indices = JuliaFormatter.source_operator_indices(node)
-        op = JuliaSyntax.children(node)[only(op_indices)]
+        op_indices = JF.source_operator_indices(node)
+        op = JS.children(node)[only(op_indices)]
 
-        @test JuliaFormatter.source_op_kind_from_offset(state, op, 3) ===
-              JuliaSyntax.Kind("+")
-        @test JuliaFormatter.source_op_kind(state, node) === JuliaSyntax.Kind("+")
+        @test JF.source_op_kind_from_offset(state, op, 3) === JS.Kind("+")
+        @test JF.source_op_kind(state, node) === JS.Kind("+")
 
         _, state, node = parsed_node("x .+ y")
-        @test JuliaFormatter.source_operator_indices(node) == [3, 4]
-        @test JuliaFormatter.source_op_kind(state, node) === JuliaSyntax.Kind("+")
+        @test JF.source_operator_indices(node) == [3, 4]
+        @test JF.source_op_kind(state, node) === JS.Kind("+")
 
         _, state, node = parsed_node("x < y < z")
-        @test JuliaFormatter.source_operator_indices(node) == [3, 7]
-        @test JuliaFormatter.source_op_kind(state, node) === JuliaSyntax.Kind("<")
+        @test JF.source_operator_indices(node) == [3, 7]
+        @test JF.source_op_kind(state, node) === JS.Kind("<")
     end
 
     @testset "source_unary_operator_index prefix $text" for text in (
@@ -37,7 +42,7 @@
         "!y",
     )
         _, state, node = parsed_node(text)
-        @test JuliaFormatter.source_unary_operator_index(true, node, state) == 1
+        @test JF.source_unary_operator_index(true, node, state) == 1
     end
 
     @testset "source_unary_operator_index postfix $text" for text in (
@@ -45,10 +50,11 @@
         "y'",
         "x'ᵀ",
         "(y)...",
-        "[1, 2]'"
+        "[1, 2]'",
     )
         _, state, node = parsed_node(text)
-        @test JuliaFormatter.source_unary_operator_index(false, node, state) == length(JuliaSyntax.children(node))
+        @test JF.source_unary_operator_index(false, node, state) ==
+              length(JS.children(node))
     end
 
     @testset "short-form function utilities" begin
@@ -56,18 +62,18 @@
         # so the equals sign keeps assignment-like spacing and metadata.
         _, state, node = parsed_node("f(x) = x")
 
-        @test JuliaFormatter.is_short_function_def(node)
-        @test JuliaFormatter.source_operator_indices(node) == [3]
-        @test JuliaFormatter.source_op_kind(state, node) === JuliaSyntax.Kind("=")
+        @test JF.is_short_function_def(node)
+        @test JF.source_operator_indices(node) == [3]
+        @test JF.source_op_kind(state, node) === JS.Kind("=")
 
         # Compound assignments split the source operator across multiple child nodes.
         _, state, node = parsed_node("x += 1")
-        @test JuliaFormatter.source_operator_indices(node) == [3, 4]
-        @test JuliaFormatter.source_op_kind(state, node) === JuliaSyntax.Kind("op=")
+        @test JF.source_operator_indices(node) == [3, 4]
+        @test JF.source_op_kind(state, node) === JS.Kind("op=")
 
         _, state, node = parsed_node("x .+= 1")
-        @test JuliaFormatter.source_operator_indices(node) == [3, 4, 5]
-        @test JuliaFormatter.source_op_kind(state, node) === JuliaSyntax.Kind("op=")
+        @test JF.source_operator_indices(node) == [3, 4, 5]
+        @test JF.source_op_kind(state, node) === JS.Kind("op=")
 
         # Long-form definitions must stay on the dedicated function-definition path.
         _, _, node = parsed_node("""
@@ -75,20 +81,20 @@
             x
         end
         """)
-        @test !JuliaFormatter.is_short_function_def(node)
+        @test !JF.is_short_function_def(node)
     end
 
     @testset "assignment predicate" begin
-        # Use JuliaSyntax's syntactic-assignment category instead of rebuilding
+        # Use JS's syntactic-assignment category instead of rebuilding
         # assignment membership from precedence ranges and child checks.
         _, _, node = parsed_node("x = 1")
-        @test JuliaFormatter.is_assignment(node)
+        @test JF.is_assignment(node)
 
         _, _, node = parsed_node("x += 1")
-        @test JuliaFormatter.is_assignment(node)
+        @test JF.is_assignment(node)
 
         _, _, node = parsed_node("x in xs")
-        @test !JuliaFormatter.is_assignment(node)
+        @test !JF.is_assignment(node)
     end
 
     @testset "do-block and iteration utilities" begin
@@ -99,22 +105,21 @@
             x + 1
         end
         """)
-        childs = JuliaSyntax.children(node)
-        do_idx = JuliaFormatter.do_block_index(childs)
+        childs = JS.children(node)
+        do_idx = JF.do_block_index(childs)
 
         @test do_idx == 5
-        @test JuliaFormatter.has_do_block_call(node) == do_idx
-        @test length(JuliaFormatter.call_args(childs[1:(do_idx-1)])) == 1
+        @test JF.has_do_block_call(node) == do_idx
+        @test length(JF.call_args(childs[1:(do_idx-1)])) == 1
 
         # Single-iterator loops can inspect the RHS iterable directly.
         _, _, node = parsed_node("""
         for x in [1, 2]
         end
         """)
-        iter = JuliaSyntax.children(node)[2]
-        @test !JuliaFormatter.iteration_has_comma(iter)
-        @test JuliaSyntax.kind(JuliaFormatter.iteration_rhs(iter)) ===
-              JuliaSyntax.Kind("vect")
+        iter = JS.children(node)[2]
+        @test !JF.iteration_has_comma(iter)
+        @test JS.kind(JF.iteration_rhs(iter)) === JS.Kind("vect")
 
         # Cartesian iterations need to detect the comma and use the final iteration
         # expression as the effective RHS.
@@ -122,67 +127,106 @@
         for x in [1, 2], y in 3:4
         end
         """)
-        iter = JuliaSyntax.children(node)[2]
-        @test JuliaFormatter.iteration_has_comma(iter)
-        @test JuliaSyntax.kind(JuliaFormatter.iteration_rhs(iter)) ===
-              JuliaSyntax.Kind("call")
+        iter = JS.children(node)[2]
+        @test JF.iteration_has_comma(iter)
+        @test JS.kind(JF.iteration_rhs(iter)) === JS.Kind("call")
     end
 
     @testset "display-width source offsets" begin
         # Alignment uses display columns, not code-unit offsets; the combining mark
         # in s\u0304_b should not add a visible column.
         text = "s\u0304_b      = 1\n"
-        doc = JuliaFormatter.Document(text)
+        doc = JF.Document(text)
         eq_offset = findfirst(isequal('='), text)
 
         @test eq_offset > 10
-        @test JuliaFormatter.source_display_line_offset(doc, 1, eq_offset) == 10
-        @test JuliaFormatter.node_align_length(
-            JuliaFormatter.FST(JuliaFormatter.IDENTIFIER, 1, 1, 1, "s\u0304_b"),
-        ) == 3
+        @test JF.source_display_line_offset(doc, 1, eq_offset) == 10
+        @test JF.node_align_length(JF.FST(JF.IDENTIFIER, 1, 1, 1, "s\u0304_b")) == 3
     end
 
     @testset "module flags" begin
-        # JuliaSyntax v1 stores baremodule as a module node with a flag.
+        # JS v1 stores baremodule as a module node with a flag.
         _, _, node = parsed_node("""
         baremodule A
         end
         """)
 
-        @test JuliaSyntax.kind(node) === JuliaSyntax.Kind("module")
-        @test JuliaSyntax.has_flags(node, JuliaSyntax.BARE_MODULE_FLAG)
-        @test !JuliaFormatter.is_short_function_def(node)
-        @test JuliaFormatter.format_text("baremodule A\nend") == "baremodule A end"
+        @test JS.kind(node) === JS.Kind("module")
+        @test JS.has_flags(node, JS.BARE_MODULE_FLAG)
+        @test !JF.is_short_function_def(node)
+        @test JF.format_text("baremodule A\nend") == "baremodule A end"
     end
 end
 
 @testset "predicates on GreenNodes" begin
     @testset "unary_info" begin
         # [1] to index into the actual node we care about
-        p(x) = JuliaSyntax.parseall(JuliaSyntax.GreenNode, strip(x))[1]
+        p(x) = JS.parseall(JS.GreenNode, strip(x))[1]
         # Prefix operator
-        @test JuliaFormatter.unary_info(p("+(x)")) === true
-        @test JuliaFormatter.unary_info(p("+x")) === true
-        @test JuliaFormatter.unary_info(p("+x")) === true
-        @test JuliaFormatter.unary_info(p("+[1,2]")) === true
-        @test JuliaFormatter.unary_info(p("<:x")) === true
-        @test JuliaFormatter.unary_info(p("-x")) === true
-        @test JuliaFormatter.unary_info(p("-[1,2]")) === true
+        @test JF.unary_info(p("+(x)")) === true
+        @test JF.unary_info(p("+x")) === true
+        @test JF.unary_info(p("+x")) === true
+        @test JF.unary_info(p("+[1,2]")) === true
+        @test JF.unary_info(p("<:x")) === true
+        @test JF.unary_info(p("-x")) === true
+        @test JF.unary_info(p("-[1,2]")) === true
         # Postfix operators
-        @test JuliaFormatter.unary_info(p("x'")) === false
-        @test JuliaFormatter.unary_info(p("x'ᵀ")) === false
-        @test JuliaFormatter.unary_info(p("x'...")) === false
-        @test JuliaFormatter.unary_info(p("[1,2]'")) === false
-        @test JuliaFormatter.unary_info(p("x...")) === false
-        @test JuliaFormatter.unary_info(p("[1,2]...")) === false
+        @test JF.unary_info(p("x'")) === false
+        @test JF.unary_info(p("x'ᵀ")) === false
+        @test JF.unary_info(p("x'...")) === false
+        @test JF.unary_info(p("[1,2]'")) === false
+        @test JF.unary_info(p("x...")) === false
+        @test JF.unary_info(p("[1,2]...")) === false
         # Things that aren't unaries at all
-        @test JuliaFormatter.unary_info(p("+")) === nothing
-        @test JuliaFormatter.unary_info(p("<:")) === nothing
-        @test JuliaFormatter.unary_info(p("x + y")) === nothing
-        @test JuliaFormatter.unary_info(p("f(x)")) === nothing
-        @test JuliaFormatter.unary_info(p("x")) === nothing
-        @test JuliaFormatter.unary_info(p("[1, 2]")) === nothing
-        @test JuliaFormatter.unary_info(p("x.y")) === nothing
-        @test JuliaFormatter.unary_info(p("+(x, y)")) === nothing
+        @test JF.unary_info(p("+")) === nothing
+        @test JF.unary_info(p("<:")) === nothing
+        @test JF.unary_info(p("x + y")) === nothing
+        @test JF.unary_info(p("f(x)")) === nothing
+        @test JF.unary_info(p("x")) === nothing
+        @test JF.unary_info(p("[1, 2]")) === nothing
+        @test JF.unary_info(p("x.y")) === nothing
+        @test JF.unary_info(p("+(x, y)")) === nothing
+        @test JF.unary_info(p("string(x)")) === nothing
+    end
+
+    @testset "first_nonws_leaf_and_offset" begin
+        p(x) = JS.parseall(JS.GreenNode, x)
+        # Simple identifier
+        let result = JF.first_nonws_leaf_and_offset(p("x")[1])
+            @test result !== nothing
+            @test JS.kind(result[1]) === JS.Kind("Identifier")
+            @test result[2] == 0
+        end
+        # Operator application — first leaf is the operator
+        let result = JF.first_nonws_leaf_and_offset(p("+x")[1])
+            @test result !== nothing
+            @test result[2] == 0
+        end
+        # With some whitespace
+        let result = JF.first_nonws_leaf_and_offset(p("  +x"))
+            @test result !== nothing
+            @test result[2] == 2
+        end
+    end
+
+    @testset "source_begins_with_op" begin
+        function check(code)
+            node = JS.parseall(JS.GreenNode, code)[1]
+            opts = JF.Options()
+            s = JF.State(JF.Document(code), opts)
+            return JF.source_begins_with_op(s, node, s.offset)
+        end
+        # Operators
+        @test check("+x")
+        @test check("-x")
+        @test check("!x")
+        @test check(">=(x)")
+        # Non-operators
+        @test !check("string(x)")
+        @test !check("x")
+        @test !check("[1, 2]")
+        @test !check("x'")
     end
 end
+
+end # module

--- a/test/internal_utils.jl
+++ b/test/internal_utils.jl
@@ -142,3 +142,34 @@
         @test JuliaFormatter.format_text("baremodule A\nend") == "baremodule A end"
     end
 end
+
+@testset "predicates on GreenNodes" begin
+    @testset "unary_info" begin
+        # [1] to index into the actual node we care about
+        p(x) = JuliaSyntax.parseall(JuliaSyntax.GreenNode, strip(x))[1]
+        # Prefix operator
+        @test JuliaFormatter.unary_info(p("+(x)")) === true
+        @test JuliaFormatter.unary_info(p("+x")) === true
+        @test JuliaFormatter.unary_info(p("+x")) === true
+        @test JuliaFormatter.unary_info(p("+[1,2]")) === true
+        @test JuliaFormatter.unary_info(p("<:x")) === true
+        @test JuliaFormatter.unary_info(p("-x")) === true
+        @test JuliaFormatter.unary_info(p("-[1,2]")) === true
+        # Postfix operators
+        @test JuliaFormatter.unary_info(p("x'")) === false
+        @test JuliaFormatter.unary_info(p("x'ᵀ")) === false
+        @test JuliaFormatter.unary_info(p("x'...")) === false
+        @test JuliaFormatter.unary_info(p("[1,2]'")) === false
+        @test JuliaFormatter.unary_info(p("x...")) === false
+        @test JuliaFormatter.unary_info(p("[1,2]...")) === false
+        # Things that aren't unaries at all
+        @test JuliaFormatter.unary_info(p("+")) === nothing
+        @test JuliaFormatter.unary_info(p("<:")) === nothing
+        @test JuliaFormatter.unary_info(p("x + y")) === nothing
+        @test JuliaFormatter.unary_info(p("f(x)")) === nothing
+        @test JuliaFormatter.unary_info(p("x")) === nothing
+        @test JuliaFormatter.unary_info(p("[1, 2]")) === nothing
+        @test JuliaFormatter.unary_info(p("x.y")) === nothing
+        @test JuliaFormatter.unary_info(p("+(x, y)")) === nothing
+    end
+end

--- a/test/internal_utils.jl
+++ b/test/internal_utils.jl
@@ -227,7 +227,11 @@ end
         @test !check("x")
         @test !check("[1, 2]")
         @test !check("x'")
+        @test !check("x'ᵀ")
+        @test !check("a ? b : c")
+        # Manual exclusions (see source_begins_with_op_needing_parens comments)
         @test !check(":x")
+        @test !check("isa(x, T)")
     end
 end
 

--- a/test/internal_utils.jl
+++ b/test/internal_utils.jl
@@ -209,23 +209,25 @@ end
         end
     end
 
-    @testset "source_begins_with_op" begin
+    @testset "source_begins_with_op_needing_parens" begin
         function check(code)
             node = JS.parseall(JS.GreenNode, code)[1]
             opts = JF.Options()
             s = JF.State(JF.Document(code), opts)
-            return JF.source_begins_with_op(s, node, s.offset)
+            return JF.source_begins_with_op_needing_parens(s, node, s.offset)
         end
         # Operators
         @test check("+x")
         @test check("-x")
         @test check("!x")
         @test check(">=(x)")
-        # Non-operators
+        # Non-operators / already parenthesised
+        @test !check("(+x)")
         @test !check("string(x)")
         @test !check("x")
         @test !check("[1, 2]")
         @test !check("x'")
+        @test !check(":x")
     end
 end
 

--- a/test/sciml_style.jl
+++ b/test/sciml_style.jl
@@ -147,6 +147,14 @@
         @test format_text(str, SciMLStyle()) == sciml_result
     end
 
+    @testset "postfix operator" begin
+        # https://github.com/JuliaEditorSupport/JuliaFormatter.jl/pull/1011
+        str1 = "@view (Q_temp' * _vstar_perp)[1:nus]"
+        @test format_text(str1, SciMLStyle()) == str1
+        str2 = "(Q' * 2)[]"
+        @test format_text(str2, SciMLStyle()) == str2
+    end
+
     str = raw"""
     Dict{Int, Int}(1 => 2,
         3 => 4)


### PR DESCRIPTION
This PR refactors a couple of things:

(1) What used to be called `is_unary` now does far more thorough checks. Previously, it wouldn't catch postfix operators like `x'`.

(2) `p_kw` was using some very hacky combinations of predicates to determine whether something on the rhs of a `kwarg=value` expression should be parenthesised. (see #360 #361 for context) While this 'worked fine' enough, I think this was not good technical decision. Consequently, I've edited this so that it checks for exactly what it should be checking for. Although the code here is more verbose, it is also more correct and will be easier to edit going forward.

Note that this PR will cause JuliaFormatter to add parens around kwargs in more cases, even when this is not totally necessary. This in fact makes its parenthesisation behaviour more consistent. See https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/1016 for a longer explanation of this.