### PR TITLE
fix block if conditions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
-# NOTE: Do NOT use this config in your own repositories. Instead, see 
-#   docs/integrations.md
+# NOTE: This pre-commit configuration is meant for the JuliaFormatter repo itself.
+# Do not use this config in your own repositories! Instead, see
+# https://juliaeditorsupport.github.io/JuliaFormatter.jl/stable/precommit/
 repos:
 - repo: local
   hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,11 @@
   Create a temporary test environment with `Pkg.activate(; temp=true)`, `Pkg.develop(; path=...)` the current checkout of JuliaFormatter, and add any other packages you need.
 
 - Code changes in the local checkout should be immediately visible without having to reload the session (thanks to Revise.jl).
+
+# Tracing JuliaFormatter's output
+
+- Use the `JuliaFormatter.Internal.format_to_stage` function to inspect the output of each stage of the formatting process.
+  If `s` is a string containing the code to be formatted, then:
+
+  - `format_to_stage(:cst, s[, style]; options...)` gives the CST from JuliaSyntax;
+  - `format_to_stage(:fst, s[, style]; options...)` gives the initial FST that JuliaFormatter constructs from the CST using `pretty()`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,10 @@
 # Tracing JuliaFormatter's output
 
 - Use the `JuliaFormatter.Internal.format_to_stage` function to inspect the output of each stage of the formatting process.
-  If `s` is a string containing the code to be formatted, then:
+  If `s` is a string containing the code to be formatted, then `format_to_stage(stage, s[, style]; options...)` will give the output of the specified stage, where `stage` is one of:
 
-  - `format_to_stage(:cst, s[, style]; options...)` gives the CST from JuliaSyntax;
-  - `format_to_stage(:fst, s[, style]; options...)` gives the initial FST that JuliaFormatter constructs from the CST using `pretty()`.
+  - `:cst` gives the CST from JuliaSyntax;
+  - `:fst` gives the initial FST that JuliaFormatter constructs from the CST using `pretty()`;
+  - `:nest` gives the FST after flattening, alignment, and nesting;
+  - `:out` gives the final formatted string;
+  - `:print` prints the final formatted string.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Running Julia code
+
+- If you have a Julia MCP tool, always run code with that.
+  Don't invoke julia from bash as that is very slow.
+
+- Avoid using Julia environments that the user has already set up.
+  Create a temporary test environment with `Pkg.activate(; temp=true)`, `Pkg.develop(; path=...)` the current checkout of JuliaFormatter, and add any other packages you need.
+
+- Code changes in the local checkout should be immediately visible without having to reload the session (thanks to Revise.jl).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,6 +1,10 @@
 # v2.5.6
 
