### PR TITLE
Fix wrapped hcat ncat formatting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,11 +7,7 @@
   Create a temporary test environment with `Pkg.activate(; temp=true)`, `Pkg.develop(; path=...)` the current checkout of JuliaFormatter, and add any other packages you need.
 
 - Code changes in the local checkout should be immediately visible without having to reload the session (thanks to Revise.jl).
-
-# Running tests
-
-- Do not run the full test suite unless explicitly instructed to.
-  Only run specific, targeted tests that are relevant to the changes you are making.
+  If you encounter any issues with this, try restarting the MCP session.
 
 # Tracing JuliaFormatter's output
 
@@ -23,3 +19,10 @@
   - `:nest` gives the FST after flattening, alignment, and nesting;
   - `:out` gives the final formatted string;
   - `:print` prints the final formatted string.
+
+# Running tests
+
+- Do not run the full test suite unless explicitly instructed to.
+  Only run specific, targeted tests that are relevant to the changes you are making.
+
+- To test whether a string is valid Julia code, you can use `Meta.parse(s)` or `format_to_stage(:cst, s)`. Both throw if the code is invalid.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 
 # Tracing JuliaFormatter's output
 
-- Use the `JuliaFormatter.Internal.format_to_stage` function to inspect the output of each stage of the formatting process.
+- Always use the `JuliaFormatter.Internal.format_to_stage` function to inspect the output of each stage of the formatting process.
   If `s` is a string containing the code to be formatted, then `format_to_stage(stage, s[, style]; options...)` will give the output of the specified stage, where `stage` is one of:
 
   - `:cst` gives the CST from JuliaSyntax;
@@ -20,9 +20,26 @@
   - `:out` gives the final formatted string;
   - `:print` prints the final formatted string.
 
+  If `format_text` generates invalid Julia code, it will throw, which is unhelpful for debugging.
+  In such cases you should use `format_to_stage(:out, ...)` as that will show you the actual invalid code.
+
 # Running tests
 
 - Do not run the full test suite unless explicitly instructed to.
   Only run specific, targeted tests that are relevant to the changes you are making.
 
+- To test formatting, you should always use `JuliaFormatter.Internal.test_format(input_string, expected_output[, style]; options...)`, which checks that formatting `input_string` produces `expected_output`, and also for idempotence.
+  This function prints helpful information if it fails so that you can easily debug the issue.
+
 - To test whether a string is valid Julia code, you can use `Meta.parse(s)` or `format_to_stage(:cst, s)`. Both throw if the code is invalid.
+
+# Comment style
+
+JuliaFormatter is a complex codebase with many moving parts.
+Do not assume that other developers will understand terse comments as they do not have the same context as you.
+For example, when writing function-level comments, it's useful to illustrate your point with a concrete example of code that is being formatted.
+
+# Avoid hacks
+
+Do not use fragile heuristics or hacks to achieve the desired formatting.
+Where possible, you should always try to implement formatting logic at the CST stage (i.e. `pretty()`), because the CST has more precise structural information about the code being run.

