### PR TITLE
Fix more hcat/ncat bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,9 @@
 - If you have a Julia MCP tool, always run code with that.
   Don't invoke julia from bash as that is very slow.
 
+- When running code in the MCP tool it's not easily visible to the user.
+  If you're e.g. checking how a string parses, you should explicitly report the user what you tested and what the result was.
+
 - Avoid using Julia environments that the user has already set up.
   Create a temporary test environment with `Pkg.activate(; temp=true)`, `Pkg.develop(; path=...)` the current checkout of JuliaFormatter, and add any other packages you need.
 
@@ -25,11 +28,10 @@
 
 # Running tests
 
-- Do not run the full test suite unless explicitly instructed to.
-  Only run specific, targeted tests that are relevant to the changes you are making.
-
-- To test formatting, you should always use `JuliaFormatter.Internal.test_format(input_string, expected_output[, style]; options...)`, which checks that formatting `input_string` produces `expected_output`, and also for idempotence.
-  This function prints helpful information if it fails so that you can easily debug the issue.
+- Do NOT run complete segments of the test suite unless explicitly instructed to.
+  Only run specific, targeted tests that are relevant to the changes you are making, using `JuliaFormatter.Internal.test_format(input_string, expected_output[, style]; options...)`
+  This function checks that formatting `input_string` produces `expected_output`, and also for idempotence.
+  It also prints helpful information if it fails so that you can easily debug the issue.
 
 - To test whether a string is valid Julia code, you can use `Meta.parse(s)` or `format_to_stage(:cst, s)`. Both throw if the code is invalid.
 
@@ -41,5 +43,8 @@ For example, when writing function-level comments, it's useful to illustrate you
 
 # Avoid hacks
 
-Do not use fragile heuristics or hacks to achieve the desired formatting.
-Where possible, you should always try to implement formatting logic at the CST stage (i.e. `pretty()`), because the CST has more precise structural information about the code being run.
+- Do not write off any valid syntactic construct as "pathological" or not worth supporting.
+  ALL valid Julia code should be supported by the formatter, even if it's not common in practice.
+
+- Do not use fragile heuristics or hacks to achieve the desired formatting.
+  Where possible, you should always try to implement formatting logic at the CST stage (i.e. `pretty()`), because the CST has more precise structural information about the code being run.

--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,6 +1,6 @@
 # v2.6.1
 