-Fixed a bug where JuliaFormatter would fail to format a condition (following an `if` or `elseif` keyword) was a block (e.g. `(a; b)` or `begin ... end`). (#1025, #1026)
+Fixed a bug where JuliaFormatter would emit invalid code when parsing an `if`/`elseif` with a block condition (e.g. `(a; b)` or `begin ... end`). (#1025, #1026)
+
+The same bug was present for `while` loops with similar block conditions.
+Although Julia would still parse the code correctly, the output was ugly.
+This PR therefore also fixes this. (#1026)
 
 # v2.5.5
 

--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,3 +1,7 @@
+# v2.5.6
+
+Fixed a bug where JuliaFormatter would fail to format a condition (following an `if` or `elseif` keyword) was a block (e.g. `(a; b)` or `begin ... end`). (#1025, #1026)
+
 # v2.5.5
 
 Fixed a number of issues with `pipe_to_function_call=true`:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.5.5"
+version = "2.5.6"
 authors = ["Dominique Luna <dluna132@gmail.com> and contributors"]
 
 [deps]

--- a/src/internal/utils.jl
+++ b/src/internal/utils.jl
@@ -26,6 +26,8 @@ Available stages:
    directly return the child.
 
  - `:fst`: the output of prettification.
+
+ - `:nest`: the nested FST.
  
  - `:out`: the string output of the formatter.
 
@@ -55,13 +57,61 @@ function format_to_stage(
     style::JF.AbstractStyle = JF.DefaultStyle();
     options...,
 )
+    # :cst
     cst = JS.parseall(JS.GreenNode, text)
-    stage in (:gn, :greennode, :parse, :cst) && return cst[1]
+    stage in (:gn, :cst) && return cst[1]
 
+    # :fst
     opts = JF.Options(; merge(JF.options(style), options)...)
     state = JF.State(JF.Document(text), opts)
     fst = JF.pretty(style, cst, state)
     stage === :fst && return fst
+
+    # :nest
+    if JF.hascomment(state.doc, fst.endline)
+        JF.add_node!(fst, JF.InlineComment(fst.endline), state)
+    end
+    JF.flatten_fst!(fst)
+    if state.opts.short_circuit_to_if
+        JF.short_circuit_to_if_pass!(fst, state)
+    end
+    if JF.needs_alignment(state.opts)
+        JF.align_fst!(fst, state.doc, state.opts)
+    end
+    JF.nest!(style, fst, state)
+    if state.opts.join_lines_based_on_source
+        JF.remove_superfluous_whitespace!(fst)
+    end
+    stage === :nest && return fst
+
+    # :out
+    state.line_offset = 0
+    io = IOBuffer()
+    if fst.startline > 1
+        JF.format_check(io, JF.Notcode(1, fst.startline - 1), state)
+        JF.print_leaf(io, JF.Newline(), state)
+    end
+    JF.print_tree(io, fst, state)
+    nlines = JF.numlines(state.doc)
+    if state.on && fst.endline < nlines
+        JF.print_leaf(io, JF.Newline(), state)
+        JF.format_check(io, JF.Notcode(fst.endline + 1, nlines), state)
+    end
+    if state.doc.ends_on_nl
+        JF.print_leaf(io, JF.Newline(), state)
+    end
+    out = String(take!(io))
+    replacer = if state.opts.normalize_line_endings == "unix"
+        JF.WINDOWS_TO_UNIX
+    elseif state.opts.normalize_line_endings == "windows"
+        JF.UNIX_TO_WINDOWS
+    else
+        JF.choose_line_ending_replacer(state.doc.srcfile.code)
+    end
+    out = JF.normalize_line_ending(out, replacer)
+    stage === :out && return out
+
+    stage === :print && return print(out)
 
     throw(ArgumentError("unknown stage: $stage"))
 end

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1721,24 +1721,39 @@ function p_for(
     end
 
     ends_in_iterable = false
+    is_while_cond = false
 
     for c in children(cst)
         if kind(c) in KSet"for while" && !haschildren(c)
             add_node!(t, pretty(style, c, s), s)
+            if kind(c) === K"while"
+                is_while_cond = true
+            end
         elseif kind(c) === K"end"
             add_node!(t, pretty(style, c, s), s)
         elseif kind(c) === K"block"
-            s.indent += s.opts.indent
-            n = pretty(style, c, s, newctx(ctx; ignore_single_line = true), lineage)
-            add_node!(t, n, s; max_padding = s.opts.indent)
-            s.indent -= s.opts.indent
+            # We need `is_while_cond` to determine whether the block we see is the body of
+            # the loop, or the condition of a while loop such as `while (a; b; c) ... end`.
+            # See also `p_if` for similar considerations.
+            if is_while_cond
+                add_node!(t, Whitespace(1), s)
+                add_node!(t, pretty(style, c, s), s; join_lines = true)
+                is_while_cond = false
+            else
+                # The body of the for/while loop.
+                s.indent += s.opts.indent
+                n = pretty(style, c, s, newctx(ctx; ignore_single_line = true), lineage)
+                add_node!(t, n, s; max_padding = s.opts.indent)
+                s.indent -= s.opts.indent
 
-            if !ends_in_iterable && (t.nodes::Vector{FST})[end-2].typ !== NOTCODE
-                insert!(t, length(t.nodes) - 1, Placeholder(0))
+                if !ends_in_iterable && (t.nodes::Vector{FST})[end-2].typ !== NOTCODE
+                    insert!(t, length(t.nodes) - 1, Placeholder(0))
+                end
             end
         elseif JuliaSyntax.is_whitespace(c)
             add_node!(t, pretty(style, c, s, ctx, lineage), s)
         else
+            # Non-block while conditions or for loop iterables fall here.
             add_node!(t, Whitespace(1), s)
             n = if kind(c) === K"iteration"
                 rhs_is_iterable = !iteration_has_comma(c) && is_iterable(iteration_rhs(c))

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1972,30 +1972,53 @@ function p_if(
         return t
     end
 
+    # Flag to indicate when we are processing the condition of an if or elseif.
+    is_cond = false
+
     for c in children(cst)
         if kind(c) in KSet"if elseif else"
             if !haschildren(c)
                 add_node!(t, pretty(style, c, s, ctx, lineage), s; max_padding = 0)
             else
+                # TODO(penelopeysm) how can an if/elseif/else keyword have a child?
                 len = length(t)
                 n = pretty(style, c, s, ctx, lineage)
                 add_node!(t, n, s)
                 t.len = max(len, length(n))
             end
+            if kind(c) in KSet"if elseif"
+                # The next non-whitespace node we see is the condition.
+                is_cond = true
+            end
         elseif kind(c) === K"end"
             add_node!(t, pretty(style, c, s, ctx, lineage), s)
         elseif kind(c) === K"block"
-            s.indent += s.opts.indent
-            add_node!(
-                t,
-                pretty(style, c, s, newctx(ctx; ignore_single_line = true), lineage),
-                s;
-                max_padding = s.opts.indent,
-            )
-            s.indent -= s.opts.indent
+            # This block could either be the condition (if it immediatelly follows an `if`
+            # or `elseif`, ignoring whitespace), or it could be the actual body. This is
+            # determined by the `is_cond` flag.
+            if is_cond
+                add_node!(t, Whitespace(1), s)
+                add_node!(t, pretty(style, c, s, ctx, lineage), s; join_lines = true)
+                # The next block will be the body.
+                is_cond = false
+            else
+                s.indent += s.opts.indent
+                add_node!(
+                    t,
+                    pretty(style, c, s, newctx(ctx; ignore_single_line = true), lineage),
+                    s;
+                    max_padding = s.opts.indent,
+                )
+                s.indent -= s.opts.indent
+            end
         elseif !JuliaSyntax.is_whitespace(c)
+            # This branch is hit for non-block conditions (i.e. simple things like the `x`
+            # in `if x; ...`).
             add_node!(t, Whitespace(1), s)
             add_node!(t, pretty(style, c, s, ctx, lineage), s; join_lines = true)
+            if is_cond # should be true, but check just to be safe
+                is_cond = false
+            end
         else
             add_node!(t, pretty(style, c, s, ctx, lineage), s)
         end
@@ -2122,7 +2145,7 @@ function p_pipe_to_call(
         " meaning that you must explicitly opt out. Alternatively, you can use" *
         " `#! format: off` and `#! format: on` to disable formatting for specific" *
         " sections of code that use `|>`."
-    ) maxlog=1
+    ) maxlog = 1
 
     call_node = FST(Call, nspaces(s))
     childs = children(cst)

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1736,9 +1736,9 @@ function p_for(
             # the loop, or the condition of a while loop such as `while (a; b; c) ... end`.
             # See also `p_if` for similar considerations.
             if is_while_cond
+                is_while_cond = false
                 add_node!(t, Whitespace(1), s)
                 add_node!(t, pretty(style, c, s), s; join_lines = true)
-                is_while_cond = false
             else
                 # The body of the for/while loop.
                 s.indent += s.opts.indent
@@ -1754,6 +1754,7 @@ function p_for(
             add_node!(t, pretty(style, c, s, ctx, lineage), s)
         else
             # Non-block while conditions or for loop iterables fall here.
+            is_while_cond = false
             add_node!(t, Whitespace(1), s)
             n = if kind(c) === K"iteration"
                 rhs_is_iterable = !iteration_has_comma(c) && is_iterable(iteration_rhs(c))

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -1497,19 +1497,15 @@
             end
 
             # Nesting
-            str_ = """
-            if (veryverylong; veryverylongtoo)
+            str_ = """if (veryverylong; veryverylongtoo)
                 f
-            end
-            """
-            str = """
-            if (
+            end"""
+            str = """if (
                 veryverylong;
                 veryverylongtoo
             )
                 f
-            end
-            """
+            end"""
             @test fmt(str_; margin=20) == str
         end
 

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -1454,6 +1454,65 @@
         end"""
         t = run_pretty(str, 80)
         @test length(t) == 14
+
+        @testset "block conditions" begin
+            # https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/1025
+            for block in (
+                "(a; b)",
+                "begin\n    a\n    b\nend\n",
+            )
+                str = """
+                if $block
+                    foo
+                end
+                """
+                @test fmt(str) == str
+
+                str = """
+                if x
+                    foo
+                elseif $block
+                    bar
+                end
+                """
+                @test fmt(str) == str
+
+                str = """
+                if $block
+                    foo
+                elseif $block
+                    bar
+                end
+                """
+                @test fmt(str) == str
+
+                str = """
+                if $block
+                    foo
+                else
+                    bar
+                end
+                """
+                @test fmt(str) == str
+            end
+
+            # Nesting
+            str_ = """
+            if (veryverylong; veryverylongtoo)
+                f
+            end
+            """
+            str = """
+            if (
+                veryverylong;
+                veryverylongtoo
+            )
+                f
+            end
+            """
+            @test fmt(str_; margin=20) == str
+        end
+
     end
 
     @testset "strings" begin

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -1235,6 +1235,30 @@
         end"""
         t = run_pretty(str, 80)
         @test length(t) == 27
+
+        @testset "block conditions" begin
+            s1 = """while (a; b)
+                c
+            end"""
+            @test fmt(s1) == s1
+            s2 = """while begin
+                a
+                b
+            end
+                c
+            end"""
+            @test fmt(s2) == s2
+            s3_ = """while (prettylong; prettylongtoo)
+                c
+            end"""
+            s3 = """while (
+                prettylong;
+                prettylongtoo
+            )
+                c
+            end"""
+            @test fmt(s3_, 4, 20) == s3
+        end
     end
 
     @testset "let" begin

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -1506,7 +1506,7 @@
             )
                 f
             end"""
-            @test fmt(str_; margin=20) == str
+            @test fmt(str_, 4, 20) == str
         end
 
     end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1964,4 +1964,25 @@
         s = "-0x1p1"
         @test fmt(s) == s
     end
+
+    @testset "1025" begin
+        # from julia@1.12.6 Compiler/src/typelimits.jl
+        s = """
+        if is_lattice_equal(𝕃, ai, bi) || is_lattice_equal(𝕃, ai, ft)
+            tyi = ai
+        elseif is_lattice_equal(𝕃, bi, ft)
+            tyi = bi
+        elseif (tyi′ = tmerge_field(𝕃, ai, bi); tyi′ !== nothing)
+            tyi = tyi′
+        else
+            tni = _typename(widenconst(ai))
+            if tni isa Const && tni === _typename(widenconst(bi))
+                tyi = typeintersect(ft, (tni.val::Core.TypeName).wrapper)
+            else
+                tyi = ft
+            end
+        end
+        """
+        @test fmt(s) == s
+    end
 end


### PR DESCRIPTION
Closes #1025

Prior to this PR, the following

```julia
if (a; b)
    foo
end
```

would get reformatted to

```julia
if
(a; b)
    foo
end
```

which would fail to parse. This patch prevents this. It also fixes the equivalent problem with `while` (even though the output of that one parses correctly, it's ugly and almost certainly unintended).