--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,3 +1,7 @@
+# v2.6.1
+
+Fixed a bug where matrices with `;;\n` horizontal concatenation separators were being formatted into invalid code. (#1029)
+
 # v2.6.0
 
 Fixed a number of cases where the left-hand operand of binary operators would be aggressively nested.

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 CommonMark = "0.5, 0.6, 0.7, 0.8, 0.9, 0.10, 1"
@@ -16,6 +17,7 @@ Glob = "1.3"
 JuliaSyntax = "1"
 PrecompileTools = "1"
 TOML = "1"
+Test = "1.11.0"
 julia = "1.10"
 
 [apps.jlfmt]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.6.0"
+version = "2.6.1"
 authors = ["Dominique Luna <dluna132@gmail.com> and contributors"]
 
 [deps]
@@ -17,7 +17,7 @@ Glob = "1.3"
 JuliaSyntax = "1"
 PrecompileTools = "1"
 TOML = "1"
-Test = "1.11.0"
+Test = "1"
 julia = "1.10"
 
 [apps.jlfmt]

--- a/src/internal/utils.jl
+++ b/src/internal/utils.jl
@@ -150,19 +150,19 @@ function test_format(
 )
     out = JF.format_text(input, style; options...)
     if out != expected
-        printstyled("Formatting output did not match expected value.\n\n"; color=:cyan)
-        printstyled("Expected:\n$expected\n\n"; color=:green)
-        printstyled("Got:\n$out\n\n"; color=:red)
-        printstyled("Repro:\n$(_repro_hint(input, style, options))\n"; color=:cyan)
+        printstyled("Formatting output did not match expected value.\n\n"; color = :cyan)
+        printstyled("Expected:\n$expected\n\n"; color = :green)
+        printstyled("Got:\n$out\n\n"; color = :red)
+        printstyled("Repro:\n$(_repro_hint(input, style, options))\n"; color = :cyan)
     end
     @test out == expected
 
     out2 = JF.format_text(out, style; options...)
     if out2 != out
-        printstyled("Formatting was not idempotent.\n\n"; color=:cyan)
-        printstyled("First pass:\n$out\n\n"; color=:green)
-        printstyled("Second pass:\n$out2\n\n"; color=:red)
-        printstyled("Repro:\n$(_repro_hint(out, style, options))\n"; color=:cyan)
+        printstyled("Formatting was not idempotent.\n\n"; color = :cyan)
+        printstyled("First pass:\n$out\n\n"; color = :green)
+        printstyled("Second pass:\n$out2\n\n"; color = :red)
+        printstyled("Repro:\n$(_repro_hint(out, style, options))\n"; color = :cyan)
     end
     @test out2 == out
 end

--- a/src/internal/utils.jl
+++ b/src/internal/utils.jl
@@ -6,6 +6,7 @@ module Internal
 
 import JuliaSyntax as JS
 import ..JuliaFormatter as JF
+using Test
 
 """
     JuliaFormatter.Internal.format_to_stage(
@@ -114,6 +115,56 @@ function format_to_stage(
     stage === :print && return print(out)
 
     throw(ArgumentError("unknown stage: $stage"))
+end
+
+function _repro_hint(input, style, options)
+    opts_str = if isempty(options)
+        ""
+    else
+        "; " * join(["$k=$(repr(v))" for (k, v) in pairs(options)], ", ")
+    end
+    style_str = if style isa JF.DefaultStyle
+        ""
+    else
+        ", $(typeof(style))()"
+    end
+    return "format_text($(repr(input))$(style_str)$(opts_str))"
+end
+
+"""
+    JuliaFormatter.Internal.test_format(
+        input::AbstractString,
+        expected::AbstractString,
+        [style=DefaultStyle();]
+        options...
+    )
+
+Test that formatting `input` produces `expected`, and that `expected` is idempotent under
+formatting.
+"""
+function test_format(
+    input::AbstractString,
+    expected::AbstractString,
+    style::JF.AbstractStyle = JF.DefaultStyle();
+    options...,
+)
+    out = JF.format_text(input, style; options...)
+    if out != expected
+        printstyled("Formatting output did not match expected value.\n\n"; color=:cyan)
+        printstyled("Expected:\n$expected\n\n"; color=:green)
+        printstyled("Got:\n$out\n\n"; color=:red)
+        printstyled("Repro:\n$(_repro_hint(input, style, options))\n"; color=:cyan)
+    end
+    @test out == expected
+
+    out2 = JF.format_text(out, style; options...)
+    if out2 != out
+        printstyled("Formatting was not idempotent.\n\n"; color=:cyan)
+        printstyled("First pass:\n$out\n\n"; color=:green)
+        printstyled("Second pass:\n$out2\n\n"; color=:red)
+        printstyled("Repro:\n$(_repro_hint(out, style, options))\n"; color=:cyan)
+    end
+    @test out2 == out
 end
 
 end # module

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -118,7 +118,7 @@ function nest!(
         n_vect!(style, fst, s, lineage)
     elseif fst.typ === Vcat
         n_vcat!(style, fst, s, lineage)
-    elseif fst.typ === Hcat
+    elseif fst.typ === Hcat || fst.typ === TypedHcat
         n_hcat!(style, fst, s, lineage)
     elseif fst.typ === Ncat
         n_vcat!(style, fst, s, lineage)

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -453,7 +453,14 @@ function n_hcat!(
     lineage::Vector{Tuple{FNode,Union{Nothing,Metadata}}},
 )
     # Keep DefaultStyle's old fallback behavior while allowing style-specific Hcat hooks.
-    nest!(getstyle(ds), fst.nodes::Vector, s, fst.indent, lineage; extra_margin = fst.extra_margin)
+    nest!(
+        getstyle(ds),
+        fst.nodes::Vector,
+        s,
+        fst.indent,
+        lineage;
+        extra_margin = fst.extra_margin,
+    )
 end
 
 function n_braces!(

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -118,6 +118,8 @@ function nest!(
         n_vect!(style, fst, s, lineage)
     elseif fst.typ === Vcat
         n_vcat!(style, fst, s, lineage)
+    elseif fst.typ === Hcat
+        n_hcat!(style, fst, s, lineage)
     elseif fst.typ === Ncat
         n_vcat!(style, fst, s, lineage)
     elseif fst.typ === Braces
@@ -442,6 +444,15 @@ function n_vcat!(
     lineage::Vector{Tuple{FNode,Union{Nothing,Metadata}}},
 )
     n_tuple!(ds, fst, s, lineage)
+end
+
+function n_hcat!(
+    ds::AbstractStyle,
+    fst::FST,
+    s::State,
+    lineage::Vector{Tuple{FNode,Union{Nothing,Metadata}}},
+)
+    nest!(getstyle(ds), fst.nodes::Vector, s, fst.indent, lineage; extra_margin = fst.extra_margin)
 end
 
 function n_braces!(

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -452,15 +452,7 @@ function n_hcat!(
     s::State,
     lineage::Vector{Tuple{FNode,Union{Nothing,Metadata}}},
 )
-    # Keep DefaultStyle's old fallback behavior while allowing style-specific Hcat hooks.
-    nest!(
-        getstyle(ds),
-        fst.nodes::Vector,
-        s,
-        fst.indent,
-        lineage;
-        extra_margin = fst.extra_margin,
-    )
+    n_tuple!(ds, fst, s, lineage)
 end
 
 function n_braces!(

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -452,6 +452,7 @@ function n_hcat!(
     s::State,
     lineage::Vector{Tuple{FNode,Union{Nothing,Metadata}}},
 )
+    # Keep DefaultStyle's old fallback behavior while allowing style-specific Hcat hooks.
     nest!(getstyle(ds), fst.nodes::Vector, s, fst.indent, lineage; extra_margin = fst.extra_margin)
 end
 

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -3497,6 +3497,22 @@ function p_typedvcat(
     t
 end
 
+"""
+    is_newline_after_2semicolons(cst::JuliaSyntax.GreenNode, i::Int)
+
+Detect if child node `i` of `cst` is a newline that follows two semicolons. For example,
+this will detect the newline in constructs such as
+
+    [a b;;
+     c d]
+"""
+function is_newline_after_2semicolons(cst::JuliaSyntax.GreenNode, i::Int)
+    return i >= 3 &&
+        kind(cst[i]) === K"NewlineWs"
+        kind(cst[i - 1]) === K";" &&
+        kind(cst[i - 2]) === K";"
+end
+
 function p_hcat(
     ds::AbstractStyle,
     cst::JuliaSyntax.GreenNode,
@@ -3511,37 +3527,54 @@ function p_hcat(
     end
 
     childs = children(cst)
-    # st = kind(cst) === K"hcat" ? 1 : 2
     st = findfirst(n -> kind(n) === K"[", childs)::Int
+
+    # Deciding whether to nest hcat expressions
+    # -----------------------------------------
+    #
+    # hcat is very sensitive towards newlines. There are several potential 'hcat' separators
+    # that are allowed:
+    #
+    #  (1) spaces
+    #  (2) double semicolon
+    #  (3) double semicolon followed by newline
+    #
+    # Now, there are some Julia syntax rules that must be obeyed.
+    # (See: https://docs.julialang.org/en/v1/manual/arrays/#man-array-concatenation)
+    #
+    #  - (1) and (2) cannot be mixed, but (1) and (3) can be mixed.
+    #
+    #    This implies that if we have a (3), we *must not* remove the newline to make a (2).
+    #
+    #  - Otherwise, it's illegal to have a newline separator between hcat arguments. The
+    #    meaning of newline is 'vertical concatenation', and any vertical concat would turn
+    #    the hcat node into ncat, so a hcat node itself can't have newline separators.
+    #
+    #    This implies that we *must not* add newline separators on our own accord as that
+    #    would change the semantics.
+    #
+    #  - The only other place where newlines are allowed to be present are after the opening
+    #    `[` and before the closing `]`. Let's call these 'boundary newlines'.
+    #
+    #    We are allowed to decide whether to place boundary newlines. In other words, we can
+    #    safely insert Placeholder nodes at these positions. For hcat, we will elect to
+    #    always do so.
 
     for (i, a) in enumerate(childs)
         n = pretty(style, a, s, ctx, lineage)
-        if JuliaSyntax.is_whitespace(a)
-            # Wrapped ncat like `[a b;;\n c d]` reparses as Hcat with `;` leaves.
-            # That newline is syntactic, not cosmetic; joining it makes invalid Julia.
-            prev_idx = findprev(n -> !JuliaSyntax.is_whitespace(n), childs, i - 1)
-            prev_prev_idx = if isnothing(prev_idx)
-                nothing
-            else
-                findprev(n -> !JuliaSyntax.is_whitespace(n), childs, prev_idx - 1)
-            end
-            if kind(a) === K"NewlineWs" &&
-               !isnothing(prev_idx) &&
-               !isnothing(prev_prev_idx) &&
-               kind(childs[prev_idx]) === K";" &&
-               kind(childs[prev_prev_idx]) === K";"
+        if kind(a) === K"["
+            add_node!(t, n, s; join_lines = true)
+            add_node!(t, Placeholder(0), s)
+        elseif kind(a) === K"]"
+            add_node!(t, Placeholder(0), s)
+            add_node!(t, n, s; join_lines = true)
+        elseif JuliaSyntax.is_whitespace(a)
+            if is_newline_after_2semicolons(cst, i)
+                # See above: we cannot convert ';;\n' to ';;'
                 add_node!(t, Newline(; nest_behavior = AlwaysNest), s)
-            else
-                add_node!(t, n, s; join_lines = true)
-            end
-        elseif kind(a) === K";"
-            add_node!(t, n, s; join_lines = true)
-        elseif i > st
-            add_node!(t, n, s; join_lines = true)
-            next_idx = findnext(n -> !JuliaSyntax.is_whitespace(n), childs, i + 1)
-            # Do not manufacture whitespace between hcat entries and ncat separators.
-            if needs_placeholder(childs, i + 1, K"]") &&
-               !(!isnothing(next_idx) && kind(childs[next_idx]) === K";")
+            elseif !(kind(cst[i + 1]) in KSet"; ]")
+                # Don't print spaces before ';;' separators, since they do the same job.
+                # Same logic for the closing brace.
                 add_node!(t, Whitespace(1), s)
             end
         else

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -3508,9 +3508,9 @@ this will detect the newline in constructs such as
 """
 function is_newline_after_2semicolons(cst::JuliaSyntax.GreenNode, i::Int)
     return i >= 3 &&
-        kind(cst[i]) === K"NewlineWs" &&
-        kind(cst[i - 1]) === K";" &&
-        kind(cst[i - 2]) === K";"
+           kind(cst[i]) === K"NewlineWs" &&
+           kind(cst[i-1]) === K";" &&
+           kind(cst[i-2]) === K";"
 end
 
 function p_hcat(
@@ -3578,7 +3578,7 @@ function p_hcat(
                 # later on, `n_tuple!` will insert newlines after the `[` and before the
                 # `].`
                 t.nest_behavior = AlwaysNest
-            elseif !(kind(cst[i + 1]) in KSet"; ]") && kind(cst[i - 1]) !== K"["
+            elseif !(kind(cst[i+1]) in KSet"; ]") && kind(cst[i-1]) !== K"["
                 # Whitespace is generally important to retain, because it can be a separator
                 # -- but we should omit it in a few cases:
                 # 1. If it's followed by a ';;' separator, since it's not needed.

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -3478,10 +3478,25 @@ function p_hcat(
     for (i, a) in enumerate(childs)
         n = pretty(style, a, s, ctx, lineage)
         if JuliaSyntax.is_whitespace(a)
+            prev_idx = findprev(n -> !JuliaSyntax.is_whitespace(n), childs, i - 1)
+            prev_prev_idx = isnothing(prev_idx) ? nothing :
+                            findprev(n -> !JuliaSyntax.is_whitespace(n), childs, prev_idx - 1)
+            if kind(a) === K"NewlineWs" &&
+               !isnothing(prev_idx) &&
+               !isnothing(prev_prev_idx) &&
+               kind(childs[prev_idx]) === K";" &&
+               kind(childs[prev_prev_idx]) === K";"
+                add_node!(t, Newline(; nest_behavior = AlwaysNest), s)
+            else
+                add_node!(t, n, s; join_lines = true)
+            end
+        elseif kind(a) === K";"
             add_node!(t, n, s; join_lines = true)
         elseif i > st
             add_node!(t, n, s; join_lines = true)
-            if needs_placeholder(childs, i + 1, K"]")
+            next_idx = findnext(n -> !JuliaSyntax.is_whitespace(n), childs, i + 1)
+            if needs_placeholder(childs, i + 1, K"]") &&
+               !(!isnothing(next_idx) && kind(childs[next_idx]) === K";")
                 add_node!(t, Whitespace(1), s)
             end
         else

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -3478,6 +3478,8 @@ function p_hcat(
     for (i, a) in enumerate(childs)
         n = pretty(style, a, s, ctx, lineage)
         if JuliaSyntax.is_whitespace(a)
+            # Wrapped ncat like `[a b;;\n c d]` reparses as Hcat with `;` leaves.
+            # That newline is syntactic, not cosmetic; joining it makes invalid Julia.
             prev_idx = findprev(n -> !JuliaSyntax.is_whitespace(n), childs, i - 1)
             prev_prev_idx = isnothing(prev_idx) ? nothing :
                             findprev(n -> !JuliaSyntax.is_whitespace(n), childs, prev_idx - 1)
@@ -3495,6 +3497,7 @@ function p_hcat(
         elseif i > st
             add_node!(t, n, s; join_lines = true)
             next_idx = findnext(n -> !JuliaSyntax.is_whitespace(n), childs, i + 1)
+            # Do not manufacture whitespace between hcat entries and ncat separators.
             if needs_placeholder(childs, i + 1, K"]") &&
                !(!isnothing(next_idx) && kind(childs[next_idx]) === K";")
                 add_node!(t, Whitespace(1), s)

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -3508,7 +3508,7 @@ this will detect the newline in constructs such as
 """
 function is_newline_after_2semicolons(cst::JuliaSyntax.GreenNode, i::Int)
     return i >= 3 &&
-        kind(cst[i]) === K"NewlineWs"
+        kind(cst[i]) === K"NewlineWs" &&
         kind(cst[i - 1]) === K";" &&
         kind(cst[i - 2]) === K";"
 end
@@ -3572,9 +3572,18 @@ function p_hcat(
             if is_newline_after_2semicolons(cst, i)
                 # See above: we cannot convert ';;\n' to ';;'
                 add_node!(t, Newline(; nest_behavior = AlwaysNest), s)
-            elseif !(kind(cst[i + 1]) in KSet"; ]")
-                # Don't print spaces before ';;' separators, since they do the same job.
-                # Same logic for the closing brace.
+                # Additionally, because the contents of the hcat will be on different lines
+                # and there's no way to later un-nest it without breaking semantics, we can
+                # set the nest behaviour of the entire hcat to AlwaysNest. This means that
+                # later on, `n_tuple!` will insert newlines after the `[` and before the
+                # `].`
+                t.nest_behavior = AlwaysNest
+            elseif !(kind(cst[i + 1]) in KSet"; ]") && kind(cst[i - 1]) !== K"["
+                # Whitespace is generally important to retain, because it can be a separator
+                # -- but we should omit it in a few cases:
+                # 1. If it's followed by a ';;' separator, since it's not needed.
+                # 2. Directly after the opening bracket.
+                # 3. Directly before the closing bracket.
                 add_node!(t, Whitespace(1), s)
             end
         else

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -3481,8 +3481,11 @@ function p_hcat(
             # Wrapped ncat like `[a b;;\n c d]` reparses as Hcat with `;` leaves.
             # That newline is syntactic, not cosmetic; joining it makes invalid Julia.
             prev_idx = findprev(n -> !JuliaSyntax.is_whitespace(n), childs, i - 1)
-            prev_prev_idx = isnothing(prev_idx) ? nothing :
-                            findprev(n -> !JuliaSyntax.is_whitespace(n), childs, prev_idx - 1)
+            prev_prev_idx = if isnothing(prev_idx)
+                nothing
+            else
+                findprev(n -> !JuliaSyntax.is_whitespace(n), childs, prev_idx - 1)
+            end
             if kind(a) === K"NewlineWs" &&
                !isnothing(prev_idx) &&
                !isnothing(prev_prev_idx) &&

--- a/src/styles/yas/nest.jl
+++ b/src/styles/yas/nest.jl
@@ -224,7 +224,6 @@ function n_hcat!(
     s::State,
     lineage::Vector{Tuple{FNode,Union{Nothing,Metadata}}},
 )
-    # Wrapped ncat can reparse as Hcat; keep YAS alignment on that second pass.
     n_tuple!(ys, fst, s, lineage)
 end
 function n_bracescat!(

--- a/src/styles/yas/nest.jl
+++ b/src/styles/yas/nest.jl
@@ -207,6 +207,7 @@ function n_hcat!(
     s::State,
     lineage::Vector{Tuple{FNode,Union{Nothing,Metadata}}},
 )
+    # Wrapped ncat can reparse as Hcat; keep YAS alignment on that second pass.
     n_tuple!(ys, fst, s, lineage)
 end
 function n_bracescat!(

--- a/src/styles/yas/nest.jl
+++ b/src/styles/yas/nest.jl
@@ -201,6 +201,14 @@ function n_vcat!(
 )
     n_tuple!(ys, fst, s, lineage)
 end
+function n_hcat!(
+    ys::YASStyle,
+    fst::FST,
+    s::State,
+    lineage::Vector{Tuple{FNode,Union{Nothing,Metadata}}},
+)
+    n_tuple!(ys, fst, s, lineage)
+end
 function n_bracescat!(
     ys::YASStyle,
     fst::FST,

--- a/test/multidimensional_array.jl
+++ b/test/multidimensional_array.jl
@@ -52,6 +52,8 @@
     end
 
     @testset "wrapped hcat with ncat separators" begin
+        # Repeated semicolons are n-dimensional concatenation separators.
+        # They may follow an hcat row only when the next row is wrapped.
         separators = [";;", ";;;", ";;;;"]
         styles = (DefaultStyle(), YASStyle(), SciMLStyle())
 
@@ -69,6 +71,7 @@
                 @test JuliaSyntax.parseall(JuliaSyntax.GreenNode, str) isa
                       JuliaSyntax.GreenNode
 
+                # Styles choose different layouts here, so the invariant is parsability.
                 for style in styles
                     formatted = format_text(str, style; join_lines_based_on_source = false)
                     @test JuliaSyntax.parseall(JuliaSyntax.GreenNode, formatted) isa

--- a/test/multidimensional_array.jl
+++ b/test/multidimensional_array.jl
@@ -1,3 +1,11 @@
+module MultidimensionalArrayTests
+
+using JuliaFormatter
+using JuliaFormatter.Internal: test_format
+using Test
+
+ALL_STYLES = (DefaultStyle(), YASStyle(), BlueStyle(), MinimalStyle(), SciMLStyle())
+
 @testset "Multidimensional Arrays" begin
     @testset "hcat and typed_hcat nodes" begin
         # hcat nodes are the ones without T; typed_hcat nodes are the ones with T. Both
@@ -9,9 +17,13 @@
                     "x = $(T)[a b]",
                     "x = $(T)[a      b     ]",
                     )
-                    @test fmt(s) == "x = $(T)[a b]"
-                    @test fmt(s, 4, 5+length(T)) == "x = $(T)[\n    a b\n]"
+                    for style in ALL_STYLES
+                        test_format(s, "x = $(T)[a b]", style)
+                    end
+                    test_format(s, "x = $(T)[\n    a b\n]"; margin=5+length(T))
+                    # test_format(s, "x = $(T)[\n    a b\n    ]", SciMLStyle(); margin=5+length(T))
                 end
+
             end
 
             @testset ";;\\n only" begin
@@ -21,9 +33,16 @@
                     )
                     # because the original matrix is already split across a newline,
                     # the formatter will insert more newlines
-                    expected = "x = $(T)[\n    a;;\n    b\n]"
-                    @test fmt(s) == expected
-                    @test fmt(s, 4, 5+length(T)) == expected
+                    expected_default = "x = $(T)[\n    a;;\n    b\n]"
+                    test_format(s, expected_default)
+                    test_format(s, expected_default; margin=5+length(T))
+
+                    ws = " " ^ (5 + length(T))
+                    expected_sciml = "x = $(T)[a;;\n$(ws)b]"
+                    test_format(s, expected_sciml, SciMLStyle())
+                    test_format(s, expected_sciml, SciMLStyle(); margin=5+length(T))
+                    test_format(s, expected_sciml, YASStyle())
+                    test_format(s, expected_sciml, YASStyle(); margin=5+length(T))
                 end
             end
 
@@ -35,8 +54,15 @@
                     # because the original matrix is already split across a newline,
                     # the formatter will insert more newlines
                     expected = "x = $(T)[\n    a b;;\n    c d\n]"
-                    @test fmt(s) == expected
-                    @test fmt(s, 4, 5+length(T)) == expected
+                    test_format(s, expected)
+                    test_format(s, expected; margin=5+length(T))
+
+                    ws = " " ^ (5 + length(T))
+                    expected_sciml = "x = $(T)[a b;;\n$(ws)c d]"
+                    test_format(s, expected_sciml, SciMLStyle())
+                    test_format(s, expected_sciml, SciMLStyle(); margin=8+length(T))
+                    test_format(s, expected_sciml, YASStyle())
+                    test_format(s, expected_sciml, YASStyle(); margin=8+length(T))
                 end
             end
         end
@@ -45,53 +71,53 @@
     @testset "#490" begin
         @testset "DefaultStyle" begin
             str = "[1;; 2]"
-            @test fmt(str) == str
+            test_format(str, str)
 
             str_ = """
             [
                 1;;
                 2
             ]"""
-            @test fmt(str, 4, 1) == str_
+            test_format(str, str_; margin=1)
 
             str = "T[1;; 2]"
-            @test fmt(str) == str
+            test_format(str, str)
 
             str_ = """
             T[
                 1;;
                 2
             ]"""
-            @test fmt(str, 4, 1) == str_
+            test_format(str, str_; margin=1)
         end
 
         @testset "YASStyle" begin
             str = "[1;; 2]"
-            @test yasfmt(str) == str
+            test_format(str, str, YASStyle())
 
             str_ = """
             [1;;
              2]"""
-            @test yasfmt(str, 4, 1) == str_
+            test_format(str, str_, YASStyle(); margin=1)
 
             str = "T[1;; 2]"
-            @test yasfmt(str) == str
+            test_format(str, str, YASStyle())
 
             str_ = """
             T[1;;
               2]"""
-            @test yasfmt(str, 4, 1) == str_
+            test_format(str, str_, YASStyle(); margin=1)
         end
     end
 
     @testset "#620" begin
         s = "[1; 0;;]"
-        @test fmt(s) == s
-        @test yasfmt(s) == s
+        test_format(s, s)
+        test_format(s, s, YASStyle())
     end
 
     @testset "#582" begin
-        @test yasfmt("[a;b;;]") == "[a; b;;]"
+        test_format("[a;b;;]", "[a; b;;]", YASStyle())
     end
 
     @testset "#608" begin
@@ -99,18 +125,23 @@
         hcat([zeros(1); ones(3)], [zeros(2); ones(2)], [zeros(3); ones(1)], [zeros(1); ones(3)], [zeros(2); ones(2)], [zeros(3); ones(1)])
         """
         s2 = """
-        hcat([zeros(1); ones(3)], [zeros(2); ones(2)], [zeros(3); ones(1)],
-             [zeros(1); ones(3)], [zeros(2); ones(2)], [zeros(3); ones(1)])
+        hcat([zeros(1); ones(3)], [zeros(2); ones(2)], [zeros(3); ones(1)], [zeros(1); ones(3)],
+             [zeros(2); ones(2)], [zeros(3); ones(1)])
         """
-        @test yasfmt(s1) == s2
+        test_format(s1, s2, YASStyle())
     end
 
     @testset "#532" begin
         s = "(; a = [1;;], b = cos[2;;])"
-        @test fmt(s) == s
-        @test bluefmt(s) == s
-        @test yasfmt(s) == s
-        @test format_text(s, SciMLStyle()) == s
-        @test minimalfmt(s) == s
+        s_nospace = "(; a=[1;;], b=cos[2;;])"
+        for style in (DefaultStyle(), SciMLStyle())
+            test_format(s, s, style)
+        end
+        # whitespace_around_kwarg = false
+        for style in (BlueStyle(), YASStyle(), MinimalStyle())
+            test_format(s, s_nospace, style)
+        end
     end
 end
+
+end # module

--- a/test/multidimensional_array.jl
+++ b/test/multidimensional_array.jl
@@ -51,6 +51,33 @@
         @test yasfmt("[a;b;;]") == "[a; b;;]"
     end
 
+    @testset "wrapped hcat with ncat separators" begin
+        separators = [";;", ";;;", ";;;;"]
+        styles = (DefaultStyle(), YASStyle(), SciMLStyle())
+
+        for sep in separators
+            cases = (
+                # Source form: hcat rows wrapped before the ncat separator.
+                "x = [a\n     b$(sep)\n     c\n     d]",
+                "x = T[a\n      b$(sep)\n      c\n      d]",
+                # Formatted form: JuliaSyntax reparses this as hcat with separator tokens.
+                "x = [a b$(sep)\n     c d]",
+                "x = T[a b$(sep)\n      c d]",
+            )
+
+            for str in cases
+                @test JuliaSyntax.parseall(JuliaSyntax.GreenNode, str) isa
+                      JuliaSyntax.GreenNode
+
+                for style in styles
+                    formatted = format_text(str, style; join_lines_based_on_source = false)
+                    @test JuliaSyntax.parseall(JuliaSyntax.GreenNode, formatted) isa
+                          JuliaSyntax.GreenNode
+                end
+            end
+        end
+    end
+
     @testset "#608" begin
         s1 = """
         hcat([zeros(1); ones(3)], [zeros(2); ones(2)], [zeros(3); ones(1)], [zeros(1); ones(3)], [zeros(2); ones(2)], [zeros(3); ones(1)])

--- a/test/multidimensional_array.jl
+++ b/test/multidimensional_array.jl
@@ -26,7 +26,11 @@ ALL_STYLES = (DefaultStyle(), YASStyle(), BlueStyle(), MinimalStyle(), SciMLStyl
                     # place. But we can at least check for now that it parses to the same
                     # AST (meaning that at worst, it's ugly, but not wrong), and that it's
                     # idempotent.
-                    for style in ALL_STYLES, kwargs in ((;), (;margin=5+length(T)))
+                    for style in ALL_STYLES, kwargs in (
+                        (;),
+                        (;margin=5+length(T)),
+                        (;join_lines_based_on_source=false),
+                        )
                         out1 = format_text(s, style; kwargs...)
                         out2 = format_text(out1, style; kwargs...)
                         @test out1 == out2
@@ -71,7 +75,11 @@ ALL_STYLES = (DefaultStyle(), YASStyle(), BlueStyle(), MinimalStyle(), SciMLStyl
                     # place. But we can at least check for now that it parses to the same
                     # AST (meaning that at worst, it's ugly, but not wrong), and that it's
                     # idempotent.
-                    for style in ALL_STYLES, kwargs in ((;), (;margin=5+length(T)))
+                    for style in ALL_STYLES, kwargs in (
+                        (;),
+                        (;margin=5+length(T)),
+                        (;join_lines_based_on_source=false),
+                        )
                         out1 = format_text(s, style; kwargs...)
                         out2 = format_text(out1, style; kwargs...)
                         @test out1 == out2

--- a/test/multidimensional_array.jl
+++ b/test/multidimensional_array.jl
@@ -1,4 +1,47 @@
 @testset "Multidimensional Arrays" begin
+    @testset "hcat and typed_hcat nodes" begin
+        # hcat nodes are the ones without T; typed_hcat nodes are the ones with T. Both
+        # should more or less be formatted the same way.
+        for T in ("", "T")
+            @testset "spaces only" begin
+                # Additionally check that superfluous whitespace is removed.
+                for s in (
+                    "x = $(T)[a b]",
+                    "x = $(T)[a      b     ]",
+                    )
+                    @test fmt(s) == "x = $(T)[a b]"
+                    @test fmt(s, 4, 5+length(T)) == "x = $(T)[\n    a b\n]"
+                end
+            end
+
+            @testset ";;\\n only" begin
+                for s in (
+                    "x = $(T)[a;;\n b]",
+                    "x = $(T)[a    ;;\n   b   ]",
+                    )
+                    # because the original matrix is already split across a newline,
+                    # the formatter will insert more newlines
+                    expected = "x = $(T)[\n    a;;\n    b\n]"
+                    @test fmt(s) == expected
+                    @test fmt(s, 4, 5+length(T)) == expected
+                end
+            end
+
+            @testset "mixture of space and ;;\\n" begin
+                for s in (
+                    "x = $(T)[a b;;\n c d]",
+                    "x = $(T)[a    b   ;;\n   c    d   ]",
+                    )
+                    # because the original matrix is already split across a newline,
+                    # the formatter will insert more newlines
+                    expected = "x = $(T)[\n    a b;;\n    c d\n]"
+                    @test fmt(s) == expected
+                    @test fmt(s, 4, 5+length(T)) == expected
+                end
+            end
+        end
+    end
+
     @testset "#490" begin
         @testset "DefaultStyle" begin
             str = "[1;; 2]"
@@ -49,36 +92,6 @@
 
     @testset "#582" begin
         @test yasfmt("[a;b;;]") == "[a; b;;]"
-    end
-
-    @testset "wrapped hcat with ncat separators" begin
-        # Repeated semicolons are n-dimensional concatenation separators.
-        # They may follow an hcat row only when the next row is wrapped.
-        separators = [";;", ";;;", ";;;;"]
-        styles = (DefaultStyle(), YASStyle(), SciMLStyle())
-
-        for sep in separators
-            cases = (
-                # Source form: hcat rows wrapped before the ncat separator.
-                "x = [a\n     b$(sep)\n     c\n     d]",
-                "x = T[a\n      b$(sep)\n      c\n      d]",
-                # Formatted form: JuliaSyntax reparses this as hcat with separator tokens.
-                "x = [a b$(sep)\n     c d]",
-                "x = T[a b$(sep)\n      c d]",
-            )
-
-            for str in cases
-                @test JuliaSyntax.parseall(JuliaSyntax.GreenNode, str) isa
-                      JuliaSyntax.GreenNode
-
-                # Styles choose different layouts here, so the invariant is parsability.
-                for style in styles
-                    formatted = format_text(str, style; join_lines_based_on_source = false)
-                    @test JuliaSyntax.parseall(JuliaSyntax.GreenNode, formatted) isa
-                          JuliaSyntax.GreenNode
-                end
-            end
-        end
     end
 
     @testset "#608" begin

--- a/test/multidimensional_array.jl
+++ b/test/multidimensional_array.jl
@@ -21,7 +21,17 @@ ALL_STYLES = (DefaultStyle(), YASStyle(), BlueStyle(), MinimalStyle(), SciMLStyl
                         test_format(s, "x = $(T)[a b]", style)
                     end
                     test_format(s, "x = $(T)[\n    a b\n]"; margin=5+length(T))
-                    # test_format(s, "x = $(T)[\n    a b\n    ]", SciMLStyle(); margin=5+length(T))
+
+                    # TODO(penelopeysm): The indentation for other styles is all over the
+                    # place. But we can at least check for now that it parses to the same
+                    # AST (meaning that at worst, it's ugly, but not wrong), and that it's
+                    # idempotent.
+                    for style in ALL_STYLES, kwargs in ((;), (;margin=5+length(T)))
+                        out1 = format_text(s, style; kwargs...)
+                        out2 = format_text(out1, style; kwargs...)
+                        @test out1 == out2
+                        @test Meta.parse(out1) == Meta.parse(s)
+                    end
                 end
 
             end
@@ -57,12 +67,16 @@ ALL_STYLES = (DefaultStyle(), YASStyle(), BlueStyle(), MinimalStyle(), SciMLStyl
                     test_format(s, expected)
                     test_format(s, expected; margin=5+length(T))
 
-                    ws = " " ^ (5 + length(T))
-                    expected_sciml = "x = $(T)[a b;;\n$(ws)c d]"
-                    test_format(s, expected_sciml, SciMLStyle())
-                    test_format(s, expected_sciml, SciMLStyle(); margin=8+length(T))
-                    test_format(s, expected_sciml, YASStyle())
-                    test_format(s, expected_sciml, YASStyle(); margin=8+length(T))
+                    # TODO(penelopeysm): The indentation for other styles is all over the
+                    # place. But we can at least check for now that it parses to the same
+                    # AST (meaning that at worst, it's ugly, but not wrong), and that it's
+                    # idempotent.
+                    for style in ALL_STYLES, kwargs in ((;), (;margin=5+length(T)))
+                        out1 = format_text(s, style; kwargs...)
+                        out2 = format_text(out1, style; kwargs...)
+                        @test out1 == out2
+                        @test Meta.parse(out1) == Meta.parse(s)
+                    end
                 end
             end
         end

--- a/test/sciml_style.jl
+++ b/test/sciml_style.jl
@@ -156,6 +156,7 @@
     end
 
     @testset "wrapped hcat with ncat separator" begin
+        # SciML's fixpoint pass reparses this as Hcat; it must keep `;;` wrapped.
         str = raw"""
         x = [f(a=1)
              f(a=1);;

--- a/test/sciml_style.jl
+++ b/test/sciml_style.jl
@@ -155,6 +155,22 @@
         @test format_text(str2, SciMLStyle()) == str2
     end
 
+    @testset "wrapped hcat with ncat separator" begin
+        str = raw"""
+        x = [f(a=1)
+             f(a=1);;
+             f(a=2)
+             f(a=2)]
+        """
+        formatted_str = raw"""
+        x = [f(a = 1) f(a = 1);;
+             f(a = 2) f(a = 2)]
+        """
+
+        @test format_text(str, SciMLStyle(); join_lines_based_on_source = false) ==
+              formatted_str
+    end
+
     str = raw"""
     Dict{Int, Int}(1 => 2,
         3 => 4)


### PR DESCRIPTION
## Summary

Fix formatting for wrapped horizontal concatenation rows followed by repeated semicolon n-dimensional concatenation separators.

JuliaSyntax can parse a formatted result such as `[a b;;\n c d]` as an `Hcat` node with semicolon leaves rather than as the original `Ncat` shape. The formatter previously joined that syntactic newline and inserted whitespace between semicolon tokens, producing invalid Julia like `a b ; ; c d`.

This PR preserves the required newline after wrapped ncat separators, avoids manufacturing whitespace before semicolon separators, and adds explicit Hcat nesting hooks so YAS/SciML keep their second-pass alignment.

