### PR TITLE
Avoid nesting LHS if not over margin and if RHS can be nested

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-Manifest.toml
+Manifest*.toml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,11 @@
 
 - Code changes in the local checkout should be immediately visible without having to reload the session (thanks to Revise.jl).
 
+# Running tests
+
+- Do not run the full test suite unless explicitly instructed to.
+  Only run specific, targeted tests that are relevant to the changes you are making.
+
 # Tracing JuliaFormatter's output
 
 - Use the `JuliaFormatter.Internal.format_to_stage` function to inspect the output of each stage of the formatting process.

--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,3 +1,14 @@
+# v2.5.7
+
+Fixed a number of cases where the left-hand operand of binary operators would be aggressively nested.
+(In general, it is better to nest the right-hand operand as that keeps as much of the operation as possible on the same line.)
+These fixes were applied to DefaultStyle and thus should propagate to other styles as well.
+However, SciMLStyle goes slightly further than this and also allows expressions to extend beyond the stated margin in the interests of not nesting the LHS. (#998, #1012)
+
+Added a new formatting option, `sciml_margin_overrun`, which controls the extent to which SciMLStyle allows expressions to extend beyond the margin in order to avoid nesting the LHS of binary operators.
+The default is 20, but it can be set to 0 to prevent this behaviour if undesired.
+This option has no effect for styles apart from SciML. (#998)
+
 # v2.5.6
 
 Fixed a bug where JuliaFormatter would emit invalid code when parsing an `if`/`elseif` with a block condition (e.g. `(a; b)` or `begin ... end`). (#1025, #1026)

--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,4 +1,4 @@
-# v2.5.7
+# v2.6.0
 
 Fixed a number of cases where the left-hand operand of binary operators would be aggressively nested.
 (In general, it is better to nest the right-hand operand as that keeps as much of the operation as possible on the same line.)

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.5.6"
+version = "2.5.7"
 authors = ["Dominique Luna <dluna132@gmail.com> and contributors"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.5.7"
+version = "2.6.0"
 authors = ["Dominique Luna <dluna132@gmail.com> and contributors"]
 
 [deps]

--- a/docs/src/sciml_style.md
+++ b/docs/src/sciml_style.md
@@ -1,5 +1,12 @@
 # [SciML Style](@id sciml-style)
 
+!!! warning "SciMLStyle !== 'SciML style' === Runic"
+
+    Note that the SciML Style Guide currently suggests using Runic.jl for formatting instead.
+
+    JuliaFormatter's `SciMLStyle()` represents a collection of styles that predated this recommendation, and is being kept in v2 for compatibility.
+    In a future major release this style may be renamed to avoid confusion.
+
 ```@docs
 SciMLStyle
 ```

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -392,6 +392,7 @@ function binaryop_to_whereop!(fst::FST, s::State)
 
     # get everything up to the where
     binop = FST(Binary, fst[1].indent)
+    binop.metadata = oldbinop.metadata
     for n in oldbinop.nodes
         if n.typ === Where
             break

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -884,7 +884,8 @@ function n_binaryopcall!(
     line_offset = s.line_offset
     line_margin = line_offset + length(fst) + fst.extra_margin
 
-    # If there's no placeholder the binary call is not nestable
+    # If there are no top-level placeholders in the FST, the binary call itself is not
+    # nestable (although its children, i.e. the operands, might be).
     nodes = fst.nodes::Vector
     idxs = findall(n -> n.typ === PLACEHOLDER, nodes)
 
@@ -993,10 +994,11 @@ function n_binaryopcall!(
     # could itself be nested, and in general nesting the RHS is preferable to nesting the
     # LHS as it's prettier. That means we only need to account for the RHS up to the first
     # point where it could be nested.
+    #
     # Since node 1 is the LHS, we start looking for the first placeholder from node 2
     # onwards.
     len_to_first_placeholder, found = length_to(fst, (PLACEHOLDER, NEWLINE); start = 2)
-    lhs_extra_margin_needed = if found
+    lhs_extra_margin_needed = if found && op_kind(fst) !== K"::"
         len_to_first_placeholder
     else
         # Can't nest the op or RHS. That means that we need to account for the entire RHS,

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -988,15 +988,27 @@ function n_binaryopcall!(
         return nested
     end
 
-    # length of operator, surrounding whitespace, and the first line of the right operand
-    op_and_rhs_len, _ = length_to(fst, (NEWLINE,); start = 2)
+    # When we nest the LHS, we have to do so with some knowledge of how much space the RHS
+    # will take up. However, we don't need to account for the _full_ RHS, because the RHS
+    # could itself be nested, and in general nesting the RHS is preferable to nesting the
+    # LHS as it's prettier. That means we only need to account for the RHS up to the first
+    # point where it could be nested.
+    # Since node 1 is the LHS, we start looking for the first placeholder from node 2
+    # onwards.
+    len_to_first_placeholder, found = length_to(fst, (PLACEHOLDER, NEWLINE); start = 2)
+    lhs_extra_margin_needed = if found
+        len_to_first_placeholder
+    else
+        # Can't nest the op or RHS. That means that we need to account for the entire RHS,
+        # plus anything that comes after the binary expression as well.
+        sum(length, fst[2:end]) + fst.extra_margin
+    end
 
     for (i, n) in enumerate(nodes)
         if n.typ === NEWLINE
             s.line_offset = fst.indent
         elseif i == 1
-            # lhs
-            n.extra_margin = op_and_rhs_len + fst.extra_margin
+            n.extra_margin = lhs_extra_margin_needed
             nested |= nest!(style, n, s, lineage)
         elseif i == length(nodes)
             # rhs


### PR DESCRIPTION
This fixes a similar issue as #998, but more generally. It essentially does what the comments say. If we have a binary expression `LHS op RHS`, we try to avoid nesting the LHS if there is any point in the `op RHS` segment where we can nest it.

<details><summary>More discussion (outdated as the regression was fixed)</summary>

However, it also causes some regressions. For example this causes

```julia
julia> str = "foo(a, b, c)::Rtype where {A,B} = 10"
"foo(a, b, c)::Rtype where {A,B} = 10"

julia> JuliaFormatter.format_text(str; indent=4, margin=32) |> println
foo(a, b, c)::Rtype where {
    A,
    B,
} = 10
```

when previously it would be formatted instead to

```julia
foo(
    a,
    b,
    c,
)::Rtype where {A,B} = 10
```

I still think that the solution in this PR is the correct way to deal with the nesting preference, but it needs to be more tightly scoped to avoid causing regressions in other cases that we aren't trying to improve.

</summary>