### PR TITLE
Fix various issues with `pipe_to_function_call`

### DIFF
--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -7,6 +7,9 @@ Fixed a number of issues with `pipe_to_function_call=true`:
 - Transforming pipes inside macros was fundamentally dangerous.
   This patch conservatively refuses to transform pipes inside macros. (#439, #1023)
 
+- Transforming pipes inside an `Expr` changes the `Expr`.
+  This patch prevents this. (#1023)
+
 - The expression `1 .|> (sin, cos)` cannot be transformed into a function call as there is no equivalent syntax for this. This patch leaves such expressions unchanged. (#647, #1023)
 
 - For the transformations that do happen, this patch elides unnecessary parentheses. For example `(x) |> f` is now transformed into `f(x)` rather than `f((x))`. (#1023)

--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,22 +1,43 @@
+# v2.5.5
+
+Fixed a number of issues with `pipe_to_function_call=true`:
+
+- Various constructions such as `x .|> f()`, `x .|> !`, and `x |> a + b` were being transformed into code that had a different meaning from the original. (#927, #1023)
+
+- Transforming pipes inside macros was fundamentally dangerous.
+  This patch conservatively refuses to transform pipes inside macros. (#439, #1023)
+
+- The expression `1 .|> (sin, cos)` cannot be transformed into a function call as there is no equivalent syntax for this. This patch leaves such expressions unchanged. (#647, #1023)
+
+- For the transformations that do happen, this patch elides unnecessary parentheses. For example `(x) |> f` is now transformed into `f(x)` rather than `f((x))`. (#1023)
+
+- Fixed cases where newly transformed function calls would be generated with the wrong nesting, leading to a loss of idempotency. (#1023)
+
+Finally, this patch also causes a warning to be emitted whenever a pipe is transformed into a function call. (#1023)
+
+This is because `|>` is an ordinary Julia function, and can be overloaded by users such that `x |> f` may not always be equivalent to `f(x)`.
+A formatter should _never_ change the meaning of code.
+Thus, it is possible, or even likely, that this option will be completely removed in the future (it could be turned into a _linter_ rule, for example, where the user can be alerted to the presence of `|>` in their code; but the _formatter_ should not change it).
+
 # v2.5.4
 
-Fixed a bug where `jlfmt` would not use the style set in a `.JuliaFormatter.toml` configuration file (unless `--prioritize-config-file` was specified) (#951, #1021).
+Fixed a bug where `jlfmt` would not use the style set in a `.JuliaFormatter.toml` configuration file (unless `--prioritize-config-file` was specified). (#951, #1021)
 
-Fixed a bug where JuliaFormatter (both the library and app) would not correctly ignore files in subdirectories on Windows due to path separator differences (#898, #1021).
+Fixed a bug where JuliaFormatter (both the library and app) would not correctly ignore files in subdirectories on Windows due to path separator differences. (#898, #1021)
 
 # v2.5.3
 
-Fixed a bug where postfix operators (e.g. transpose) were not being recognised as unary operators, causing formatting to output unparseable code in some circumstances (#1011).
+Fixed a bug where postfix operators (e.g. transpose) were not being recognised as unary operators, causing formatting to output unparseable code in some circumstances. (#1011)
 
-Improved consistency when parenthesising the value of a keyword argument with `whitespace_in_kwargs=false`, e.g., `(; x=-pi/2)` is now formatted as `(; x=(-pi/2))` (#1011).
+Improved consistency when parenthesising the value of a keyword argument with `whitespace_in_kwargs=false`, e.g., `(; x=-pi/2)` is now formatted as `(; x=(-pi/2))`. (#1011)
 
 # v2.5.2
 
-Fixed a bug where, under SciML style, indentations of bracketed expressions on the RHS of assignments were being removed for anything on the second line onwards (#935, #1006).
+Fixed a bug where, under SciML style, indentations of bracketed expressions on the RHS of assignments were being removed for anything on the second line onwards. (#935, #1006)
 
 # v2.5.1
 
-Fix some formatting regressions introduced in v2.5.0 (#1002, #996).
+Fix some formatting regressions introduced in v2.5.0. (#1002, #996)
 In particular, this version:
 
 - no longer aggressively adds spaces around `x=>y` and `x->y` (unless spaces are already present).

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.5.4"
+version = "2.5.5"
 authors = ["Dominique Luna <dluna132@gmail.com> and contributors"]
 
 [deps]

--- a/docs/src/formatting_options.md
+++ b/docs/src/formatting_options.md
@@ -390,7 +390,30 @@ One of `"unix"` (normalize all `\r\n` to `\n`), `"windows"` (normalize all `\n` 
 
 Default: `false`
 
-If true, `x |> f` is rewritten to `f(x)`.
+If true, `x |> f` is rewritten to `f(x)`, and `x .|> f` to `f.(x)`.
+
+!!! danger "Semantics may be changed"
+
+    **Note that this transformation may change the semantics of the code in
+    some cases:**
+
+    1. If `Base.:(|>)` is overloaded to have a different meaning for a given
+       `f` and `x`.
+
+    2. If the call to `x |> f` is intercepted by a macro that transforms it to 
+       something other than `f(x)`. For example,
+       [Pipe.jl](https://github.com/oxinabox/Pipe.jl).
+
+    To avoid (2), JuliaFormatter refuses to apply this transformation within the
+    body of a macro. However, there is no way to detect (1). As such,
+    JuliaFormatter will emit a warning if this transformation is applied during
+    formatting, to alert the user to the potential of unwanted changes.
+
+    It is recommended to set this option to `true` only if you are confident
+    that there are no such cases. **Note:** `pipe_to_function_call` is set to
+    `true` by default for Blue and YAS styles, so in such cases you have to opt
+    out manually!
+
 
 ## [`remove_extra_newlines`](@id options-remove-extra-newlines)
 

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -228,10 +228,6 @@ function format_text(node::JuliaSyntax.GreenNode, style::AbstractStyle, s::State
         add_node!(fst, InlineComment(fst.endline), s)
     end
 
-    if s.opts.pipe_to_function_call
-        pipe_to_function_call_pass!(fst)
-    end
-
     flatten_fst!(fst)
 
     if s.opts.short_circuit_to_if

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -703,12 +703,22 @@ function remove_empty_notcode(fst::FST)
 end
 
 """
-    unnestable_node(cst::JuliaSyntax.GreenNode)
+    has_delimiters(cst::JuliaSyntax.GreenNode)
 
-`cst` is assumed to be a single child node. Returns true if the node is of the syntactic form `{...}, [...], or (...)`.
+`cst` is assumed to be a single child node. Returns true if the node is of the syntactic
+form `{...}, [...], or (...)`.
 """
-function unnestable_node(cst::JuliaSyntax.GreenNode)
+function has_delimiters(cst::JuliaSyntax.GreenNode)
     kind(cst) in KSet"tuple vect braces bracescat comprehension parens"
+end
+
+function should_nest_call_args(args, disallow_single_arg_nesting::Bool)
+    return length(args) > 0 && !(
+        length(args) == 1 &&
+        # If the argument has delimiters, it can itself be nested, so we
+        # don't need to nest the call expression.
+        (has_delimiters(args[1]) || disallow_single_arg_nesting)
+    )
 end
 
 function is_binaryop_nestable(::AbstractStyle, cst::JuliaSyntax.GreenNode)

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -102,7 +102,6 @@
 
 struct Metadata
     op_kind::JuliaSyntax.Kind
-    op_dotted::Bool
     is_standalone_shortcircuit::Bool
     is_short_form_function::Bool
     is_assignment::Bool
@@ -110,8 +109,8 @@ struct Metadata
     has_multiline_argument::Bool
 end
 
-function Metadata(k::JuliaSyntax.Kind, dotted::Bool)
-    return Metadata(k, dotted, false, false, false, true, false)
+function Metadata(k::JuliaSyntax.Kind)
+    return Metadata(k, false, false, false, true, false)
 end
 
 """
@@ -860,7 +859,6 @@ function eq_to_in_normalization!(fst::FST, always_for_in::Bool, for_in_replaceme
             opkind = JuliaSyntax.Kind(op.val)
             fst.metadata = Metadata(
                 opkind,
-                metadata.op_dotted,
                 metadata.is_standalone_shortcircuit,
                 metadata.is_short_form_function,
                 opkind === K"=",
@@ -1165,12 +1163,11 @@ function add_node!(
     elseif is_multiline(n) ||
            (!isnothing(t.metadata) && (t.metadata::Metadata).has_multiline_argument)
         if isnothing(t.metadata)
-            t.metadata = Metadata(K"None", false, false, false, false, true, true)
+            t.metadata = Metadata(K"None", false, false, false, true, true)
         else
             metadata = t.metadata::Metadata
             t.metadata = Metadata(
                 metadata.op_kind,
-                metadata.op_dotted,
                 metadata.is_standalone_shortcircuit,
                 metadata.is_short_form_function,
                 metadata.is_assignment,

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -599,6 +599,14 @@ end
 
 function is_binary(x)
     if !JuliaSyntax.is_infix_op_call(x) && !(JuliaSyntax.is_operator(x) && haschildren(x))
+        # "Genuine" operators are caught by is_infix_op_call.
+        #
+        # The second predicate catches things like:
+        #   - assignments `x = y`
+        #   - field access `x.y`
+        #   - logic operators `x && y` or `x || y`
+        #   - membership `x in y`
+        #   - anonymous functions `x -> y`
         return false
     end
     nops, nargs = _callinfo(x)

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -712,12 +712,10 @@ function has_delimiters(cst::JuliaSyntax.GreenNode)
 end
 
 function should_nest_call_args(args, disallow_single_arg_nesting::Bool)
-    return length(args) > 0 && !(
-        length(args) == 1 &&
-        # If the argument has delimiters, it can itself be nested, so we
-        # don't need to nest the call expression.
-        (has_delimiters(args[1]) || disallow_single_arg_nesting)
-    )
+    return length(args) > 0 && !(length(args) == 1 &&
+             # If the argument has delimiters, it can itself be nested, so we
+             # don't need to nest the call expression.
+             (has_delimiters(args[1]) || disallow_single_arg_nesting))
 end
 
 function is_binaryop_nestable(::AbstractStyle, cst::JuliaSyntax.GreenNode)

--- a/src/internal/utils.jl
+++ b/src/internal/utils.jl
@@ -20,10 +20,16 @@ stage.
 
 Available stages:
 
- - (:gn, :greennode, :parse): the output of the JuliaSyntax parser, which is a
-   `JuliaSyntax.GreenNode`.
+ - `:gn` or `:cst`: the output of the JuliaSyntax parser, which is a
+   `JuliaSyntax.GreenNode`. Note that directly calling `JuliaSyntax.parseall` will yield a
+   `toplevel` node with the actual tree of interest as its only child. This function will
+   directly return the child.
 
-This is the only stage currently implemented, but more will be added in the future.
+ - `:fst`: the output of prettification.
+ 
+ - `:out`: the string output of the formatter.
+
+ - `:print`: the string output but printed. Saves you having to wrap it in `print()`.
 
 !!! tip
     For a utility that is meant to be convenient to access, typing the full qualified
@@ -40,6 +46,8 @@ This is the only stage currently implemented, but more will be added in the futu
         ])
     end
     ```
+
+    and then just call `fs(:gn, "1 + 2")` from the REPL without having to import it.
 """
 function format_to_stage(
     stage::Symbol,
@@ -47,8 +55,13 @@ function format_to_stage(
     style::JF.AbstractStyle = JF.DefaultStyle();
     options...,
 )
-    parsed = JS.parseall(JS.GreenNode, text)
-    stage in (:gn, :greennode, :parse) && return parsed
+    cst = JS.parseall(JS.GreenNode, text)
+    stage in (:gn, :greennode, :parse, :cst) && return cst[1]
+
+    opts = JF.Options(; merge(JF.options(style), options)...)
+    state = JF.State(JF.Document(text), opts)
+    fst = JF.pretty(style, cst, state)
+    stage === :fst && return fst
 
     throw(ArgumentError("unknown stage: $stage"))
 end

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -74,99 +74,6 @@ function flatten_fst!(fst::FST)
     end
 end
 
-"""
-    pipe_to_function_call_pass!(fst::FST)
-
-Rewrites `x |> f` to `f(x)`.
-"""
-function pipe_to_function_call_pass!(fst::FST)
-    if is_leaf(fst)
-        return
-    end
-
-    # the RHS must be a valid type to apply a function call.
-    if op_kind(fst) === K"|>" && (fst[end].typ !== PUNCTUATION)
-        fst.nodes = pipe_to_function_call(fst)
-        fst.typ = Call
-        return
-    end
-    for n in fst.nodes::Vector{FST}
-        if is_leaf(n)
-            continue
-        elseif op_kind(n) === K"|>" && (n[end].typ !== PUNCTUATION)
-            n.nodes = pipe_to_function_call(n)
-            n.typ = Call
-        else
-            pipe_to_function_call_pass!(n)
-        end
-    end
-end
-
-function pipe_to_function_call(fst::FST)
-    nodes = FST[]
-    dot = !isnothing(fst.metadata) && (fst.metadata::Metadata).op_dotted
-    arg2 = fst[end]
-
-    # is RHS is an anon function?
-    # need to wrap it parens, i.e. "(x -> x + 1)(arg)"
-    # and then possibly add a "." as well !
-    if op_kind(arg2) === K"->"
-        n = FST(PUNCTUATION, -1, arg2.endline, arg2.endline, "(")
-        push!(nodes, n)
-
-        # go into anon function and convert all the pipe calls there too.
-        # The precedence of -> is greater then |> so if the anon func is of the
-        # the form `x -> x |> f`, the pipe call will not be converted unless well
-        # recurse into the anon func.
-        pipe_to_function_call_pass!(arg2)
-
-        push!(nodes, arg2)
-        n = FST(PUNCTUATION, -1, arg2.endline, arg2.endline, ")")
-        push!(nodes, n)
-        if dot
-            n = FST(PUNCTUATION, -1, arg2.endline, arg2.endline, ".")
-            push!(nodes, n)
-        end
-    else
-        push!(nodes, arg2)
-
-        if dot && arg2.typ === IDENTIFIER
-            n = FST(PUNCTUATION, -1, arg2.endline, arg2.endline, ".")
-            push!(nodes, n)
-        elseif dot &&
-               arg2.typ === Binary &&
-               arg2[end].typ === Quotenode &&
-               arg2[end][end].typ === IDENTIFIER
-            n = FST(PUNCTUATION, -1, arg2.endline, arg2.endline, ".")
-            push!(nodes, n)
-        elseif dot &&
-               arg2.typ === Accessor &&
-               arg2[end].typ === Quote &&
-               arg2[end][end].typ === IDENTIFIER
-            n = FST(PUNCTUATION, -1, arg2.endline, arg2.endline, ".")
-            push!(nodes, n)
-        elseif dot && arg2.typ === Accessor && arg2[end].typ === IDENTIFIER
-            n = FST(PUNCTUATION, -1, arg2.endline, arg2.endline, ".")
-            push!(nodes, n)
-        elseif dot && arg2.typ === Brackets
-            idx = findfirst(n -> n.typ === Binary && op_kind(n) === K"->", arg2.nodes)
-            if idx !== nothing
-                n = FST(PUNCTUATION, -1, arg2.endline, arg2.endline, ".")
-                push!(nodes, n)
-            end
-        end
-    end
-
-    paren = FST(PUNCTUATION, -1, arg2.endline, arg2.endline, "(")
-    push!(nodes, paren)
-    pipe_to_function_call_pass!(fst[1])
-    arg1 = fst[1]
-    push!(nodes, arg1)
-    paren = FST(PUNCTUATION, -1, arg1.endline, arg1.endline, ")")
-    push!(nodes, paren)
-    return nodes
-end
-
 function import_to_usings(fst::FST, s::State)
     nodes = fst.nodes::Vector{FST}
     if !(findfirst(n -> is_colon(n) || n.typ === As, nodes) === nothing)
@@ -197,7 +104,7 @@ function import_to_usings(fst::FST, s::State)
 
         add_node!(use, n, s; join_lines = true)
         colon = FST(OPERATOR, -1, sl, el, ":")
-        colon.metadata = Metadata(K"::", false)
+        colon.metadata = Metadata(K"::")
         add_node!(use, colon, s; join_lines = true)
         add_node!(use, Whitespace(1), s)
         add_node!(use, n[end], s; join_lines = true)
@@ -226,7 +133,7 @@ function annotate_typefields_with_any!(fst::FST, s::State)
             add_node!(nn, n, s)
             line_offset = n.line_offset + length(n)
             op = FST(OPERATOR, line_offset, n.startline, n.endline, "::")
-            op.metadata = Metadata(K"::", false)
+            op.metadata = Metadata(K"::")
             add_node!(nn, op, s; join_lines = true)
             line_offset += 2
             add_node!(
@@ -411,13 +318,13 @@ function long_to_short_function_def!(fst::FST, s::State)
     end
 
     funcdef = FST(Binary, fst.indent)
-    funcdef.metadata = Metadata(K"=", false, false, true, false, false, false)
+    funcdef.metadata = Metadata(K"=", false, true, false, false, false)
     kw = (join_lines = true, override_join_lines_based_on_source = true)
 
     add_node!(funcdef, lhs, s; kw...)
     add_node!(funcdef, Whitespace(1), s; kw...)
     op = FST(OPERATOR, 0, 0, 0, "=")
-    op.metadata = Metadata(K"=", false)
+    op.metadata = Metadata(K"=")
     add_node!(funcdef, op, s; kw...)
     add_node!(funcdef, Placeholder(1), s; kw...)
     add_node!(funcdef, Placeholder(0), s; kw...)

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -2310,7 +2310,7 @@ function p_binaryopcall(
         #    over the _caller_ rather than the callee. There's no equivalent way to express
         #    this in function call form, so we shouldn't try to transform it. See
         #    https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/647.
-        inside_macro_or_quote = any(t -> t[1] in K"macrocall quote", lineage)
+        inside_macro_or_quote = any(t -> t[1] in KSet"macrocall quote", lineage)
         rhs_cst = childs[findlast(n -> !JuliaSyntax.is_whitespace(n), childs)]
         dotted_tuple = kind(cst) === K"dotcall" && kind(rhs_cst) === K"tuple"
         if !inside_macro_or_quote && !dotted_tuple

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -429,6 +429,8 @@ function pretty(
     elseif k === K"comparison"
         p_comparison(style, node, s, ctx, lineage)
     elseif JuliaSyntax.is_operator(node) && haschildren(node)
+        # TODO(penelopeysm) What does this catch that is_binary didn't? Should run test
+        # suite with a print statement here to find out
         p_binaryopcall(style, node, s, ctx, lineage)
     elseif k in KSet"dotcall call"
         p_binaryopcall(style, node, s, ctx, lineage)
@@ -2093,6 +2095,111 @@ function p_kw(
     t
 end
 
+function p_pipe_to_call(
+    style::AbstractStyle,
+    # cst here must be a binary op call with |> as the operator (possibly dotted).
+    cst::JuliaSyntax.GreenNode,
+    s::State,
+    ctx::PrettyContext,
+    lineage::Vector{Tuple{JuliaSyntax.Kind,Bool,Bool}},
+)
+    # WARNING: This transformation can lead to semantic changes. See e.g.
+    # - https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/439
+    # - https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/647
+    # 
+    # This should really be removed in a future version of JuliaFormatter.
+    @warn (
+        "JuliaFormatter transformed one or more expressions with the form `x |> f` into" *
+        " the equivalent function call `f(x)`.\n\nNote that that this can lead to" *
+        " semantic changes if `|>` has been overloaded or otherwise has a custom meaning!" *
+        "\n\nYou can disable this behaviour by setting the `pipe_to_function_call` option" *
+        " to `false`. Note that this option is `true` by default for Blue and YAS styles," *
+        " meaning that you must explicitly opt out. Alternatively, you can use" *
+        " `#! format: off` and `#! format: on` to disable formatting for specific" *
+        " sections of code that use `|>`."
+    ) maxlog=1
+
+    call_node = FST(Call, nspaces(s))
+    childs = children(cst)
+    # Identify the LHS and RHS of the operator
+    lhs_idx = findfirst(n -> !JuliaSyntax.is_whitespace(n), childs)
+    rhs_idx = findlast(n -> !JuliaSyntax.is_whitespace(n), childs)
+    if isnothing(lhs_idx) || isnothing(rhs_idx) || lhs_idx >= rhs_idx
+        error(
+            "pipe operator with lhs_idx=$(lhs_idx) and rhs_idx=$(rhs_idx): should not happen",
+        )
+    end
+
+    lhs, rhs = nothing, nothing
+    for (i, c) in enumerate(childs)
+        if i == lhs_idx
+            lhs = pretty(style, c, s, ctx, lineage)
+        elseif i == rhs_idx
+            rhs = pretty(style, c, s, ctx, lineage)
+        else
+            # Advance s.offset past everything else without emitting
+            s.offset += span(c)
+        end
+    end
+
+    # Some things need to be wrapped in parens. We behave conservatively here and only opt
+    # out of wrapping for the following callables:
+    #   - a plain identifier               arg |> f     -> f(arg)
+    #   - a field access                   arg |> obj.f -> obj.f(arg)
+    #   - something already parenthesised  arg |> (f)   -> (f)(arg)
+    #   - a function call                  arg |> f()   -> f()(arg)
+    rhs_cst = childs[rhs_idx]
+    function_needs_parens = if kind(rhs_cst) in KSet"Identifier . parens"
+        false
+    elseif kind(rhs_cst) === K"call" && haschildren(rhs_cst)
+        # In JuliaSyntax, infix operators are also parsed as `call`, so we need to really
+        # check that it is a function call with parentheses.
+        any(n -> kind(n) === K"(", children(rhs_cst))
+    else
+        true
+    end
+    function_needs_parens && add_node!(
+        call_node,
+        FST(PUNCTUATION, -1, rhs.startline, rhs.startline, "("),
+        s;
+        join_lines = true,
+    )
+    add_node!(call_node, rhs, s; join_lines = true)
+    function_needs_parens && add_node!(
+        call_node,
+        FST(PUNCTUATION, -1, rhs.startline, rhs.startline, ")"),
+        s;
+        join_lines = true,
+    )
+
+    # Add a dot if needed
+    if kind(cst) === K"dotcall"
+        add_node!(
+            call_node,
+            FST(PUNCTUATION, -1, rhs.startline, rhs.startline, "."),
+            s;
+            join_lines = true,
+        )
+    end
+
+    argument_needs_params = true
+    argument_needs_params && add_node!(
+        call_node,
+        FST(PUNCTUATION, -1, rhs.startline, rhs.startline, "("),
+        s;
+        join_lines = true,
+    )
+    add_node!(call_node, lhs, s; join_lines = true)
+    argument_needs_params && add_node!(
+        call_node,
+        FST(PUNCTUATION, -1, rhs.startline, rhs.startline, ")"),
+        s;
+        join_lines = true,
+    )
+
+    return call_node
+end
+
 function p_binaryopcall(
     ds::AbstractStyle,
     cst::JuliaSyntax.GreenNode,
@@ -2109,6 +2216,12 @@ function p_binaryopcall(
     childs = children(cst)
     op_indices = source_operator_indices(cst)
     opkind = source_op_kind(s, cst)
+
+    # Intercept piped function calls and construct a normal function call FST instead. NOTE:
+    # If overloading `p_binaryopcall` for a custom style you will have to overload this!
+    if opkind === K"|>" && s.opts.pipe_to_function_call
+        return p_pipe_to_call(ds, cst, s, ctx, lineage)
+    end
 
     nonest = ctx.nonest || opkind === K":"
 

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -2298,19 +2298,22 @@ function p_binaryopcall(
     # If overloading `p_binaryopcall` for a custom style you will have to make sure to
     # include this logic!
     if opkind === K"|>" && s.opts.pipe_to_function_call
-        # We purposely exclude two cases:
+        # We purposely exclude three cases:
         # 
         # 1. `x |> f` inside a macro. It's too dangerous to change that inside a macro as
         #    the macro may well be handling `|>` in a custom way.
         #
-        # 2. `x .|> (f1, f2)`. This is a very weird Julia quirk where you can broadcast
+        # 2. `:(x |> f)` or `quote x |> f end`. Changing the code inside an `Expr` makes
+        #    it a different `Expr`.
+        #
+        # 3. `x .|> (f1, f2)`. This is a very weird Julia quirk where you can broadcast
         #    over the _caller_ rather than the callee. There's no equivalent way to express
         #    this in function call form, so we shouldn't try to transform it. See
         #    https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/647.
-        inside_macro = any(t -> t[1] === K"macrocall", lineage)
+        inside_macro_or_quote = any(t -> t[1] in K"macrocall quote", lineage)
         rhs_cst = childs[findlast(n -> !JuliaSyntax.is_whitespace(n), childs)]
         dotted_tuple = kind(cst) === K"dotcall" && kind(rhs_cst) === K"tuple"
-        if !inside_macro && !dotted_tuple
+        if !inside_macro_or_quote && !dotted_tuple
             return p_pipe_to_call(ds, cst, s, ctx, lineage)
         end
     end

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -918,11 +918,7 @@ function p_macrocall(
     end
 
     args = get_args(cst)
-    nest =
-        length(args) > 0 && !(
-            length(args) == 1 &&
-            (unnestable_node(args[1]) || s.opts.disallow_single_arg_nesting)
-        )
+    nest = should_nest_call_args(args, s.opts.disallow_single_arg_nesting)
     childs = children(cst)
 
     has_closer = is_closer(childs[end])
@@ -2095,6 +2091,12 @@ function p_kw(
     t
 end
 
+"""
+    p_pipe_to_call
+
+Take a CST of the form `x |> y`, but return a FST with the equivalent function call `y(x)`
+instead.
+"""
 function p_pipe_to_call(
     style::AbstractStyle,
     # cst here must be a binary op call with |> as the operator (possibly dotted).
@@ -2121,7 +2123,8 @@ function p_pipe_to_call(
 
     call_node = FST(Call, nspaces(s))
     childs = children(cst)
-    # Identify the LHS and RHS of the operator
+
+    # Identify the operator LHS (callee) and RHS (caller).
     lhs_idx = findfirst(n -> !JuliaSyntax.is_whitespace(n), childs)
     rhs_idx = findlast(n -> !JuliaSyntax.is_whitespace(n), childs)
     if isnothing(lhs_idx) || isnothing(rhs_idx) || lhs_idx >= rhs_idx
@@ -2130,50 +2133,87 @@ function p_pipe_to_call(
         )
     end
 
+    # Convert each node to an FST, storing references to the LHS and RHS nodes for later.
     lhs, rhs = nothing, nothing
     for (i, c) in enumerate(childs)
         if i == lhs_idx
-            lhs = pretty(style, c, s, ctx, lineage)
+            if kind(c) === K"parens" && haschildren(c)
+                # If the lhs is a parenthesised expression, we can strip the parentheses.
+                # For example
+                #     (x) |> f
+                # can just become f(x) rather than f((x)).
+                for pc in children(c)
+                    if kind(pc) in KSet"( )" || JuliaSyntax.is_whitespace(pc)
+                        s.offset += span(pc)
+                    else
+                        lhs = pretty(style, pc, s, ctx, lineage)
+                    end
+                end
+            else
+                lhs = pretty(style, c, s, ctx, lineage)
+            end
         elseif i == rhs_idx
             rhs = pretty(style, c, s, ctx, lineage)
         else
-            # Advance s.offset past everything else without emitting
             s.offset += span(c)
         end
     end
 
+    # Handle the caller.
+    #
     # Some things need to be wrapped in parens. We behave conservatively here and only opt
-    # out of wrapping for the following callables:
+    # out of wrapping for the following callers:
+    #
     #   - a plain identifier               arg |> f     -> f(arg)
     #   - a field access                   arg |> obj.f -> obj.f(arg)
     #   - something already parenthesised  arg |> (f)   -> (f)(arg)
     #   - a function call                  arg |> f()   -> f()(arg)
+    #
+    # There are two edge cases (of course there are).
+    #
+    # 1. For the function call case, we need to parenthesise a function call with a
+    #    do-block:
+    #
+    #     arg |> f() do           (f() do
+    #         g()          --->        g()
+    #     end                     end)(arg)
+    #
+    # 2. For the identifier case, if it's a dotted operator, we need to store a flag,
+    #    `is_dotted_operator`. This is because
+    #
+    #        arg .|> ! 
+    #
+    #    should become `.!(arg)` rather than `!.(arg)` which is a parse error.
+    #    (Alternatively, (!).(arg) would work too, but looks uglier.)
     rhs_cst = childs[rhs_idx]
-    function_needs_parens = if kind(rhs_cst) in KSet"Identifier . parens"
+    is_dotted_operator = if kind(cst) === K"dotcall" && kind(rhs_cst) === K"Identifier"
+        try
+            k = JuliaSyntax.Kind(rhs.val)
+            JuliaSyntax.is_operator(k) && !JuliaSyntax.is_word_operator(k)
+        catch
+            false
+        end
+    else
+        false
+    end
+    caller_needs_parens = if kind(rhs_cst) in KSet"Identifier . parens"
         false
     elseif kind(rhs_cst) === K"call" && haschildren(rhs_cst)
         # In JuliaSyntax, infix operators are also parsed as `call`, so we need to really
         # check that it is a function call with parentheses.
-        any(n -> kind(n) === K"(", children(rhs_cst))
+        has_parens = any(n -> kind(n) === K"(", children(rhs_cst))
+        has_do = any(n -> kind(n) === K"do", children(rhs_cst))
+        if has_parens
+            has_do
+        else
+            true # infix operator
+        end
     else
         true
     end
-    function_needs_parens && add_node!(
-        call_node,
-        FST(PUNCTUATION, -1, rhs.startline, rhs.startline, "("),
-        s;
-        join_lines = true,
-    )
-    add_node!(call_node, rhs, s; join_lines = true)
-    function_needs_parens && add_node!(
-        call_node,
-        FST(PUNCTUATION, -1, rhs.startline, rhs.startline, ")"),
-        s;
-        join_lines = true,
-    )
 
-    # Add a dot if needed
-    if kind(cst) === K"dotcall"
+    # Add a dot *before* the function if needed.
+    if kind(cst) === K"dotcall" && is_dotted_operator
         add_node!(
             call_node,
             FST(PUNCTUATION, -1, rhs.startline, rhs.startline, "."),
@@ -2182,15 +2222,48 @@ function p_pipe_to_call(
         )
     end
 
-    argument_needs_params = true
-    argument_needs_params && add_node!(
+    # Add the function, parenthesising if needed.
+    caller_needs_parens && add_node!(
         call_node,
         FST(PUNCTUATION, -1, rhs.startline, rhs.startline, "("),
         s;
         join_lines = true,
     )
+    add_node!(call_node, rhs, s; join_lines = true)
+    caller_needs_parens && add_node!(
+        call_node,
+        FST(PUNCTUATION, -1, rhs.startline, rhs.startline, ")"),
+        s;
+        join_lines = true,
+    )
+
+    # Add a dot *after* the function if needed.
+    if kind(cst) === K"dotcall" && !is_dotted_operator
+        add_node!(
+            call_node,
+            FST(PUNCTUATION, -1, rhs.startline, rhs.startline, "."),
+            s;
+            join_lines = true,
+        )
+    end
+
+    # Handle the callee.
+    nest = should_nest_call_args([cst[lhs_idx]], s.opts.disallow_single_arg_nesting)
+    add_node!(
+        call_node,
+        FST(PUNCTUATION, -1, rhs.startline, rhs.startline, "("),
+        s;
+        join_lines = true,
+    )
+    if nest
+        add_node!(call_node, Placeholder(0), s)
+    end
     add_node!(call_node, lhs, s; join_lines = true)
-    argument_needs_params && add_node!(
+    if nest
+        add_node!(call_node, TrailingComma(), s)
+        add_node!(call_node, Placeholder(0), s)
+    end
+    add_node!(
         call_node,
         FST(PUNCTUATION, -1, rhs.startline, rhs.startline, ")"),
         s;
@@ -2218,7 +2291,8 @@ function p_binaryopcall(
     opkind = source_op_kind(s, cst)
 
     # Intercept piped function calls and construct a normal function call FST instead. NOTE:
-    # If overloading `p_binaryopcall` for a custom style you will have to overload this!
+    # If overloading `p_binaryopcall` for a custom style you will have to make sure to
+    # include this logic!
     if opkind === K"|>" && s.opts.pipe_to_function_call
         return p_pipe_to_call(ds, cst, s, ctx, lineage)
     end
@@ -2496,11 +2570,7 @@ function p_whereopcall(
     end
 
     args = get_args(cst)
-    nest =
-        length(args) > 0 && !(
-            length(args) == 1 &&
-            (unnestable_node(args[1]) || s.opts.disallow_single_arg_nesting)
-        )
+    nest = should_nest_call_args(args, s.opts.disallow_single_arg_nesting)
 
     childs = children(cst)
     where_idx = findfirst(c -> kind(c) === K"where" && !haschildren(c), childs)
@@ -2643,11 +2713,7 @@ function p_curly(
     end
 
     args = get_args(cst)
-    nest =
-        length(args) > 0 && !(
-            length(args) == 1 &&
-            (unnestable_node(args[1]) || s.opts.disallow_single_arg_nesting)
-        )
+    nest = should_nest_call_args(args, s.opts.disallow_single_arg_nesting)
 
     nws = s.opts.whitespace_typedefs ? 1 : 0
 
@@ -2703,11 +2769,7 @@ function p_call(
     end
 
     args = call_args(childs)
-    nest =
-        length(args) > 0 && !(
-            length(args) == 1 &&
-            (unnestable_node(args[1]) || s.opts.disallow_single_arg_nesting)
-        )
+    nest = should_nest_call_args(args, s.opts.disallow_single_arg_nesting)
 
     for (i, a) in enumerate(childs)
         k = kind(a)
@@ -2822,11 +2884,7 @@ function p_tupleblock(
     end
 
     args = get_args(cst)
-    nest =
-        length(args) > 0 && !(
-            length(args) == 1 &&
-            (unnestable_node(args[1]) || s.opts.disallow_single_arg_nesting)
-        )
+    nest = should_nest_call_args(args, s.opts.disallow_single_arg_nesting)
 
     childs = children(cst)
     for (i, a) in enumerate(childs)
@@ -2871,11 +2929,7 @@ function p_tuple(
     end
 
     args = get_args(cst)
-    nest =
-        length(args) > 0 && !(
-            length(args) == 1 &&
-            (unnestable_node(args[1]) || s.opts.disallow_single_arg_nesting)
-        )
+    nest = should_nest_call_args(args, s.opts.disallow_single_arg_nesting)
 
     childs = children(cst)
     for (i, a) in enumerate(childs)
@@ -2889,8 +2943,6 @@ function p_tuple(
             add_node!(t, n, s; join_lines = true)
             if nest
                 add_node!(t, Placeholder(0), s)
-            else
-                false
             end
         elseif kind(a) === K")"
             # An odd case but this could occur if there are no keyword arguments.
@@ -2930,11 +2982,7 @@ function p_braces(
     end
 
     args = get_args(cst)
-    nest =
-        length(args) > 0 && !(
-            length(args) == 1 &&
-            (unnestable_node(args[1]) || s.opts.disallow_single_arg_nesting)
-        )
+    nest = should_nest_call_args(args, s.opts.disallow_single_arg_nesting)
 
     nws = ctx.from_typedef && !s.opts.whitespace_typedefs ? 0 : 1
 
@@ -2946,8 +2994,6 @@ function p_braces(
             add_node!(t, n, s; join_lines = true)
             if nest
                 add_node!(t, Placeholder(0), s)
-            else
-                false
             end
         elseif kind(a) === K"}"
             if nest
@@ -2981,11 +3027,7 @@ function p_bracescat(
     end
 
     args = get_args(cst)
-    nest =
-        length(args) > 0 && !(
-            length(args) == 1 &&
-            (unnestable_node(args[1]) || s.opts.disallow_single_arg_nesting)
-        )
+    nest = should_nest_call_args(args, s.opts.disallow_single_arg_nesting)
 
     nws = ctx.from_typedef && !s.opts.whitespace_typedefs ? 0 : 1
     childs = children(cst)
@@ -3031,11 +3073,7 @@ function p_vect(
     end
 
     args = get_args(cst)
-    nest =
-        length(args) > 0 && !(
-            length(args) == 1 &&
-            (unnestable_node(args[1]) || s.opts.disallow_single_arg_nesting)
-        )
+    nest = should_nest_call_args(args, s.opts.disallow_single_arg_nesting)
 
     childs = children(cst)
     for (i, a) in enumerate(childs)
@@ -3292,11 +3330,7 @@ function p_ref(
     end
 
     args = get_args(cst)
-    nest =
-        length(args) > 1 && !(
-            length(args) == 1 &&
-            (unnestable_node(args[1]) || s.opts.disallow_single_arg_nesting)
-        )
+    nest = length(args) > 1
 
     childs = children(cst)
     for (i, a) in enumerate(childs)
@@ -3342,11 +3376,7 @@ function p_vcat(
     end
 
     args = get_args(cst)
-    nest =
-        length(args) > 0 && !(
-            length(args) == 1 &&
-            (unnestable_node(args[1]) || s.opts.disallow_single_arg_nesting)
-        )
+    nest = should_nest_call_args(args, s.opts.disallow_single_arg_nesting)
     childs = children(cst)
     idx = findfirst(n -> kind(n) === K"[", childs)::Int
     first_arg_idx = findnext(n -> !JuliaSyntax.is_whitespace(n), childs, idx + 1)

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -598,7 +598,7 @@ function p_operator(
     val = getsrcval(s.doc, (s.offset):(s.offset+span(cst)-1))
     s.offset += span(cst)
     t = FST(OPERATOR, loc[2], loc[1], loc[1], val)
-    t.metadata = Metadata(kind(cst), JuliaSyntax.is_dotted(cst))
+    t.metadata = Metadata(kind(cst))
     return t
 end
 
@@ -1219,7 +1219,7 @@ function p_functiondef(
             add_node!(t, pretty(style, c, s, ctx, lineage), s; join_lines = true)
         end
     end
-    t.metadata = Metadata(kind(cst), false, false, false, false, true, false)
+    t.metadata = Metadata(kind(cst), false, false, false, true, false)
     t
 end
 
@@ -2312,7 +2312,6 @@ function p_binaryopcall(
     end
 
     is_short_form_function = defines_function(cst) && !ctx.from_let
-    op_dotted = kind(cst) === K"dotcall"
     standalone_binary_circuit = ctx.standalone_binary_circuit
     can_separate_kwargs = ctx.can_separate_kwargs && !is_function_or_macro_def(cst)
 
@@ -2332,7 +2331,6 @@ function p_binaryopcall(
 
     t.metadata = Metadata(
         opkind,
-        op_dotted,
         lazy_op && standalone_binary_circuit,
         is_short_form_function,
         is_assignment(cst) || defines_function(cst),
@@ -2404,7 +2402,7 @@ function p_binaryopcall(
             val = getsrcval(s.doc, (s.offset):(s.offset+op_span-1))
             s.offset += op_span
             n = FST(OPERATOR, loc[2], loc[1], loc[1], val)
-            n.metadata = Metadata(K"op=", startswith(val, "."))
+            n.metadata = Metadata(K"op=")
             if nws > 0 && i > 1
                 add_node!(t, Whitespace(nws), s)
             end
@@ -2441,7 +2439,7 @@ function p_binaryopcall(
         if is_op && n.typ === IDENTIFIER
             n.typ = OPERATOR
             n.metadata =
-                Metadata(source_op_kind_from_offset(s, c, offset)::JuliaSyntax.Kind, is_dot)
+                Metadata(source_op_kind_from_offset(s, c, offset)::JuliaSyntax.Kind)
         end
         if is_dot && haschildren(c) && length(children(c)) == 2
             # [.]
@@ -2677,9 +2675,8 @@ function p_unaryopcall(
         op_idx = first_idx
     end
     opkind = isnothing(op_idx) ? op_kind(cst) : source_op_kind(s, cst)
-    op_dotted = kind(cst) === K"dotcall"
 
-    t.metadata = Metadata(opkind, op_dotted)
+    t.metadata = Metadata(opkind)
 
     for (i, c) in enumerate(childs)
         offset = s.offset
@@ -2691,7 +2688,7 @@ function p_unaryopcall(
             k = source_op_kind_from_offset(s, c, offset)
             if !isnothing(k)
                 n.typ = OPERATOR
-                n.metadata = Metadata(k, false)
+                n.metadata = Metadata(k)
             end
         end
         add_node!(t, n, s; join_lines = true)

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -2168,6 +2168,7 @@ function p_pipe_to_call(
     #   - a field access                   arg |> obj.f -> obj.f(arg)
     #   - something already parenthesised  arg |> (f)   -> (f)(arg)
     #   - a function call                  arg |> f()   -> f()(arg)
+    #   - a parametrised type constructor  arg |> F{x}  -> F{x}(arg)
     #
     # There are two edge cases (of course there are).
     #
@@ -2196,7 +2197,7 @@ function p_pipe_to_call(
     else
         false
     end
-    caller_needs_parens = if kind(rhs_cst) in KSet"Identifier . parens"
+    caller_needs_parens = if kind(rhs_cst) in KSet"Identifier . parens curly"
         false
     elseif kind(rhs_cst) === K"call" && haschildren(rhs_cst)
         # In JuliaSyntax, infix operators are also parsed as `call`, so we need to really

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -2094,8 +2094,11 @@ end
 """
     p_pipe_to_call
 
-Take a CST of the form `x |> y`, but return a FST with the equivalent function call `y(x)`
-instead.
+Take a CST of the form `x |> y` or `x .|> y`, but return a FST with the equivalent function
+call `y(x)` or `y.(x)` instead.
+
+Note that this function is only called for certain pipe-applications. See the call site in
+`p_binaryopcall` for details.
 """
 function p_pipe_to_call(
     style::AbstractStyle,
@@ -2295,7 +2298,21 @@ function p_binaryopcall(
     # If overloading `p_binaryopcall` for a custom style you will have to make sure to
     # include this logic!
     if opkind === K"|>" && s.opts.pipe_to_function_call
-        return p_pipe_to_call(ds, cst, s, ctx, lineage)
+        # We purposely exclude two cases:
+        # 
+        # 1. `x |> f` inside a macro. It's too dangerous to change that inside a macro as
+        #    the macro may well be handling `|>` in a custom way.
+        #
+        # 2. `x .|> (f1, f2)`. This is a very weird Julia quirk where you can broadcast
+        #    over the _caller_ rather than the callee. There's no equivalent way to express
+        #    this in function call form, so we shouldn't try to transform it. See
+        #    https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/647.
+        inside_macro = any(t -> t[1] === K"macrocall", lineage)
+        rhs_cst = childs[findlast(n -> !JuliaSyntax.is_whitespace(n), childs)]
+        dotted_tuple = kind(cst) === K"dotcall" && kind(rhs_cst) === K"tuple"
+        if !inside_macro && !dotted_tuple
+            return p_pipe_to_call(ds, cst, s, ctx, lineage)
+        end
     end
 
     nonest = ctx.nonest || opkind === K":"

--- a/test/options.jl
+++ b/test/options.jl
@@ -336,6 +336,34 @@
             """
             @test fmt(str_; pipe_to_function_call = true) == str
         end
+
+        # Make sure that nesting decisions are made correctly the first time
+        # see https://github.com/JuliaEditorSupport/JuliaFormatter.jl/pull/1023
+        # Formatting the string below used to not be idempotent.
+        str_ = """
+        function f()
+            ps_mods = map(
+                layer_mods -> (
+                    layer_mods === nothing ? () :
+                        map(l -> initialparameters(rng, l), layer_mods) |> Tuple
+                ),
+                mods
+            ) |> Tuple
+        end"""
+        str = """
+        function f()
+            ps_mods = Tuple(
+                map(
+                    layer_mods -> (
+                        layer_mods === nothing ? () :
+                        Tuple(map(l -> initialparameters(rng, l), layer_mods))
+                    ),
+                    mods,
+                ),
+            )
+        end"""
+        @test fmt(str_; pipe_to_function_call = true) == str
+        @test fmt(str; pipe_to_function_call = true) == str
     end
 
     @testset "function shortdef to longdef" begin

--- a/test/options.jl
+++ b/test/options.jl
@@ -360,12 +360,12 @@
         end
 
         @testset "block argument" begin
-            for dot in (""," .")
-                str_ = """quote
-                    foo
-                end $dot|> esc"""
-                str = """esc$dot(quote
-                    foo
+            for dot in ("", ".")
+                str_ = """begin
+                    f
+                end $dot|> g"""
+                str = """g$dot(begin
+                    f
                 end)"""
                 @test fmt(str_; pipe_to_function_call = true) == str
             end

--- a/test/options.jl
+++ b/test/options.jl
@@ -272,100 +272,119 @@
     end
 
     @testset "rewrite x |> f to f(x)" begin
-        for dot in ("", ".")
-            # Basic cases
-            @test fmt("x $dot|> f"; pipe_to_function_call = true) == "f$dot(x)"
-            @test fmt("x $dot|> f()"; pipe_to_function_call = true) == "f()$dot(x)"
-            @test fmt("x $dot|> f(a)"; pipe_to_function_call = true) == "f(a)$dot(x)"
-            @test fmt("x $dot|> M.f"; pipe_to_function_call = true) == "M.f$dot(x)"
-            @test fmt("x $dot|> T{x}"; pipe_to_function_call = true) == "T{x}$dot(x)"
-            # Check that callable is parenthesised if necessary
-            @test fmt("x $dot|> y -> y + 1"; pipe_to_function_call = true) == "(y -> y + 1)$dot(x)"
-            @test fmt("x $dot|> f ∘ g"; pipe_to_function_call = true) == "(f ∘ g)$dot(x)"
-        end
-
-        # Operators
-        @test fmt("x |> !"; pipe_to_function_call = true) == "!(x)"
-        @test fmt("x .|> !"; pipe_to_function_call = true) == ".!(x)"
-
-        # Removal of extra argument parentheses
-        @test fmt("(x) |> f"; pipe_to_function_call = true) == "f(x)"
-        @test fmt("(x) .|> f"; pipe_to_function_call = true) == "f.(x)"
-        @test fmt("(a for a in x) |> f()"; pipe_to_function_call = true) == "f()(a for a in x)"
-        # make sure that genuine tuples don't get de-parenthesised
-        @test fmt("(x, y) |> f()"; pipe_to_function_call = true) == "f()((x, y))"
-        @test fmt("(x,) |> f()"; pipe_to_function_call = true) == "f()((x,))"
-        @test fmt("(; x) |> f()"; pipe_to_function_call = true) == "f()((; x))"
-
-        # Chained pipes
-        str_ = "var = func1(arg1) |> func2 |> func3 |> func4 |> func5"
-        str = "var = func5(func4(func3(func2(func1(arg1)))))"
-        @test fmt(str_; pipe_to_function_call = true) == str
-        @test fmt(str_; pipe_to_function_call = true, margin = 1) == fmt(str)
-        @test fmt("x .|> f .|> g"; pipe_to_function_call = true) == "g.(f.(x))"
-        @test fmt("(x |> f) |> g"; pipe_to_function_call = true) == "g(f(x))"
-        @test fmt("x |> f .|> g"; pipe_to_function_call = true) == "g.(f(x))"
-        @test fmt("x .|> f |> g"; pipe_to_function_call = true) == "g(f.(x))"
-        @test fmt("x |> y -> y |> f"; pipe_to_function_call = true) == "(y -> f(y))(x)"
-
-        # Complex LHS
-        @test fmt("f(a, b) |> g"; pipe_to_function_call = true) == "g(f(a, b))"
-        @test fmt("a + b |> f"; pipe_to_function_call = true) == "f(a + b)"
-        @test fmt("[1...] |> f"; pipe_to_function_call = true) == "f([1...])"
-        @test fmt("1:10 |> collect"; pipe_to_function_call = true) == "collect(1:10)"
-
-        # Nesting with narrow margin
-        for dot in ("", ".")
-            f = "some_long_function_name"
-            x = "very_long_variable_name"
-            str_ = "$x $(dot)|> $f"
-            str = "$f$(dot)($x)"
-            @test fmt(str_; pipe_to_function_call = true, margin = 1) == fmt(str; margin = 1)
-        end
-
-        # Do block
-        for dot in ("", ".")
-            str_ = """
-            x $dot|> f(a) do a
-                g(a)
+        @testset "basic cases" begin
+            for dot in ("", ".")
+                @test fmt("x $dot|> f"; pipe_to_function_call = true) == "f$dot(x)"
+                @test fmt("x $dot|> f()"; pipe_to_function_call = true) == "f()$dot(x)"
+                @test fmt("x $dot|> f(a)"; pipe_to_function_call = true) == "f(a)$dot(x)"
+                @test fmt("x $dot|> M.f"; pipe_to_function_call = true) == "M.f$dot(x)"
+                @test fmt("x $dot|> T{x}"; pipe_to_function_call = true) == "T{x}$dot(x)"
+                # Check that callable is parenthesised if necessary
+                @test fmt("x $dot|> y -> y + 1"; pipe_to_function_call = true) == "(y -> y + 1)$dot(x)"
+                @test fmt("x $dot|> f ∘ g"; pipe_to_function_call = true) == "(f ∘ g)$dot(x)"
             end
-            """
-            str = """
-            (f(a) do a
-                g(a)
-            end)$dot(x)
-            """
-            @test fmt(str_; pipe_to_function_call = true) == str
         end
 
-        @testset "nesting & idempotence" begin
-            # Make sure that nesting decisions are made correctly the first time
-            # see https://github.com/JuliaEditorSupport/JuliaFormatter.jl/pull/1023
-            # Formatting the string below used to not be idempotent.
-            str_ = """
-            function f()
-                ps_mods = map(
-                    layer_mods -> (
-                        layer_mods === nothing ? () :
-                            map(l -> initialparameters(rng, l), layer_mods) |> Tuple
-                    ),
-                    mods
-                ) |> Tuple
-            end"""
-            str = """
-            function f()
-                ps_mods = Tuple(
-                    map(
+        @testset "operators on rhs" begin
+            @test fmt("x |> !"; pipe_to_function_call = true) == "!(x)"
+            @test fmt("x .|> !"; pipe_to_function_call = true) == ".!(x)"
+        end
+
+        @testset "elision of extra argument parentheses" begin
+            @test fmt("(x) |> f"; pipe_to_function_call = true) == "f(x)"
+            @test fmt("(x) .|> f"; pipe_to_function_call = true) == "f.(x)"
+            @test fmt("(a for a in x) |> f()"; pipe_to_function_call = true) == "f()(a for a in x)"
+            # make sure that genuine tuples don't get de-parenthesised
+            @test fmt("(x, y) |> f()"; pipe_to_function_call = true) == "f()((x, y))"
+            @test fmt("(x,) |> f()"; pipe_to_function_call = true) == "f()((x,))"
+            @test fmt("(; x) |> f()"; pipe_to_function_call = true) == "f()((; x))"
+        end
+
+        @testset "chained pipes" begin
+            str_ = "var = func1(arg1) |> func2 |> func3 |> func4 |> func5"
+            str = "var = func5(func4(func3(func2(func1(arg1)))))"
+            @test fmt(str_; pipe_to_function_call = true) == str
+            @test fmt(str_; pipe_to_function_call = true, margin = 1) == fmt(str)
+            @test fmt("x .|> f .|> g"; pipe_to_function_call = true) == "g.(f.(x))"
+            @test fmt("(x |> f) |> g"; pipe_to_function_call = true) == "g(f(x))"
+            @test fmt("x |> f .|> g"; pipe_to_function_call = true) == "g.(f(x))"
+            @test fmt("x .|> f |> g"; pipe_to_function_call = true) == "g(f.(x))"
+            @test fmt("x |> y -> y |> f"; pipe_to_function_call = true) == "(y -> f(y))(x)"
+        end
+
+        @testset "expressions on lhs" begin
+            @test fmt("f(a, b) |> g"; pipe_to_function_call = true) == "g(f(a, b))"
+            @test fmt("a + b |> f"; pipe_to_function_call = true) == "f(a + b)"
+            @test fmt("[1...] |> f"; pipe_to_function_call = true) == "f([1...])"
+            @test fmt("1:10 |> collect"; pipe_to_function_call = true) == "collect(1:10)"
+        end
+
+        @testset "nesting" begin
+            for dot in ("", ".")
+                f = "some_long_function_name"
+                x = "very_long_variable_name"
+                str_ = "$x $(dot)|> $f"
+                str = "$f$(dot)($x)"
+                @test fmt(str_; pipe_to_function_call = true, margin = 1) == fmt(str; margin = 1)
+            end
+
+            @testset "extra idempotence test" begin
+                # Make sure that nesting decisions are made correctly the first time
+                # see https://github.com/JuliaEditorSupport/JuliaFormatter.jl/pull/1023
+                # Formatting the string below used to not be idempotent.
+                str_ = """
+                function f()
+                    ps_mods = map(
                         layer_mods -> (
                             layer_mods === nothing ? () :
-                            Tuple(map(l -> initialparameters(rng, l), layer_mods))
+                                map(l -> initialparameters(rng, l), layer_mods) |> Tuple
                         ),
-                        mods,
-                    ),
-                )
-            end"""
-            @test fmt(str_; pipe_to_function_call = true) == str
-            @test fmt(str; pipe_to_function_call = true) == str
+                        mods
+                    ) |> Tuple
+                end"""
+                str = """
+                function f()
+                    ps_mods = Tuple(
+                        map(
+                            layer_mods -> (
+                                layer_mods === nothing ? () :
+                                Tuple(map(l -> initialparameters(rng, l), layer_mods))
+                            ),
+                            mods,
+                        ),
+                    )
+                end"""
+                @test fmt(str_; pipe_to_function_call = true) == str
+                @test fmt(str; pipe_to_function_call = true) == str
+            end
+        end
+
+        @testset "block argument" begin
+            for dot in (""," .")
+                str_ = """quote
+                    foo
+                end $dot|> esc"""
+                str = """esc$dot(quote
+                    foo
+                end)"""
+                @test fmt(str_; pipe_to_function_call = true) == str
+            end
+        end
+
+        @testset "function with do block" begin
+            for dot in ("", ".")
+                str_ = """
+                x $dot|> f(a) do a
+                    g(a)
+                end
+                """
+                str = """
+                (f(a) do a
+                    g(a)
+                end)$dot(x)
+                """
+                @test fmt(str_; pipe_to_function_call = true) == str
+            end
         end
 
         @testset "cases where transformation should not happen" begin
@@ -374,6 +393,12 @@
             @test fmt(smacro; pipe_to_function_call = true) == smacro
             smacro2 = "@macro function f()\n    x |> g\nend"
             @test fmt(smacro2; pipe_to_function_call = true) == smacro2
+
+            # inside Expr
+            sexpr = ":(x |> f)"
+            @test fmt(sexpr; pipe_to_function_call = true) == sexpr
+            squote = "quote\n    x |> f\nend"
+            @test fmt(squote; pipe_to_function_call = true) == squote
 
             # dotted tuple of functions
             # https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/647

--- a/test/options.jl
+++ b/test/options.jl
@@ -272,12 +272,70 @@
     end
 
     @testset "rewrite x |> f to f(x)" begin
-        @test fmt("x |> f"; pipe_to_function_call = true) == "f(x)"
+        for dot in ("", ".")
+            # Basic cases
+            @test fmt("x $dot|> f"; pipe_to_function_call = true) == "f$dot(x)"
+            @test fmt("x $dot|> f()"; pipe_to_function_call = true) == "f()$dot(x)"
+            @test fmt("x $dot|> f(a)"; pipe_to_function_call = true) == "f(a)$dot(x)"
+            @test fmt("x $dot|> M.f"; pipe_to_function_call = true) == "M.f$dot(x)"
+            # Check that callable is parenthesised if necessary
+            @test fmt("x $dot|> y -> y + 1"; pipe_to_function_call = true) == "(y -> y + 1)$dot(x)"
+            @test fmt("x $dot|> f ∘ g"; pipe_to_function_call = true) == "(f ∘ g)$dot(x)"
+        end
 
+        # Operators
+        @test fmt("x |> !"; pipe_to_function_call = true) == "!(x)"
+        @test fmt("x .|> !"; pipe_to_function_call = true) == ".!(x)"
+
+        # Removal of extra argument parentheses
+        @test fmt("(x) |> f"; pipe_to_function_call = true) == "f(x)"
+        @test fmt("(x) .|> f"; pipe_to_function_call = true) == "f.(x)"
+        @test fmt("(a for a in x) |> f()"; pipe_to_function_call = true) == "f()(a for a in x)"
+        # make sure that genuine tuples don't get de-parenthesised
+        @test fmt("(x, y) |> f()"; pipe_to_function_call = true) == "f()((x, y))"
+        @test fmt("(x,) |> f()"; pipe_to_function_call = true) == "f()((x,))"
+        @test fmt("(; x) |> f()"; pipe_to_function_call = true) == "f()((; x))"
+
+        # Chained pipes
         str_ = "var = func1(arg1) |> func2 |> func3 |> func4 |> func5"
         str = "var = func5(func4(func3(func2(func1(arg1)))))"
         @test fmt(str_; pipe_to_function_call = true) == str
         @test fmt(str_; pipe_to_function_call = true, margin = 1) == fmt(str)
+        @test fmt("x .|> f .|> g"; pipe_to_function_call = true) == "g.(f.(x))"
+        @test fmt("(x |> f) |> g"; pipe_to_function_call = true) == "g(f(x))"
+        @test fmt("x |> f .|> g"; pipe_to_function_call = true) == "g.(f(x))"
+        @test fmt("x .|> f |> g"; pipe_to_function_call = true) == "g(f.(x))"
+        @test fmt("x |> y -> y |> f"; pipe_to_function_call = true) == "(y -> f(y))(x)"
+
+        # Complex LHS
+        @test fmt("f(a, b) |> g"; pipe_to_function_call = true) == "g(f(a, b))"
+        @test fmt("a + b |> f"; pipe_to_function_call = true) == "f(a + b)"
+        @test fmt("[1...] |> f"; pipe_to_function_call = true) == "f([1...])"
+        @test fmt("1:10 |> collect"; pipe_to_function_call = true) == "collect(1:10)"
+
+        # Nesting with narrow margin
+        for dot in ("", ".")
+            f = "some_long_function_name"
+            x = "very_long_variable_name"
+            str_ = "$x $(dot)|> $f"
+            str = "$f$(dot)($x)"
+            @test fmt(str_; pipe_to_function_call = true, margin = 1) == fmt(str; margin = 1)
+        end
+
+        # Do block
+        for dot in ("", ".")
+            str_ = """
+            x $dot|> f(a) do a
+                g(a)
+            end
+            """
+            str = """
+            (f(a) do a
+                g(a)
+            end)$dot(x)
+            """
+            @test fmt(str_; pipe_to_function_call = true) == str
+        end
     end
 
     @testset "function shortdef to longdef" begin

--- a/test/options.jl
+++ b/test/options.jl
@@ -278,6 +278,7 @@
             @test fmt("x $dot|> f()"; pipe_to_function_call = true) == "f()$dot(x)"
             @test fmt("x $dot|> f(a)"; pipe_to_function_call = true) == "f(a)$dot(x)"
             @test fmt("x $dot|> M.f"; pipe_to_function_call = true) == "M.f$dot(x)"
+            @test fmt("x $dot|> T{x}"; pipe_to_function_call = true) == "T{x}$dot(x)"
             # Check that callable is parenthesised if necessary
             @test fmt("x $dot|> y -> y + 1"; pipe_to_function_call = true) == "(y -> y + 1)$dot(x)"
             @test fmt("x $dot|> f ∘ g"; pipe_to_function_call = true) == "(f ∘ g)$dot(x)"

--- a/test/options.jl
+++ b/test/options.jl
@@ -338,33 +338,48 @@
             @test fmt(str_; pipe_to_function_call = true) == str
         end
 
-        # Make sure that nesting decisions are made correctly the first time
-        # see https://github.com/JuliaEditorSupport/JuliaFormatter.jl/pull/1023
-        # Formatting the string below used to not be idempotent.
-        str_ = """
-        function f()
-            ps_mods = map(
-                layer_mods -> (
-                    layer_mods === nothing ? () :
-                        map(l -> initialparameters(rng, l), layer_mods) |> Tuple
-                ),
-                mods
-            ) |> Tuple
-        end"""
-        str = """
-        function f()
-            ps_mods = Tuple(
-                map(
+        @testset "nesting & idempotence" begin
+            # Make sure that nesting decisions are made correctly the first time
+            # see https://github.com/JuliaEditorSupport/JuliaFormatter.jl/pull/1023
+            # Formatting the string below used to not be idempotent.
+            str_ = """
+            function f()
+                ps_mods = map(
                     layer_mods -> (
                         layer_mods === nothing ? () :
-                        Tuple(map(l -> initialparameters(rng, l), layer_mods))
+                            map(l -> initialparameters(rng, l), layer_mods) |> Tuple
                     ),
-                    mods,
-                ),
-            )
-        end"""
-        @test fmt(str_; pipe_to_function_call = true) == str
-        @test fmt(str; pipe_to_function_call = true) == str
+                    mods
+                ) |> Tuple
+            end"""
+            str = """
+            function f()
+                ps_mods = Tuple(
+                    map(
+                        layer_mods -> (
+                            layer_mods === nothing ? () :
+                            Tuple(map(l -> initialparameters(rng, l), layer_mods))
+                        ),
+                        mods,
+                    ),
+                )
+            end"""
+            @test fmt(str_; pipe_to_function_call = true) == str
+            @test fmt(str; pipe_to_function_call = true) == str
+        end
+
+        @testset "cases where transformation should not happen" begin
+            # inside macro
+            smacro = "@macro x |> f"
+            @test fmt(smacro; pipe_to_function_call = true) == smacro
+            smacro2 = "@macro function f()\n    x |> g\nend"
+            @test fmt(smacro2; pipe_to_function_call = true) == smacro2
+
+            # dotted tuple of functions
+            # https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/647
+            sdotcall = "x .|> (f, g)"
+            @test fmt(sdotcall; pipe_to_function_call = true) == sdotcall
+        end
     end
 
     @testset "function shortdef to longdef" begin


### PR DESCRIPTION
Closes #439
Closes #647
Closes #927

1. The transformation is fundamentally unsafe, and is enabled by default for Blue and YAS styles. This patch therefore causes JuliaFormatter to emit a warning when this transformation is invoked (with maxlog=1 to avoid being spammy). Unfortunately, in VSCode it will be swallowed into the LSP logs, but this is pretty much all I can do without outright removing the option.

2. This PR disables the pipe-to-function-call transformation, _even if the option is enabled_, in three cases:
    - inside macro calls (#439, out of an abundance of caution); 
    - the weird broadcast-over-function case (#647, there's no valid transformed output for this construct); and
    - inside `Expr`s (transforming it causes the `Expr` to become something completely different, which is incorrect).

3. This PR also fixes a number of other inconsistencies. Example:

```julia
using JuliaFormatter

s = """
x |> f
x |> !
x .|> !
x .|> f()
(x) |> f
x |> a.b
x |> a + b
"""

format_text(s; pipe_to_function_call=true) |> print
```

Here's the difference on current release (v2.5.4) vs this PR. As can be seen, this PR fixes several cases where the formatted text is either different to the original, or invalid Julia code. (Note that case 4 is #927)

```
     input          v2.5.4       this PR       notes

1    x |> f         f(x)         f(x)          unchanged
2    x |> !         !(x)         !(x)          unchanged
3    x .|> !        !.(x)        .!(x)         v2.5.4 is invalid code
4    x .|> f()      f()(x)       f().(x)       v2.5.4 transforms code wrongly
5    (x) |> f       f((x))       f(x)          v2.5.4 has extraneous parentheses
6    x |> a.b       a.b(x)       a.b(x)        unchanged
7    x |> a + b     a + b(x)     (a + b)(x)    v2.5.4 transforms code wrongly
```

For case 7, note that `+` has higher precedence than `|>`

```julia
julia> dump(:(x |> a + b))
Expr
  head: Symbol call
  args: Array{Any}((3,))
    1: Symbol |>
    2: Symbol x
    3: Expr
      head: Symbol call
      args: Array{Any}((3,))
        1: Symbol +
        2: Symbol a
        3: Symbol b
```

4. Fixes some cases where formatting with `pipe_to_function_call=true` was not idempotent, probably because of the transformation not making the same nesting decisions as it usually would. e.g.

```julia
s2 = """
function f()
    ps_mods = map(
        layer_mods -> (
            layer_mods === nothing ? () :
                map(l -> initialparameters(rng, l), layer_mods) |> Tuple
        ),
        mods
    ) |> Tuple
end
"""

using JuliaFormatter, Test
f(s) = format_text(s; pipe_to_function_call=true)
@test f(s2) == f(f(s2))
```

fails on v2.5.4, passes on this PR. (FWIW this is the output:)

```julia
julia> f(s2) |> print
function f()
    ps_mods = Tuple(
        map(
            layer_mods -> (
                layer_mods === nothing ? () :
                Tuple(map(l -> initialparameters(rng, l), layer_mods))
            ),
            mods,
        ),
    )
end
```