-Fixed a number of bugs where newlines in array literals were not being correctly handled, which meant that formatting led to either invalid code or silently different code. (#1029, #1037, #1038, #1039)
+Fixed a number of bugs where newlines in array literals were not being correctly handled, which caused JuliaFormatter to output invalid code (or worse!) silently different code. (#1029, #1037, #1038, #1039)
 
 # v2.6.0
 

--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,6 +1,6 @@
 # v2.6.1
 
-Fixed a bug where matrices with `;;\n` horizontal concatenation separators were being formatted into invalid code. (#1029)
+Fixed a number of bugs where newlines in array literals were not being correctly handled, which meant that formatting led to either invalid code or silently different code. (#1029, #1037, #1038, #1039)
 
 # v2.6.0
 

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -3792,7 +3792,9 @@ function p_row(
     #     of this node.
     # (b) Or this node will have an nrow/row child that ends with a newline.
 
+    last_node_ended_with_newline = false
     for (i, a) in enumerate(childs)
+        forced_newline = false
         nonest = is_opcall(a)
         # Threading is_last_ncat_or_nrow_arg through here handles case (b).
         is_last_ncat_or_nrow_arg =
@@ -3808,7 +3810,6 @@ function p_row(
             ),
             lineage,
         )
-
         if kind(a) === K";"
             add_node!(t, n, s; join_lines = true)
         elseif JuliaSyntax.is_whitespace(a)
@@ -3817,15 +3818,19 @@ function p_row(
                is_semantically_important_newline(cst, i, is_last_arg_of_parent)
                 # Must force this newline!
                 add_node!(t, Newline(; nest_behavior = AlwaysNest), s)
+                forced_newline = true
             else
                 add_node!(t, n, s; join_lines = true)
             end
         else
-            if !isnothing(first_arg_idx) && i > first_arg_idx
+            if !isnothing(first_arg_idx) &&
+               i > first_arg_idx &&
+               !last_node_ended_with_newline
                 add_node!(t, Whitespace(1), s; join_lines = true)
             end
             add_node!(t, n, s; join_lines = true)
         end
+        last_node_ended_with_newline = forced_newline || is_prev_newline(n)
     end
     t.nest_behavior = NeverNest
     t

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -3525,9 +3525,7 @@ function p_hcat(
     if !haschildren(cst)
         return t
     end
-
     childs = children(cst)
-    st = findfirst(n -> kind(n) === K"[", childs)::Int
 
     # Deciding whether to nest hcat expressions
     # -----------------------------------------
@@ -3560,6 +3558,7 @@ function p_hcat(
     #    safely insert Placeholder nodes at these positions. For hcat, we will elect to
     #    always do so.
 
+    # Note: for the indexing operations b need to check i > 1 since hcat must begin with a `[`.
     for (i, a) in enumerate(childs)
         n = pretty(style, a, s, ctx, lineage)
         if kind(a) === K"["
@@ -3587,6 +3586,13 @@ function p_hcat(
                 add_node!(t, Whitespace(1), s)
             end
         else
+            # Argument that is being hcatted. Annoyingly, there isn't always whitespace
+            # between hcat arguments (see e.g. `[1:2 3:4 5:6]`), so sometimes we have to
+            # manually add some ourselves.
+            # https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/1038
+            if !JuliaSyntax.is_whitespace(childs[i-1]) && kind(childs[i-1]) !== K"["
+                add_node!(t, Whitespace(1), s)
+            end
             add_node!(t, n, s; join_lines = true)
         end
     end

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -3795,14 +3795,26 @@ function p_row(
     for (i, a) in enumerate(childs)
         nonest = is_opcall(a)
         # Threading is_last_ncat_or_nrow_arg through here handles case (b).
-        is_last_ncat_or_nrow_arg = is_last_arg_of_parent && i == last_arg_idx && kind(a) in KSet"nrow row"
-        n = pretty(style, a, s, newctx(ctx; nonest = nonest, is_last_ncat_or_nrow_arg = is_last_ncat_or_nrow_arg), lineage)
+        is_last_ncat_or_nrow_arg =
+            is_last_arg_of_parent && i == last_arg_idx && kind(a) in KSet"nrow row"
+        n = pretty(
+            style,
+            a,
+            s,
+            newctx(
+                ctx;
+                nonest = nonest,
+                is_last_ncat_or_nrow_arg = is_last_ncat_or_nrow_arg,
+            ),
+            lineage,
+        )
 
         if kind(a) === K";"
             add_node!(t, n, s; join_lines = true)
         elseif JuliaSyntax.is_whitespace(a)
             # is_semantically_important_newline handles case (a)
-            if ctx.from_nrow && is_semantically_important_newline(cst, i, is_last_arg_of_parent)
+            if ctx.from_nrow &&
+               is_semantically_important_newline(cst, i, is_last_arg_of_parent)
                 # Must force this newline!
                 add_node!(t, Newline(; nest_behavior = AlwaysNest), s)
             else
@@ -3826,7 +3838,7 @@ function p_nrow(
     ctx::PrettyContext,
     lineage::Vector{Tuple{JuliaSyntax.Kind,Bool,Bool}},
 )
-    t = p_row(ds, cst, s, newctx(ctx; from_nrow=true), lineage)
+    t = p_row(ds, cst, s, newctx(ctx; from_nrow = true), lineage)
     t.typ = NRow
     t
 end

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -3566,6 +3566,8 @@ function p_hcat(
         elseif kind(a) === K"]"
             add_node!(t, Placeholder(0), s)
             add_node!(t, n, s; join_lines = true)
+        elseif kind(a) === K";"
+            add_node!(t, n, s; join_lines = true)
         elseif JuliaSyntax.is_whitespace(a)
             if is_newline_after_2semicolons(cst, i)
                 # See above: we cannot convert ';;\n' to ';;'

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -12,7 +12,15 @@
     from_ref::Bool = false
     from_colon::Bool = false
     from_for::Bool = false
+
+    # These two flags are used to compensate for weird structure of ncat and nrow
+    # nodes in JuliaSyntax. See p_ncat for more info
+    #
+    # indicates whether newlines inside are semantically meaningful
     from_nrow::Bool = false
+    # indicates whether newlines at the end are semantically meaningful
+    is_last_ncat_or_nrow_arg::Bool=false
+
     ignore_single_line::Bool = false
     from_quote::Bool = false
     join_body::Bool = false
@@ -3436,11 +3444,19 @@ function p_vcat(
     args = get_args(cst)
     nest = should_nest_call_args(args, s.opts.disallow_single_arg_nesting)
     childs = children(cst)
-    idx = findfirst(n -> kind(n) === K"[", childs)::Int
-    first_arg_idx = findnext(n -> !JuliaSyntax.is_whitespace(n), childs, idx + 1)
+    opening_idx = findfirst(n -> kind(n) === K"[", childs)::Int
+    closing_idx = findlast(n -> kind(n) === K"]", childs)::Int
+    first_arg_idx = findnext(n -> !JuliaSyntax.is_whitespace(n), childs, opening_idx + 1)
+    last_arg_idx = findprev(n -> !JuliaSyntax.is_whitespace(n), childs, closing_idx - 1)
 
     for (i, a) in enumerate(childs)
-        n = pretty(style, a, s, ctx, lineage)
+        n = if i == last_arg_idx
+            ctx2 = newctx(ctx; is_last_ncat_or_nrow_arg = true)
+            pretty(style, a, s, ctx2, lineage)
+        else
+            pretty(style, a, s)
+        end
+
         diff_line = t.endline != t.startline
         # If arguments are on different lines then always nest
         if diff_line
@@ -3706,21 +3722,21 @@ See comment in `p_row` for details.
 function is_semantically_important_newline(
     row_cst::JuliaSyntax.GreenNode,
     i::Int,
+    is_last_arg_of_parent::Bool,
 )
     kind(row_cst[i]) === K"NewlineWs" || return false
-
     n = length(children(row_cst))
     # Start of the row - not important
     i == 1 && return false
     # End of the row -- might be important
-    i == n && return kind(row_cst[i-1]) !== K";"
+    i == n && return (!is_last_arg_of_parent && kind(row_cst[i-1]) !== K";")
     # Otherwise it's important
     return true
 end
 
 # `nrow` and `row` nodes both delegate to this function, and the underlying logic is the
 # same, but newlines need to be handled differently, which motivates the `ctx.from_nrow`
-# flag.
+# and `ctx.is_last_ncat_or_nrow_arg` flags.
 #
 # In general for `row` nodes, newlines are unnecessary so can be collapsed to ordinary
 # whitespace.
@@ -3728,14 +3744,29 @@ end
 # However, for `nrow` nodes AND `row` children of `nrow` nodes, there are two kinds of
 # newlines:
 #
-#  - Newlines at the start at the end of the row OR at the end of the nrow with a preceding
-#    semicolon, for example, the ones in `[\n1; 2;;\n 3; 4]`. These are semantically
-#    unnecessary. Annoyingly, the parser sticks these inside the `nrow` node rather than at
-#    the top level `ncat` row!
+#  - Those that are semantically *necessary*, because they are used to indicate vertical
+#    concatenation. These can be:
 #
-#  - Newlines in the middle of the nrow, or at the end of the row WITHOUT a preceding
-#    semicolon, are semantically important because they represent vertical concatenation of
-#    elements, so we can't ignore them.
+#    (1) Newlines in the middle of the row: [1\n2;; 3\n4]
+#    (2) Newlines at the end of a row: [1 2 3\n4 5 6]. In general, all newlines at the end
+#        of a row are considered semantically important, with the exceptions listed below.
+#
+#  - Those that are semantically *unnecessary*. These could be:
+#
+#    (3) Newlines at the start of the row, e.g. [\n1 2;; 3 4].
+#    (4) Newlines at the end of the row but preceded by a semicolon, e.g. [1 2;;\n 3 4].
+#    (5) Newlines at the end of the row but before the closing brace, e.g. [1 2;; 3 4\n].
+#
+# The annoying thing about JuliaSyntax's parser is that all the newlines are placed inside
+# the child nodes rather than the parent nodes. For example, in the last example
+#
+#     [1 2;; 3 4\n]
+#
+# the newline is a child of the last row, rather than a child of the ncat. (If it were
+# the latter, then this would be trivial to handle since we could just check if it's the
+# last child before the closing brace!) This means that we have to thread this information
+# into each recursive pretty() call to tell us whether we are allowed to remove the newline
+# or not.
 function p_row(
     ds::AbstractStyle,
     cst::JuliaSyntax.GreenNode,
@@ -3743,7 +3774,7 @@ function p_row(
     ctx::PrettyContext,
     lineage::Vector{Tuple{JuliaSyntax.Kind,Bool,Bool}},
 )
-    is_nrow = ctx.from_nrow
+    is_last_arg_of_parent = ctx.is_last_ncat_or_nrow_arg
 
     style = getstyle(ds)
     t = FST(Row, nspaces(s))
@@ -3753,18 +3784,25 @@ function p_row(
 
     childs = children(cst)
     first_arg_idx = findfirst(n -> !JuliaSyntax.is_whitespace(n), childs)
+    last_arg_idx = findlast(n -> !JuliaSyntax.is_whitespace(n), childs)
+
+    # To detect the final newline i.e. (5) above, we need to handle two cases:
+    #
+    # (a) Either the newline is part of this node, in which case it will be the last child
+    #     of this node.
+    # (b) Or this node will have an nrow/row child that ends with a newline.
 
     for (i, a) in enumerate(childs)
-        n = if is_opcall(a)
-            pretty(style, a, s, newctx(ctx; nonest = true), lineage)
-        else
-            pretty(style, a, s, ctx, lineage)
-        end
+        nonest = is_opcall(a)
+        # Threading is_last_ncat_or_nrow_arg through here handles case (b).
+        is_last_ncat_or_nrow_arg = is_last_arg_of_parent && i == last_arg_idx && kind(a) in KSet"nrow row"
+        n = pretty(style, a, s, newctx(ctx; nonest = nonest, is_last_ncat_or_nrow_arg = is_last_ncat_or_nrow_arg), lineage)
 
         if kind(a) === K";"
             add_node!(t, n, s; join_lines = true)
         elseif JuliaSyntax.is_whitespace(a)
-            if is_nrow && is_semantically_important_newline(cst, i)
+            # is_semantically_important_newline handles case (a)
+            if ctx.from_nrow && is_semantically_important_newline(cst, i, is_last_arg_of_parent)
                 # Must force this newline!
                 add_node!(t, Newline(; nest_behavior = AlwaysNest), s)
             else

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -12,6 +12,7 @@
     from_ref::Bool = false
     from_colon::Bool = false
     from_for::Bool = false
+    from_nrow::Bool = false
     ignore_single_line::Bool = false
     from_quote::Bool = false
     join_body::Bool = false
@@ -3443,23 +3444,17 @@ function p_vcat(
         diff_line = t.endline != t.startline
         # If arguments are on different lines then always nest
         if diff_line
-            (t.nest_behavior = AlwaysNest)
-        else
-            false
+            t.nest_behavior = AlwaysNest
         end
 
         if kind(a) === K"["
             add_node!(t, n, s; join_lines = true)
             if nest
                 add_node!(t, Placeholder(0), s)
-            else
-                false
             end
         elseif kind(a) === K"]"
             if nest
                 add_node!(t, Placeholder(0), s)
-            else
-                false
             end
             add_node!(t, n, s; join_lines = true)
         elseif JuliaSyntax.is_whitespace(a)
@@ -3527,36 +3522,46 @@ function p_hcat(
     end
     childs = children(cst)
 
-    # Deciding whether to nest hcat expressions
-    # -----------------------------------------
+    # Handling newlines in hcat nodes
+    # -------------------------------
     #
-    # hcat is very sensitive towards newlines. There are several potential 'hcat' separators
-    # that are allowed:
+    # hcat is very sensitive towards newlines. There are several potential separators that
+    # *semantically*, lead to horizontal concatenation of the arguments:
     #
-    #  (1) spaces
-    #  (2) double semicolon
-    #  (3) double semicolon followed by newline
+    #  (A) spaces, e.g. `[1 2 3]`
+    #  (B) double semicolon, e.g. `[1;; 2;; 3;; 4]`
+    #  (C) double semicolon followed by newline, e.g. `[1;;\n 2;;\n 3;;\n 4]`
     #
-    # Now, there are some Julia syntax rules that must be obeyed.
-    # (See: https://docs.julialang.org/en/v1/manual/arrays/#man-array-concatenation)
+    # However, *syntactically*, an expression is only parsed as a `hcat` if it contains **at
+    # least one** space separator (i.e., (A)). That means that 
     #
-    #  - (1) and (2) cannot be mixed, but (1) and (3) can be mixed.
+    #    `[1 2 3]`         -> parsed as hcat
+    #    `[1 2;;\n3]`      -> parsed as hcat
     #
-    #    This implies that if we have a (3), we *must not* remove the newline to make a (2).
+    # but anything _without_ space separators is parsed as `ncat`, even if semantically
+    # it means the same thing as `hcat`.
     #
-    #  - Otherwise, it's illegal to have a newline separator between hcat arguments. The
-    #    meaning of newline is 'vertical concatenation', and any vertical concat would turn
-    #    the hcat node into ncat, so a hcat node itself can't have newline separators.
+    #    `[1;; 2;; 3]`     -> parsed as ncat
+    #    `[1;;\n2;;\n3]`   -> parsed as ncat
     #
-    #    This implies that we *must not* add newline separators on our own accord as that
-    #    would change the semantics.
+    # Now, the catch (see the Julia docs:)
+    # https://docs.julialang.org/en/v1/manual/arrays/#man-array-concatenation)
+    # is that (A) and (B) *cannot* be mixed, but (A) and (C) can be mixed.
     #
-    #  - The only other place where newlines are allowed to be present are after the opening
-    #    `[` and before the closing `]`. Let's call these 'boundary newlines'.
+    # Given that in this function we *must* have at least one (A) separator, this implies
+    # that if we have a (C) ";;\\n", we *must not* remove the newline to make a (B) ";;".
+    # Otherwise, this would lead to a mixture of (A) and (B), which is disallowed.
     #
-    #    We are allowed to decide whether to place boundary newlines. In other words, we can
-    #    safely insert Placeholder nodes at these positions. For hcat, we will elect to
-    #    always do so.
+    # Furthermore, it's otherwise illegal to have a newline separator between hcat
+    # arguments. The meaning of newline is 'vertical concatenation', and any vertical concat
+    # would turn the hcat node into ncat, so a hcat node itself can't have newline
+    # separators. This implies that we *must not* add newline separators on our own accord
+    # as that would change the semantics.
+    #
+    # The only other place where newlines are allowed to be present are after the opening
+    # `[` and before the closing `]`. Let's call these 'boundary newlines'. We are allowed
+    # to decide whether to place boundary newlines. In other words, we can safely insert
+    # Placeholder nodes at these positions.
 
     for (i, a) in enumerate(childs)
         n = pretty(style, a, s, ctx, lineage)
@@ -3622,6 +3627,43 @@ function p_ncat(
     ctx::PrettyContext,
     lineage::Vector{Tuple{JuliaSyntax.Kind,Bool,Bool}},
 )
+    # Unfortunately `ncat` nodes cover a diverse range of syntax and the way the parser
+    # groups it can be somewhat inconsistent at times.
+    #
+    # It's very lucky that we can simply delegate to `p_vcat` and have it Just Work; but
+    # it's still worth documenting and understanding this. The main reason why `p_vcat`
+    # handles it correctly is because the main separator is a sequence of semicolons (see
+    # (1)), and newlines inserted after those separators have no effect on the semantics.
+    # This is the same as for a vcat node which has single semicolons as separators.
+    #
+    # (1) In general, arguments to `ncat` are separated by 2 or more semicolons. The 'main'
+    #     separator is the longest contiguous sequence of semicolons.
+    #
+    #        `[1;; 2]` is ncat with main separator ';;'
+    #                           and arguments `1` and `2`
+    #
+    #        `[1; 2;; 3; 4]` is ncat with main separator ';;'
+    #                                 and arguments `1; 2` and `3; 4`
+    #
+    #        `[1; 2;; 3;;; 4]` is ncat with main separator ';;;'
+    #                                   and arguments `1; 2;; 3` and `4`
+    #
+    # (2) When the arguments don't contain semicolons, they are placed at the top level of
+    #     the `ncat` node. The semicolon separators that follow them are also placed at the
+    #     top level of the `ncat` node.
+    #
+    # (3) When the arguments themselves contain semicolons, they are further grouped into `nrow`
+    #     nodes. In the above examples, the arguments `1; 2`, `3; 4`, and `1; 2;; 3` are all
+    #     parsed as `nrow` nodes.
+    #
+    # (4) Main separators that follow `nrow` nodes are placed *inside* the `nrow` node, NOT
+    #     at the top level of the `ncat` node.
+    #
+    # (5) When `nrow` nodes contain different *levels* of semicolons, they themselves will
+    #     contain `nrow` nodes. Just like for `ncat` nodes, the 'main' separator for the
+    #     `nrow` node will be the longest contiguous sequence of semicolons. In the above
+    #     examples, the `nrow` node `1; 2;; 3` has main separator ';;' and arguments `1; 2`
+    #     `3`.
     t = p_vcat(ds, cst, s, ctx, lineage)
     t.typ = Ncat
     return t
@@ -3639,6 +3681,61 @@ function p_typedncat(
     t
 end
 
+"""
+    last_row_ends_with_newline
+
+Checks whether the last nrow or row element (recursively) ends in a newline.
+"""
+function last_row_ends_with_newline(cst::JuliaSyntax.GreenNode)
+    haschildren(cst) || return false
+
+    last_child = children(cst)[end]
+    if kind(last_child) in KSet"row nrow"
+        return last_row_ends_with_newline(last_child)
+    else
+        return kind(last_child) === K"NewlineWs"
+    end
+end
+
+"""
+    is_semantically_important_newline
+
+Checks whether the `i`-th child of `row_cst` is a newline that is semantically important.
+See comment in `p_row` for details.
+"""
+function is_semantically_important_newline(
+    row_cst::JuliaSyntax.GreenNode,
+    i::Int,
+)
+    kind(row_cst[i]) === K"NewlineWs" || return false
+
+    n = length(children(row_cst))
+    # Start of the row - not important
+    i == 1 && return false
+    # End of the row -- might be important
+    i == n && return kind(row_cst[i-1]) !== K";"
+    # Otherwise it's important
+    return true
+end
+
+# `nrow` and `row` nodes both delegate to this function, and the underlying logic is the
+# same, but newlines need to be handled differently, which motivates the `ctx.from_nrow`
+# flag.
+#
+# In general for `row` nodes, newlines are unnecessary so can be collapsed to ordinary
+# whitespace.
+#
+# However, for `nrow` nodes AND `row` children of `nrow` nodes, there are two kinds of
+# newlines:
+#
+#  - Newlines at the start at the end of the row OR at the end of the nrow with a preceding
+#    semicolon, for example, the ones in `[\n1; 2;;\n 3; 4]`. These are semantically
+#    unnecessary. Annoyingly, the parser sticks these inside the `nrow` node rather than at
+#    the top level `ncat` row!
+#
+#  - Newlines in the middle of the nrow, or at the end of the row WITHOUT a preceding
+#    semicolon, are semantically important because they represent vertical concatenation of
+#    elements, so we can't ignore them.
 function p_row(
     ds::AbstractStyle,
     cst::JuliaSyntax.GreenNode,
@@ -3646,6 +3743,8 @@ function p_row(
     ctx::PrettyContext,
     lineage::Vector{Tuple{JuliaSyntax.Kind,Bool,Bool}},
 )
+    is_nrow = ctx.from_nrow
+
     style = getstyle(ds)
     t = FST(Row, nspaces(s))
     if !haschildren(cst)
@@ -3665,7 +3764,12 @@ function p_row(
         if kind(a) === K";"
             add_node!(t, n, s; join_lines = true)
         elseif JuliaSyntax.is_whitespace(a)
-            add_node!(t, n, s; join_lines = true)
+            if is_nrow && is_semantically_important_newline(cst, i)
+                # Must force this newline!
+                add_node!(t, Newline(; nest_behavior = AlwaysNest), s)
+            else
+                add_node!(t, n, s; join_lines = true)
+            end
         else
             if !isnothing(first_arg_idx) && i > first_arg_idx
                 add_node!(t, Whitespace(1), s; join_lines = true)
@@ -3684,7 +3788,7 @@ function p_nrow(
     ctx::PrettyContext,
     lineage::Vector{Tuple{JuliaSyntax.Kind,Bool,Bool}},
 )
-    t = p_row(ds, cst, s, ctx, lineage)
+    t = p_row(ds, cst, s, newctx(ctx; from_nrow=true), lineage)
     t.typ = NRow
     t
 end

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -3558,7 +3558,6 @@ function p_hcat(
     #    safely insert Placeholder nodes at these positions. For hcat, we will elect to
     #    always do so.
 
-    # Note: for the indexing operations b need to check i > 1 since hcat must begin with a `[`.
     for (i, a) in enumerate(childs)
         n = pretty(style, a, s, ctx, lineage)
         if kind(a) === K"["
@@ -3585,6 +3584,9 @@ function p_hcat(
                 # 3. Directly before the closing bracket.
                 add_node!(t, Whitespace(1), s)
             end
+        elseif i == 1 && kind(a) !== K"["
+            # Type preceding the `[`, e.g. `T` in `T[1 2 3]`.
+            add_node!(t, n, s; join_lines = true)
         else
             # Argument that is being hcatted. Annoyingly, there isn't always whitespace
             # between hcat arguments (see e.g. `[1:2 3:4 5:6]`), so sometimes we have to

--- a/test/multidimensional_array.jl
+++ b/test/multidimensional_array.jl
@@ -12,6 +12,7 @@ ALL_STYLES = (DefaultStyle(), YASStyle(), BlueStyle(), MinimalStyle(), SciMLStyl
         for s in (
             "$(T)[1, 2, 3]",
             "$(T)[1:2 3:4 5:6]",
+            "$(T)[1, 2.3, 4//5]",
         )
             for style in ALL_STYLES
                 test_format(s, s)

--- a/test/multidimensional_array.jl
+++ b/test/multidimensional_array.jl
@@ -6,17 +6,41 @@ using Test
 
 ALL_STYLES = (DefaultStyle(), YASStyle(), BlueStyle(), MinimalStyle(), SciMLStyle())
 
-@testset "examples from docs" begin
+@testset "array literal examples from docs" begin
+    # Don't really care how it formats, but make sure that it parses to the same AST. Some
+    # of these are probably redundant; that's fine, we can just be safe.
+    #
     # https://docs.julialang.org/en/v1/manual/arrays/#man-array-literals
     for T in ("", "T")
         for s in (
             "$(T)[1, 2, 3]",
-            "$(T)[1:2 3:4 5:6]",
             "$(T)[1, 2.3, 4//5]",
+            "$(T)[1:2, 4:5]",
+            "$(T)[1:2\n 4:5\n 6]",
+            "$(T)[1:2  4:5  7:8]",
+            "$(T)[[1,2]  [4,5]  [7,8]]",
+            "$(T)[1 2 3]",
+            "$(T)[1;; 2;; 3;; 4]",
+            "$(T)[1 2\n 3 4]",
+            "$(T)[zeros(Int, 2, 2) [1; 2]\n [3 4]            5]",
+            "$(T)[[1 1]; 2 3; [4 4]]",
+            "$(T)[zeros(Int, 2, 2) ; [3 4] ;; [1; 2] ; 5]",
+            "$(T)[1:2; 4;; 1; 3:4]",
+            "$(T)[1; 2;; 3; 4;; 5; 6;;;\n 7; 8;; 9; 10;; 11; 12]",
+            # BROKEN
+            # "$(T)[1 3 5\n 2 4 6;;;\n 7 9 11\n 8 10 12]",
+            "$(T)[1 2;;; 3 4;;;; 5 6;;; 7 8]",
+            "$(T)[[1 2;;; 3 4];;;; [5 6];;; [7 8]]",
+            "$(T)[1 2 ;;\n 3 4]",
+            "$(T)[1;;]",
+            "$(T)[2; 3;;;]",
+            "$(T)[[1 2] [3 4]]",
         )
             for style in ALL_STYLES
-                test_format(s, s)
-                @test Meta.parse(s) == Meta.parse(format_text(s, style))
+                out1 = format_text(s, style)
+                out2 = format_text(out1, style)
+                @test out1 == out2
+                @test Meta.parse(out1) == Meta.parse(s)
             end
         end
     end

--- a/test/multidimensional_array.jl
+++ b/test/multidimensional_array.jl
@@ -6,13 +6,13 @@ using Test
 
 ALL_STYLES = (DefaultStyle(), YASStyle(), BlueStyle(), MinimalStyle(), SciMLStyle())
 
-@testset "array literal examples from docs" begin
+@testset "array literal examples" begin
     # Don't really care how it formats, but make sure that it parses to the same AST. Some
     # of these are probably redundant; that's fine, we can just be safe.
-    #
-    # https://docs.julialang.org/en/v1/manual/arrays/#man-array-literals
     for T in ("", "T")
         for s in (
+            # These are taken from the docs:
+            # https://docs.julialang.org/en/v1/manual/arrays/#man-array-literals
             "$(T)[1, 2, 3]",
             "$(T)[1, 2.3, 4//5]",
             "$(T)[1:2, 4:5]",
@@ -27,14 +27,17 @@ ALL_STYLES = (DefaultStyle(), YASStyle(), BlueStyle(), MinimalStyle(), SciMLStyl
             "$(T)[zeros(Int, 2, 2) ; [3 4] ;; [1; 2] ; 5]",
             "$(T)[1:2; 4;; 1; 3:4]",
             "$(T)[1; 2;; 3; 4;; 5; 6;;;\n 7; 8;; 9; 10;; 11; 12]",
-            # BROKEN
-            # "$(T)[1 3 5\n 2 4 6;;;\n 7 9 11\n 8 10 12]",
+            "$(T)[1 3 5\n 2 4 6;;;\n 7 9 11\n 8 10 12]",
             "$(T)[1 2;;; 3 4;;;; 5 6;;; 7 8]",
             "$(T)[[1 2;;; 3 4];;;; [5 6];;; [7 8]]",
             "$(T)[1 2 ;;\n 3 4]",
             "$(T)[1;;]",
             "$(T)[2; 3;;;]",
             "$(T)[[1 2] [3 4]]",
+
+            # These are supplements, not from the docs
+            "$(T)[1\n2;;\n3\n4]",
+            "$(T)[f(a)\n f(a);;\n f(a)\n f(a)]",
         )
             for style in ALL_STYLES
                 @testset let style = style

--- a/test/multidimensional_array.jl
+++ b/test/multidimensional_array.jl
@@ -38,6 +38,7 @@ ALL_STYLES = (DefaultStyle(), YASStyle(), BlueStyle(), MinimalStyle(), SciMLStyl
             # These are supplements, not from the docs
             "$(T)[1\n2;;\n3\n4]",
             "$(T)[f(a)\n f(a);;\n f(a)\n f(a)]",
+            "$(T)[\n1\n2;;\n3\n4\n]", # extra newlines
         )
             for style in ALL_STYLES
                 @testset let style = style

--- a/test/multidimensional_array.jl
+++ b/test/multidimensional_array.jl
@@ -38,6 +38,13 @@ ALL_STYLES = (DefaultStyle(), YASStyle(), BlueStyle(), MinimalStyle(), SciMLStyl
                     end
                 end
 
+                @testset "with call arguments" begin
+                    # https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/1038
+                    x = "$(T)[1:2 3:4 5:6]"
+                    for style in ALL_STYLES
+                        test_format(x, x)
+                    end
+                end
             end
 
             @testset ";;\\n only" begin

--- a/test/multidimensional_array.jl
+++ b/test/multidimensional_array.jl
@@ -37,10 +37,12 @@ ALL_STYLES = (DefaultStyle(), YASStyle(), BlueStyle(), MinimalStyle(), SciMLStyl
             "$(T)[[1 2] [3 4]]",
         )
             for style in ALL_STYLES
-                out1 = format_text(s, style)
-                out2 = format_text(out1, style)
-                @test out1 == out2
-                @test Meta.parse(out1) == Meta.parse(s)
+                @testset let style = style
+                    out1 = format_text(s, style)
+                    out2 = format_text(out1, style)
+                    @test out1 == out2
+                    @test Meta.parse(out1) == Meta.parse(s)
+                end
             end
         end
     end

--- a/test/multidimensional_array.jl
+++ b/test/multidimensional_array.jl
@@ -6,170 +6,164 @@ using Test
 
 ALL_STYLES = (DefaultStyle(), YASStyle(), BlueStyle(), MinimalStyle(), SciMLStyle())
 
-@testset "Multidimensional Arrays" begin
-    @testset "hcat and typed_hcat nodes" begin
-        # hcat nodes are the ones without T; typed_hcat nodes are the ones with T. Both
-        # should more or less be formatted the same way.
-        for T in ("", "T")
-            @testset "spaces only" begin
-                # Additionally check that superfluous whitespace is removed.
-                for s in (
-                    "x = $(T)[a b]",
-                    "x = $(T)[a      b     ]",
-                    )
-                    for style in ALL_STYLES
-                        test_format(s, "x = $(T)[a b]", style)
-                    end
-                    test_format(s, "x = $(T)[\n    a b\n]"; margin=5+length(T))
+@testset "examples from docs" begin
+    # https://docs.julialang.org/en/v1/manual/arrays/#man-array-literals
+    for T in ("", "T")
+        for s in (
+            "$(T)[1, 2, 3]",
+            "$(T)[1:2 3:4 5:6]",
+        )
+            for style in ALL_STYLES
+                test_format(s, s)
+                @test Meta.parse(s) == Meta.parse(format_text(s, style))
+            end
+        end
+    end
+end
 
-                    # TODO(penelopeysm): The indentation for other styles is all over the
-                    # place. But we can at least check for now that it parses to the same
-                    # AST (meaning that at worst, it's ugly, but not wrong), and that it's
-                    # idempotent.
-                    for style in ALL_STYLES, kwargs in (
-                        (;),
-                        (;margin=5+length(T)),
-                        (;join_lines_based_on_source=false),
-                        )
-                        out1 = format_text(s, style; kwargs...)
-                        out2 = format_text(out1, style; kwargs...)
-                        @test out1 == out2
-                        @test Meta.parse(out1) == Meta.parse(s)
-                    end
+@testset "hcat and typed_hcat nodes" begin
+    # hcat nodes are the ones without T; typed_hcat nodes are the ones with T. Both
+    # should more or less be formatted the same way.
+    for T in ("", "T")
+        @testset "spaces only" begin
+            # Additionally check that superfluous whitespace is removed.
+            for s in ("x = $(T)[a b]", "x = $(T)[a      b     ]")
+                for style in ALL_STYLES
+                    test_format(s, "x = $(T)[a b]", style)
                 end
+                test_format(s, "x = $(T)[\n    a b\n]"; margin = 5+length(T))
 
-                @testset "with call arguments" begin
-                    # https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/1038
-                    x = "$(T)[1:2 3:4 5:6]"
-                    for style in ALL_STYLES
-                        test_format(x, x)
-                    end
+                # TODO(penelopeysm): The indentation for other styles is all over the
+                # place. But we can at least check for now that it parses to the same
+                # AST (meaning that at worst, it's ugly, but not wrong), and that it's
+                # idempotent.
+                for style in ALL_STYLES,
+                    kwargs in
+                    ((;), (; margin = 5+length(T)), (; join_lines_based_on_source = false))
+
+                    out1 = format_text(s, style; kwargs...)
+                    out2 = format_text(out1, style; kwargs...)
+                    @test out1 == out2
+                    @test Meta.parse(out1) == Meta.parse(s)
                 end
             end
+        end
 
-            @testset ";;\\n only" begin
-                for s in (
-                    "x = $(T)[a;;\n b]",
-                    "x = $(T)[a    ;;\n   b   ]",
-                    )
-                    # because the original matrix is already split across a newline,
-                    # the formatter will insert more newlines
-                    expected_default = "x = $(T)[\n    a;;\n    b\n]"
-                    test_format(s, expected_default)
-                    test_format(s, expected_default; margin=5+length(T))
+        @testset ";;\\n only" begin
+            for s in ("x = $(T)[a;;\n b]", "x = $(T)[a    ;;\n   b   ]")
+                # because the original matrix is already split across a newline,
+                # the formatter will insert more newlines
+                expected_default = "x = $(T)[\n    a;;\n    b\n]"
+                test_format(s, expected_default)
+                test_format(s, expected_default; margin = 5+length(T))
 
-                    ws = " " ^ (5 + length(T))
-                    expected_sciml = "x = $(T)[a;;\n$(ws)b]"
-                    test_format(s, expected_sciml, SciMLStyle())
-                    test_format(s, expected_sciml, SciMLStyle(); margin=5+length(T))
-                    test_format(s, expected_sciml, YASStyle())
-                    test_format(s, expected_sciml, YASStyle(); margin=5+length(T))
-                end
+                ws = " " ^ (5 + length(T))
+                expected_sciml = "x = $(T)[a;;\n$(ws)b]"
+                test_format(s, expected_sciml, SciMLStyle())
+                test_format(s, expected_sciml, SciMLStyle(); margin = 5+length(T))
+                test_format(s, expected_sciml, YASStyle())
+                test_format(s, expected_sciml, YASStyle(); margin = 5+length(T))
             end
+        end
 
-            @testset "mixture of space and ;;\\n" begin
-                for s in (
-                    "x = $(T)[a b;;\n c d]",
-                    "x = $(T)[a    b   ;;\n   c    d   ]",
-                    )
-                    # because the original matrix is already split across a newline,
-                    # the formatter will insert more newlines
-                    expected = "x = $(T)[\n    a b;;\n    c d\n]"
-                    test_format(s, expected)
-                    test_format(s, expected; margin=5+length(T))
+        @testset "mixture of space and ;;\\n" begin
+            for s in ("x = $(T)[a b;;\n c d]", "x = $(T)[a    b   ;;\n   c    d   ]")
+                # because the original matrix is already split across a newline,
+                # the formatter will insert more newlines
+                expected = "x = $(T)[\n    a b;;\n    c d\n]"
+                test_format(s, expected)
+                test_format(s, expected; margin = 5+length(T))
 
-                    # TODO(penelopeysm): The indentation for other styles is all over the
-                    # place. But we can at least check for now that it parses to the same
-                    # AST (meaning that at worst, it's ugly, but not wrong), and that it's
-                    # idempotent.
-                    for style in ALL_STYLES, kwargs in (
-                        (;),
-                        (;margin=5+length(T)),
-                        (;join_lines_based_on_source=false),
-                        )
-                        out1 = format_text(s, style; kwargs...)
-                        out2 = format_text(out1, style; kwargs...)
-                        @test out1 == out2
-                        @test Meta.parse(out1) == Meta.parse(s)
-                    end
+                # TODO(penelopeysm): The indentation for other styles is all over the
+                # place. But we can at least check for now that it parses to the same
+                # AST (meaning that at worst, it's ugly, but not wrong), and that it's
+                # idempotent.
+                for style in ALL_STYLES,
+                    kwargs in
+                    ((;), (; margin = 5+length(T)), (; join_lines_based_on_source = false))
+
+                    out1 = format_text(s, style; kwargs...)
+                    out2 = format_text(out1, style; kwargs...)
+                    @test out1 == out2
+                    @test Meta.parse(out1) == Meta.parse(s)
                 end
             end
         end
     end
+end
 
-    @testset "#490" begin
-        @testset "DefaultStyle" begin
-            str = "[1;; 2]"
-            test_format(str, str)
+@testset "#490" begin
+    @testset "DefaultStyle" begin
+        str = "[1;; 2]"
+        test_format(str, str)
 
-            str_ = """
-            [
-                1;;
-                2
-            ]"""
-            test_format(str, str_; margin=1)
+        str_ = """
+        [
+            1;;
+            2
+        ]"""
+        test_format(str, str_; margin = 1)
 
-            str = "T[1;; 2]"
-            test_format(str, str)
+        str = "T[1;; 2]"
+        test_format(str, str)
 
-            str_ = """
-            T[
-                1;;
-                2
-            ]"""
-            test_format(str, str_; margin=1)
-        end
-
-        @testset "YASStyle" begin
-            str = "[1;; 2]"
-            test_format(str, str, YASStyle())
-
-            str_ = """
-            [1;;
-             2]"""
-            test_format(str, str_, YASStyle(); margin=1)
-
-            str = "T[1;; 2]"
-            test_format(str, str, YASStyle())
-
-            str_ = """
-            T[1;;
-              2]"""
-            test_format(str, str_, YASStyle(); margin=1)
-        end
+        str_ = """
+        T[
+            1;;
+            2
+        ]"""
+        test_format(str, str_; margin = 1)
     end
 
-    @testset "#620" begin
-        s = "[1; 0;;]"
-        test_format(s, s)
-        test_format(s, s, YASStyle())
-    end
+    @testset "YASStyle" begin
+        str = "[1;; 2]"
+        test_format(str, str, YASStyle())
 
-    @testset "#582" begin
-        test_format("[a;b;;]", "[a; b;;]", YASStyle())
-    end
+        str_ = """
+        [1;;
+         2]"""
+        test_format(str, str_, YASStyle(); margin = 1)
 
-    @testset "#608" begin
-        s1 = """
-        hcat([zeros(1); ones(3)], [zeros(2); ones(2)], [zeros(3); ones(1)], [zeros(1); ones(3)], [zeros(2); ones(2)], [zeros(3); ones(1)])
-        """
-        s2 = """
-        hcat([zeros(1); ones(3)], [zeros(2); ones(2)], [zeros(3); ones(1)], [zeros(1); ones(3)],
-             [zeros(2); ones(2)], [zeros(3); ones(1)])
-        """
-        test_format(s1, s2, YASStyle())
-    end
+        str = "T[1;; 2]"
+        test_format(str, str, YASStyle())
 
-    @testset "#532" begin
-        s = "(; a = [1;;], b = cos[2;;])"
-        s_nospace = "(; a=[1;;], b=cos[2;;])"
-        for style in (DefaultStyle(), SciMLStyle())
-            test_format(s, s, style)
-        end
-        # whitespace_around_kwarg = false
-        for style in (BlueStyle(), YASStyle(), MinimalStyle())
-            test_format(s, s_nospace, style)
-        end
+        str_ = """
+        T[1;;
+          2]"""
+        test_format(str, str_, YASStyle(); margin = 1)
+    end
+end
+
+@testset "#620" begin
+    s = "[1; 0;;]"
+    test_format(s, s)
+    test_format(s, s, YASStyle())
+end
+
+@testset "#582" begin
+    test_format("[a;b;;]", "[a; b;;]", YASStyle())
+end
+
+@testset "#608" begin
+    s1 = """
+    hcat([zeros(1); ones(3)], [zeros(2); ones(2)], [zeros(3); ones(1)], [zeros(1); ones(3)], [zeros(2); ones(2)], [zeros(3); ones(1)])
+    """
+    s2 = """
+    hcat([zeros(1); ones(3)], [zeros(2); ones(2)], [zeros(3); ones(1)], [zeros(1); ones(3)],
+         [zeros(2); ones(2)], [zeros(3); ones(1)])
+    """
+    test_format(s1, s2, YASStyle())
+end
+
+@testset "#532" begin
+    s = "(; a = [1;;], b = cos[2;;])"
+    s_nospace = "(; a=[1;;], b=cos[2;;])"
+    for style in (DefaultStyle(), SciMLStyle())
+        test_format(s, s, style)
+    end
+    # whitespace_around_kwarg = false
+    for style in (BlueStyle(), YASStyle(), MinimalStyle())
+        test_format(s, s_nospace, style)
     end
 end
 

--- a/test/multidimensional_array.jl
+++ b/test/multidimensional_array.jl
@@ -9,7 +9,7 @@ ALL_STYLES = (DefaultStyle(), YASStyle(), BlueStyle(), MinimalStyle(), SciMLStyl
 @testset "array literal examples" begin
     # Don't really care how it formats, but make sure that it parses to the same AST. Some
     # of these are probably redundant; that's fine, we can just be safe.
-    for T in ("", "T")
+    for T in ("", "T", "x = ")
         for s in (
             # These are taken from the docs:
             # https://docs.julialang.org/en/v1/manual/arrays/#man-array-literals
@@ -119,6 +119,26 @@ end
                 end
             end
         end
+    end
+end
+
+@testset "ncat and typed ncat nodes" begin
+    @testset "newline and ;;" begin
+        s = "[1\n2;;\n3\n4]"
+        # Default and Blue style will impose the standard 4-space indentation
+        expected_indent4 = "[\n    1\n    2;;\n    3\n    4\n]"
+        # SciML and YAS style will indent to the opening brace
+        expected_indent1 = "[1\n 2;;\n 3\n 4]"
+        for style in (DefaultStyle(), BlueStyle())
+            test_format(s, expected_indent4, style)
+            test_format(s, expected_indent4, style; margin = 1)
+        end
+        for style in (SciMLStyle(), YASStyle())
+            test_format(s, expected_indent1, style)
+            test_format(s, expected_indent1, style; margin = 1)
+        end
+        # MinimalStyle is weird...
+        test_format(s, "[1\n    2;;\n    3\n    4]", MinimalStyle())
     end
 end
 

--- a/test/sciml_style.jl
+++ b/test/sciml_style.jl
@@ -155,23 +155,6 @@
         @test format_text(str2, SciMLStyle()) == str2
     end
 
-    @testset "wrapped hcat with ncat separator" begin
-        # SciML's fixpoint pass reparses this as Hcat; it must keep `;;` wrapped.
-        str = raw"""
-        x = [f(a=1)
-             f(a=1);;
-             f(a=2)
-             f(a=2)]
-        """
-        formatted_str = raw"""
-        x = [f(a = 1) f(a = 1);;
-             f(a = 2) f(a = 2)]
-        """
-
-        @test format_text(str, SciMLStyle(); join_lines_based_on_source = false) ==
-              formatted_str
-    end
-
     str = raw"""
     Dict{Int, Int}(1 => 2,
         3 => 4)


### PR DESCRIPTION
Closes #1037 (P5)
Closes #1038 (P5)

This was a massive pain to work out, especially the ncat parts. The problem is twofold:

1. Julia's syntax is context-sensitive in a tricky way. Sometimes newlines are important, sometimes they aren't. The rules for this, which I worked out by some not-fun trial and error, are described in the comment above p_row

    https://github.com/JuliaEditorSupport/JuliaFormatter.jl/blob/c236484aaca404ad2855be130caadbc21a49e5b0/src/styles/default/pretty.jl#L3737-L3769

2. If that was it, that would be fine. But JuliaSyntax's parser places the newlines in a very weird place. Naively, one might think that something like `[\n1\n2;;\n3\n4\n]` would parse to something like this, which would make it quite easy to detect the different cases that comment describes:

```
ncat
  [
  \n       <- first child after [, not significant
  nrow
    1
    \n       <- not at the end & not preceded by semicolon, significant
    2
  ;
  ;
  \n          <- preceded by semicolon, not significant
  nrow
    3
    \n       <- not at the end & not preceded by semicolon, significant
    4
  \n       <- last child before ], not significant
  ]
```

Alas, no:
 
```julia
julia> JuliaFormatter.Internal.format_to_stage(:cst, "[\n1\n2;;\n3\n4\n]")
     1:13     │[ncat]
     1:1      │  [
     2:8      │  [nrow]
     2:2      │    NewlineWs
     3:3      │    Integer              ✔
     4:4      │    NewlineWs
     5:5      │    Integer              ✔
     6:6      │    ;
     7:7      │    ;
     8:8      │    NewlineWs
     9:12     │  [nrow]
     9:9      │    Integer              ✔
    10:10     │    NewlineWs
    11:11     │    Integer              ✔
    12:12     │    NewlineWs
    13:13     │  ]
```

So the `;`'s and the newlines are not at the top level of where they should be, but are rather included as part of the child nodes.

This PR fixes it in what I consider a very ugly way, by threading state through the various `p_...` calls and using that to determine whether or not to emit the newline. Personally, I would much rather have preferred to heavily refactor JuliaFormatter to get rid of this (see e.g. #1032). Basically, I would like to implement a CST normalisation pass to convert JuliaSyntax's output into something more like the idealised version above.

However, because this PR fixes not one but two high-severity bugs, I think on balance it's more important to get this out.