### PR TITLE
stop using *fmt test helpers

### DIFF
--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -32,7 +32,7 @@ The exact label for an issue is left to my discretion, but generally these are t
 Additionally where possible I'll also add **good first issue** tags for changes that are quite self-contained.
 These may include any priority level but should generally be P3 or lower.
 
-You can see a list of all triaged issues [here](https://github.com/orgs/JuliaEditorSupport/projects/1/views/1).
+You can see a list of all triaged issues [here](https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues?q=is%3Aissue%20state%3Aopen%20label%3AP5%2CP4%2CP3%2CP2%2CP1).
 
 ## AI usage
 

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1,4 +1,4 @@
-function test_format(fmt, before, after)
+function test_format_file(fmt, before, after)
     sandbox_dir = joinpath(@__DIR__, "tmp")
     mkdir(sandbox_dir)
     try
@@ -18,14 +18,14 @@ end
         pos = path -> f(path, BlueStyle())
         key = path -> f(path; style = BlueStyle())
         after = "foo(; k=v)"
-        test_format(pos, before, after)
-        test_format(key, before, after)
+        test_format_file(pos, before, after)
+        test_format_file(key, before, after)
     end
     @testset "other keywords take affect" begin
         pos = path -> f(path, BlueStyle(); whitespace_in_kwargs = true)
         key = path -> f(path; style = BlueStyle(), whitespace_in_kwargs = true)
         after = "foo(; k = v)"
-        test_format(pos, before, after)
-        test_format(key, before, after)
+        test_format_file(pos, before, after)
+        test_format_file(key, before, after)
     end
 end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -726,7 +726,7 @@ end
         new{T1,
             T2}(arg1,
                 arg2)"""
-        test_format(str_, str, YASStyle(); m = 1)
+        test_format(str_, str, YASStyle(); margin = 1)
     end
 
     if VERSION >= v"1.6.0"
@@ -789,13 +789,13 @@ end
         [z for y in x for z in y]
         """
         test_format(str, str, YASStyle())
-        test_format(str, str, YASStyle(); m = 25)
+        test_format(str, str, YASStyle(); margin = 25)
 
         str_ = """
         [z for y in x
          for z in y]
         """
-        test_format(str, str_, YASStyle(); m = 24)
+        test_format(str, str_, YASStyle(); margin = 24)
 
         str_ = """
         [z
@@ -804,7 +804,7 @@ end
          for z in
              y]
         """
-        test_format(str, str_, YASStyle(); m = 1)
+        test_format(str, str_, YASStyle(); margin = 1)
     end
 
     @testset "issue 427" begin
@@ -850,7 +850,7 @@ end
         end
         """
         test_format(str_, str; margin = 1)
-        test_format(str_, str, BlueStyle(); m = 1)
+        test_format(str_, str, BlueStyle(); margin = 1)
     end
 
     @testset "issue 431" begin
@@ -1250,12 +1250,12 @@ end
     @testset "533" begin
         # semicolon should not be added prior to `extrap` since it's a function definition.
         s = "function linterp(x0::T, y0::T, x1::T, y1::T, x::T, extrap::Bool = false)::T where {T<:AbstractFloat} end"
-        test_format(s, s, BlueStyle(); m = 200)
-        test_format(s, s, YASStyle(); m = 200)
+        test_format(s, s, BlueStyle(); margin = 200)
+        test_format(s, s, YASStyle(); margin = 200)
 
         s = "function linterp(x0::T, y0::T, x1::T, y1::T, x::T, extrap::Bool = false)::T end"
-        test_format(s, s, BlueStyle(); m = 200)
-        test_format(s, s, YASStyle(); m = 200)
+        test_format(s, s, BlueStyle(); margin = 200)
+        test_format(s, s, YASStyle(); margin = 200)
     end
 
     @testset "541" begin

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1,3 +1,28 @@
+module IssuesTests
+
+using JuliaFormatter
+using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, MinimalStyle, Options, format_text
+using JuliaFormatter.Internal: test_format
+using JuliaSyntax
+using Test
+
+function run_nest(text::String; opts = Options(), style = DefaultStyle())
+    d = JuliaFormatter.Document(text)
+    s = JuliaFormatter.State(d, opts)
+    g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text)
+    t = JuliaFormatter.pretty(style, g, s)
+    JuliaFormatter.nest!(style, t, s)
+    t, s
+end
+
+function run_format(text::String; style = DefaultStyle(), opts = Options())
+    d = JuliaFormatter.Document(text)
+    s = JuliaFormatter.State(d, opts)
+    g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text)
+    JuliaFormatter.format_text(g, style, s)
+    s
+end
+
 @testset "GitHub Issues" begin
     @testset "issue #137" begin
         str = """
@@ -16,7 +41,7 @@
                    x
                end for x in xs
          )"""
-        @test fmt(str_) == str
+        test_format(str_, str)
 
         str = """
         (
@@ -35,7 +60,7 @@
               end
               x
           end for x in xs)"""
-        @test fmt(str_) == str
+        test_format(str_, str)
 
         str = """
         let n = try
@@ -45,7 +70,7 @@
             end
             ..
         end"""
-        @test fmt(str) == str
+        test_format(str, str)
 
         str = """
         let n = let
@@ -53,7 +78,7 @@
             end
             ..
         end"""
-        @test fmt(str) == str
+        test_format(str, str)
 
         str = """
         let n = begin
@@ -61,7 +86,7 @@
             end
             ..
         end"""
-        @test fmt(str) == str
+        test_format(str, str)
     end
 
     @testset "multiline / issue 139" begin
@@ -85,7 +110,7 @@
             aaa,
             str,
         )"""
-        @test fmt(str_) == str
+        test_format(str_, str)
 
         str_ = """
         m = match(r```
@@ -107,7 +132,7 @@
             aaa,
             str,
         )"""
-        @test fmt(str_) == str
+        test_format(str_, str)
 
         str_ = """
         y = similar([
@@ -124,7 +149,7 @@
             ],
             (4, 5),
         )"""
-        @test fmt(str_) == str
+        test_format(str_, str)
 
         str_ = """
         y = similar(T[
@@ -141,16 +166,16 @@
             ],
             (4, 5),
         )"""
-        @test fmt(str_) == str
+        test_format(str_, str)
     end
 
     @testset "issue #150" begin
         str_ = "const SymReg{B,MT} = ArrayReg{B,Basic,MT} where {MT <:AbstractMatrix{Basic}}"
         str = "const SymReg{B,MT} = ArrayReg{B,Basic,MT} where {MT<:AbstractMatrix{Basic}}"
-        @test fmt(str_; whitespace_typedefs = false) == str
+        test_format(str_, str; whitespace_typedefs = false)
 
         str = "const SymReg{B, MT} = ArrayReg{B, Basic, MT} where {MT <: AbstractMatrix{Basic}}"
-        @test fmt(str_; whitespace_typedefs = true) == str
+        test_format(str_, str; whitespace_typedefs = true)
     end
 
     @testset "issue #170 - block within comprehension" begin
@@ -174,7 +199,7 @@
             end for x in xs
         )
         """
-        @test fmt(str_) == str
+        test_format(str_, str)
 
         str = """
         ys = map(xs) do x
@@ -187,7 +212,7 @@
             end
         end
         """
-        @test fmt(str) == str
+        test_format(str, str)
 
         str_ = """
         y1 = Any[if true
@@ -199,7 +224,7 @@
                 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_expr
             end for i = 1:1
         ]"""
-        @test fmt(str_) == str
+        test_format(str_, str)
         _, s = run_nest(str_, 100)
         @test s.line_offset == 1
 
@@ -213,7 +238,7 @@
                 very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_very_long_expr
             end for i = 1:1
         ]"""
-        @test fmt(str_) == str
+        test_format(str_, str)
         _, s = run_nest(str_, 100)
         @test s.line_offset == 1
 
@@ -227,7 +252,7 @@
                 short_expr
             end for i = 1:1
         ]"""
-        @test fmt(str_) == str
+        test_format(str_, str)
         _, s = run_nest(str_, 100)
         @test s.line_offset == 1
     end
@@ -255,7 +280,7 @@
             )
             nothing
         end"""
-        @test fmt(str_) == str
+        test_format(str_, str)
     end
 
     @testset "issue #189" begin
@@ -274,7 +299,7 @@
             (b_hat - y_hat) * delta[i] +
             (b - y) * delta_hat[i] - delta[i] * delta_hat[i] for i = 1:8
         ]"""
-        @test fmt(str_) == str
+        test_format(str_, str)
     end
 
     @testset "issue #193" begin
@@ -282,7 +307,7 @@
         module Module
         # comment
         end"""
-        @test fmt(str) == str
+        test_format(str, str)
 
         str = """
         module Module
@@ -290,7 +315,7 @@
         @test
         # comment
         end"""
-        @test fmt(str) == str
+        test_format(str, str)
     end
 
     @testset "issue #194" begin
@@ -303,7 +328,7 @@
         function mystr(str::String)
             return SubString(str, 1:3)
         end"""
-        @test fmt(str_) == str
+        test_format(str_, str)
     end
 
     @testset "issue #200" begin
@@ -324,8 +349,8 @@
                                    weightedsum(Qe)
             end
         end"""
-        @test fmt(str_; m = 81) == str
-        @test fmt(str; m = 82) == str_
+        test_format(str_, str; margin = 81)
+        test_format(str, str_; margin = 82)
     end
 
     @testset "issue #202" begin
@@ -345,7 +370,7 @@
             end
             return function (xs) end
         end"""
-        @test fmt(str_; m = 92) == str
+        test_format(str_, str; margin = 92)
 
         str_ = """
         @vlplot(
@@ -383,7 +408,7 @@
                 ],
             }
         )"""
-        @test fmt(str_; m = 92) == str
+        test_format(str_, str; margin = 92)
     end
 
     @testset "issue #207" begin
@@ -398,7 +423,7 @@
             n::Int = 1;
             y_past = get_y(m),
         ) where {T,TGP<:AbstractGP{T};IsMultiOutput{TGP}} end"""
-        @test fmt(str_; m = 92) == str
+        test_format(str_, str; margin = 92)
 
         str = """
         @traitfn function predict_ar(
@@ -407,7 +432,7 @@
             n::Int = 1;
             y_past = get_y(m),
         ) where {T, TGP <: AbstractGP{T}; IsMultiOutput{TGP}} end"""
-        @test fmt(str_; m = 92, whitespace_typedefs = true) == str
+        test_format(str_, str; margin = 92, whitespace_typedefs = true)
 
         str_ = """
         @traitfn function predict_ar(m::TGP, p::Int = 3, n::Int = 1; y_past = get_y(m)) where C <: Union{T,TGP<:AbstractGP{T};IsMultiOutput{TGP}}
@@ -420,7 +445,7 @@
             n::Int = 1;
             y_past = get_y(m),
         ) where {C<:Union{T,TGP<:AbstractGP{T};IsMultiOutput{TGP}}} end"""
-        @test fmt(str_; m = 92) == str
+        test_format(str_, str; margin = 92)
 
         str = """
         @traitfn function predict_ar(
@@ -429,7 +454,7 @@
             n::Int = 1;
             y_past = get_y(m),
         ) where {C <: Union{T, TGP <: AbstractGP{T}; IsMultiOutput{TGP}}} end"""
-        @test fmt(str_; m = 92, whitespace_typedefs = true) == str
+        test_format(str_, str; margin = 92, whitespace_typedefs = true)
     end
 
     @testset "issue #218" begin
@@ -452,8 +477,8 @@
                 end,
             )
         end"""
-        @test fmt1(str_) == str
-        @test fmt(str_) == str
+        test_format(str_, str)
+        test_format(str_, str)
     end
 
     @testset "issue 248" begin
@@ -465,12 +490,12 @@
                 a,
                 @macrocall b
             )"""
-        @test fmt(str_, 4, 1) == str
+        test_format(str_, str; indent=4, margin=1)
     end
 
     @testset "issue 260 - BracesCat" begin
         str = "{1; 2; 3}"
-        @test fmt(str, 4, length(str)) == str
+        test_format(str, str; indent=4, margin=length(str))
 
         str_ = "{1; 2; 3}"
         str = """
@@ -479,33 +504,33 @@
           2;
           3
         }"""
-        @test fmt(str_, 2, length(str_) - 1) == str
-        @test fmt(str, 2, length(str_)) == str_
+        test_format(str_, str; indent=2, margin=length(str_) - 1)
+        test_format(str, str_; indent=2, margin=length(str_))
 
         str_ = "{1; 2; 3;}"
         str = "{1; 2; 3}"
-        @test fmt(str_, 2, 90) == str
+        test_format(str_, str; indent=2, margin=90)
     end
 
     @testset "issue 262 - removal of @ in nested macrocall" begin
         str = raw":($(@__MODULE__).@macro)"
-        @test fmt(str) == str
+        test_format(str, str)
 
         str = raw":($(@__MODULE__).property)"
-        @test fmt(str) == str
+        test_format(str, str)
 
         str = raw":($(@__MODULE__))"
-        @test fmt(str) == str
+        test_format(str, str)
 
         str_ = raw":($(@__MODULE__.macro).field.macro)"
         str = raw":($(__MODULE__.@macro).field.macro)"
-        @test fmt(str_) == str
-        @test fmt(str) == str
+        test_format(str_, str)
+        test_format(str, str)
 
         str_ = raw"@a.b.c"
         str = raw"a.b.@c"
-        @test fmt(str_) == str
-        @test fmt(str) == str
+        test_format(str_, str)
+        test_format(str, str)
     end
 
     @testset "issue 264 - `let` empty block body" begin
@@ -513,23 +538,23 @@
         str = """
         let;
         end"""
-        @test fmt(str_) == str
+        test_format(str_, str)
     end
 
     @testset "issue 268 - whitespace around dot op if LHS is number literal" begin
         str = "xs[-5 .<= xs .& xs .<= 5]"
-        @test fmt(str) == str
+        test_format(str, str)
         str_ = "xs[(-5 .<= xs).&(xs.<=5)]"
         str = "xs[(-5 .<= xs) .& (xs .<= 5)]"
-        @test fmt(str_) == str
+        test_format(str_, str)
     end
 
     @testset "issue 277 - flatten ops when no whitespace is allowed" begin
         # previously this would remove |>
         str_ = "get_actions(env)[env |> π.learner |> π.explorer]"
         str = "get_actions(env)[env|>π.learner|>π.explorer]"
-        @test fmt(str_) == str
-        @test fmt(str; whitespace_ops_in_indices = true) == str_
+        test_format(str_, str)
+        test_format(str, str_; whitespace_ops_in_indices = true)
     end
 
     @testset "issue 286 - Float32 leading/trailing zeros" begin
@@ -549,7 +574,7 @@
         e = 30.123f0
         f = 0.123f0
         """
-        @test fmt(str_) == str
+        test_format(str_, str)
 
         @testset "500 - leading zeros with '-.'" begin
             s0 = """
@@ -560,7 +585,7 @@
             a = -0.2
             b = - 0.2
             """
-            @test fmt(s0) == s1
+            test_format(s0, s1)
 
             s0 = """
             a = -.2f32
@@ -570,7 +595,7 @@
             a = -0.2f32
             b = - 0.2f32
             """
-            @test fmt(s0) == s1
+            test_format(s0, s1)
 
             s0 = """
             a = -.2f-5
@@ -580,7 +605,7 @@
             a = -0.2f-5
             b = - 0.2f-5
             """
-            @test fmt(s0) == s1
+            test_format(s0, s1)
         end
     end
 
@@ -601,7 +626,7 @@
                 f(1, 2) c/Ja -k/Ja -c/Ja
             ]
         """
-        @test fmt(str_, 4, 1) == str
+        test_format(str_, str; indent=4, margin=1)
     end
 
     @testset "issue 317 - infinite recursion" begin
@@ -652,15 +677,15 @@
             Val{1},
         )::Int
         """
-        @test fmt(str_, 4, 80) == str
+        test_format(str_, str; indent=4, margin=80)
     end
 
     @testset "issue 375" begin
         s = raw"conflictstatus = @jimport ilog.cp.IloCP$ConflictStatus"
-        @test fmt(s) == s
+        test_format(s, s)
 
         s = raw"conflictstatus = @jimport ilog.cp.IloCP$ConflictStatus"
-        @test bluefmt(s) == s
+        test_format(s, s, BlueStyle())
     end
 
     @testset "issue 352" begin
@@ -674,7 +699,7 @@
 
             a = f + m + l + k
         end"""
-        @test yasfmt(str_; always_for_in = true, join_lines_based_on_source = false) == str
+        test_format(str_, str, YASStyle(); always_for_in = true, join_lines_based_on_source = false)
 
         str_ = """
         using Test
@@ -692,7 +717,7 @@
             @test true
         end
         """
-        @test bluefmt(str_; always_for_in = true) == str
+        test_format(str_, str, BlueStyle(); always_for_in = true)
     end
 
     @testset "issue 387" begin
@@ -701,15 +726,15 @@
         new{T1,
             T2}(arg1,
                 arg2)"""
-        @test yasfmt(str_; m = 1) == str
+        test_format(str_, str, YASStyle(); m = 1)
     end
 
     if VERSION >= v"1.6.0"
         @testset "issue 396 (import as)" begin
             str = """import Base.threads as th"""
-            @test fmt(str) == str
-            @test fmt(str; m = 1) == str
-            @test fmt(str; m = 1, import_to_using = true) == str
+            test_format(str, str)
+            test_format(str, str; margin = 1)
+            test_format(str, str; margin = 1, import_to_using = true)
         end
     end
 
@@ -719,7 +744,7 @@
             raw\""" Doc string.\"""f
         end
         """
-        @test fmt(str; always_use_return = true) == str
+        test_format(str, str; always_use_return = true)
 
         str = """
         function __init__()
@@ -729,7 +754,7 @@
             f
         end
         """
-        @test fmt(str; always_use_return = true) == str
+        test_format(str, str; always_use_return = true)
 
         str = """
         function __init__()
@@ -739,38 +764,38 @@
             f
         end
         """
-        @test fmt(str; always_use_return = true) == str
+        test_format(str, str; always_use_return = true)
     end
 
     @testset "issue 417" begin
         str = """
         formαt"JPEG"
         """
-        @test fmt(str) == str
+        test_format(str, str)
 
         str = """
         A.formαt"JPEG"
         """
-        @test fmt(str) == str
+        test_format(str, str)
 
         str = """
         A.B.formαt"JPEG"
         """
-        @test fmt(str) == str
+        test_format(str, str)
     end
 
     @testset "issue 419" begin
         str = """
         [z for y in x for z in y]
         """
-        @test yasfmt(str) == str
-        @test yasfmt(str; m = 25) == str
+        test_format(str, str, YASStyle())
+        test_format(str, str, YASStyle(); m = 25)
 
         str_ = """
         [z for y in x
          for z in y]
         """
-        @test yasfmt(str; m = 24) == str_
+        test_format(str, str_, YASStyle(); m = 24)
 
         str_ = """
         [z
@@ -779,17 +804,17 @@
          for z in
              y]
         """
-        @test yasfmt(str; m = 1) == str_
+        test_format(str, str_, YASStyle(); m = 1)
     end
 
     @testset "issue 427" begin
         str = "var\"##iv#469\" = (@variables(t))[1]"
-        @test fmt(str) == str
+        test_format(str, str)
 
         str_ = """
         var\"##iv#469\" =
             (@variables(t))[1]"""
-        @test fmt(str; m = length(str) - 1) == str_
+        test_format(str, str_; margin = length(str) - 1)
     end
 
     @testset "issue 429" begin
@@ -801,12 +826,12 @@
             (find_derivatives!(vars, expr.lhs, f); find_derivatives!(vars, expr.rhs, f); vars)
         end
         """
-        @test fmt(str; m = 92, short_to_long_function_def = true) == str_
+        test_format(str, str_; margin = 92, short_to_long_function_def = true)
     end
 
     @testset "issue 440" begin
         str = "import Base.+"
-        @test fmt(str) == str
+        test_format(str, str)
     end
 
     @testset "issue 444" begin
@@ -824,30 +849,30 @@
             body
         end
         """
-        @test fmt(str_; m = 1) == str
-        @test bluefmt(str_; m = 1) == str
+        test_format(str_, str; margin = 1)
+        test_format(str_, str, BlueStyle(); m = 1)
     end
 
     @testset "issue 431" begin
         str = """
         local Jcx_rows, Jcx_cols, Jcx_vals, Jct_val
         """
-        @test fmt(str) == str
+        test_format(str, str)
 
         str_ = "global a=2,b"
         str = "global a=2, b"
-        @test fmt(str_) == str
+        test_format(str_, str)
 
         str_ = "global a = 2,b"
         str = "global a = 2, b"
-        @test fmt(str_) == str
+        test_format(str_, str)
     end
 
     @testset "issue 449" begin
         str = """
         (var"x" = 1.0,)
         """
-        @test fmt(str) == str
+        test_format(str, str)
     end
 
     @testset "issue 451" begin
@@ -869,7 +894,7 @@
             end
         end
         """
-        @test fmt(str_; import_to_using = true) == str
+        test_format(str_, str; import_to_using = true)
     end
 
     @testset "issue 456" begin
@@ -880,7 +905,7 @@
             var3 = 2
         end
         """
-        @test fmt(str; align_assignment = true) == str
+        test_format(str, str; align_assignment = true)
 
         str = """
         function update()
@@ -896,7 +921,7 @@
             var3                 = 5
         end
         """
-        @test fmt(str; align_assignment = true) == str_aligned
+        test_format(str, str_aligned; align_assignment = true)
     end
 
     @testset "issue 460" begin
@@ -920,7 +945,7 @@
         @everywhere import Distributed
         have_workers = Distributed.nprocs() - 1
         """
-        @test fmt(str; import_to_using = true) == str
+        test_format(str, str; import_to_using = true)
     end
 
     @testset "issue 463" begin
@@ -933,24 +958,21 @@
             end
         end
         """
-        @test fmt(
-            str;
-            annotate_untyped_fields_with_any = false,
-            align_struct_field = true,
-        ) == str
+        test_format(str, str; annotate_untyped_fields_with_any = false,
+            align_struct_field = true)
     end
 
     @testset "issue 467" begin
         str_ = "-3.. -2"
         str = "-3 .. -2"
-        @test fmt(str_) == str
-        @test bluefmt(str_) == str
+        test_format(str_, str)
+        test_format(str_, str, BlueStyle())
     end
 
     @testset "issue 473" begin
         str_ = "[1.0, 2.0, 3.0] .|> Int"
         str = "Int.([1.0, 2.0, 3.0])"
-        @test fmt(str_; pipe_to_function_call = true) == str
+        test_format(str_, str; pipe_to_function_call = true)
         st = run_format(str_; opts = Options(; pipe_to_function_call = true))
         @test st.line_offset == length(str)
     end
@@ -964,52 +986,32 @@
             AWSS3.s3_sign_url(config, path.bucket, path.key, Dates.value(Second(duration))),
         )
         """
-        @test fmt(
-            str,
-            4,
-            100;
-            whitespace_in_kwargs = false,
-            separate_kwargs_with_semicolon = true,
-        ) == str
+        test_format(str, str; indent=4, margin=100, whitespace_in_kwargs = false,
+            separate_kwargs_with_semicolon = true)
         str = """
         @deprecate(
             presign(path::AWSS3.S3Path; duration::Period=Hour(1), config::AWSConfig=aws_config()),
             AWSS3.s3_sign_url(config, path.bucket, path.key, Dates.value(Second(duration))),
         )
         """
-        @test fmt(
-            str,
-            4,
-            100;
-            whitespace_in_kwargs = false,
-            separate_kwargs_with_semicolon = true,
-        ) == str
+        test_format(str, str; indent=4, margin=100, whitespace_in_kwargs = false,
+            separate_kwargs_with_semicolon = true)
 
         str = """
         @deprecate(presign(path::AWSS3.S3Path, duration::Period=Hour(1); config::AWSConfig=aws_config()),
                    AWSS3.s3_sign_url(config, path.bucket, path.key, Dates.value(Second(duration))),)
         """
-        @test yasfmt(
-            str,
-            4,
-            100;
-            margin = 100,
+        test_format(str, str, YASStyle(); margin = 100,
             whitespace_in_kwargs = false,
-            separate_kwargs_with_semicolon = true,
-        ) == str
+            separate_kwargs_with_semicolon = true)
 
         str = """
         @deprecate(presign(path::AWSS3.S3Path, duration::Period=Hour(1), config::AWSConfig=aws_config()),
                    AWSS3.s3_sign_url(config, path.bucket, path.key, Dates.value(Second(duration))),)
         """
-        @test yasfmt(
-            str,
-            4,
-            100;
-            margin = 100,
+        test_format(str, str, YASStyle(); margin = 100,
             whitespace_in_kwargs = false,
-            separate_kwargs_with_semicolon = true,
-        ) == str
+            separate_kwargs_with_semicolon = true)
     end
 
     @testset "485 - blue style binary/chain op nesting" begin
@@ -1020,7 +1022,7 @@
             foo()
         end
         """
-        @test bluefmt(str, 4, 80) == str
+        test_format(str, str, BlueStyle(); indent=4, margin=80)
 
         str_ = """
         if a && b
@@ -1031,7 +1033,7 @@
             b
         end
         """
-        @test bluefmt(str_, 4, 1) == str
+        test_format(str_, str, BlueStyle(); indent=4, margin=1)
 
         str_ = """
         @test foo == bar == baz
@@ -1041,7 +1043,7 @@
             bar ==
             baz
         """
-        @test bluefmt(str_, 4, 1) == str
+        test_format(str_, str, BlueStyle(); indent=4, margin=1)
 
         str_ = """
         @test foo == bar
@@ -1050,7 +1052,7 @@
         @test foo ==
             bar
         """
-        @test bluefmt(str_, 4, 1) == str
+        test_format(str_, str, BlueStyle(); indent=4, margin=1)
 
         str = """
         const a =
@@ -1058,32 +1060,32 @@
             arg2 +
             arg3
         """
-        @test bluefmt(str, 4, 1) == str
+        test_format(str, str, BlueStyle(); indent=4, margin=1)
 
         str = """
         const a =
             arg1 +
             arg2
         """
-        @test bluefmt(str, 4, 1) == str
+        test_format(str, str, BlueStyle(); indent=4, margin=1)
     end
 
     @testset "494" begin
         str = "Base.@deprecate f(x, y = x) g(x, y)\n"
-        @test bluefmt(str) == str
+        test_format(str, str, BlueStyle())
 
         str = "Base.@deprecate f(x, y) g(x, y = y)\n"
-        @test bluefmt(str) == str
+        test_format(str, str, BlueStyle())
     end
 
     @testset "509" begin
         code = """M.var"@f";"""
-        @test fmt(code) == code
+        test_format(code, code)
 
         code = """
         const var"@_assert" = Base.var"@assert"
         """
-        @test fmt(code) == code
+        test_format(code, code)
     end
 
     @testset "512" begin
@@ -1101,7 +1103,7 @@
             end
         end
         """
-        @test fmt(fmt(str)) == str
+        test_format(str, str)
     end
 
     @testset "513" begin
@@ -1135,7 +1137,7 @@
             + 10 # hello
         )
         """
-        @test fmt(str_) == str
+        test_format(str_, str)
 
         str_ = """
         (
@@ -1155,7 +1157,7 @@
             10 # hello
         )
         """
-        @test fmt(str_) == str
+        test_format(str_, str)
 
         str_ = """
         (
@@ -1173,7 +1175,7 @@
             10 # hello
         )
         """
-        @test fmt(str_) == str
+        test_format(str_, str)
 
         # before this would format to f(a, b)
         str_ = """
@@ -1188,44 +1190,44 @@
             b,
         )
         """
-        @test fmt(str_) == str
+        test_format(str_, str)
     end
 
     @testset "514" begin
         str_ = "output = input .|> f.g"
         str = "output = f.g.(input)"
-        @test fmt(str_; pipe_to_function_call = true) == str
+        test_format(str_, str; pipe_to_function_call = true)
 
         str_ = "output = input .|> f.g.h"
         str = "output = f.g.h.(input)"
-        @test fmt(str_; pipe_to_function_call = true) == str
+        test_format(str_, str; pipe_to_function_call = true)
     end
 
     @testset "526" begin
         str = "Base.:(|>)(r::AbstractRegister, blk::AbstractBlock) = apply!(r, blk)"
-        @test fmt(str; pipe_to_function_call = true) == str
+        test_format(str, str; pipe_to_function_call = true)
     end
 
     @testset "480" begin
         str = "@show (1,)"
-        @test fmt(str) == str
+        test_format(str, str)
 
         str = "@show(1,)"
-        @test fmt(str) == str
+        test_format(str, str)
 
         str = """
         @NamedTuple{a::Int, b::Int}[]
 
         @SVector[@SVector[1, 2], @SVector[1, 2]]
         """
-        @test fmt(str) == str
+        test_format(str, str)
 
         str = """
         @NamedTuple {a::Int, b::Int}[]
 
         @SVector[@SVector[1, 2], @SVector [1, 2]]
         """
-        @test fmt(str) == str
+        test_format(str, str)
     end
 
     @testset "530" begin
@@ -1233,14 +1235,14 @@
         @testset "DefaultStyle" begin
             for op in radical_ops
                 s = "3$(op)2"
-                @test fmt(s) == s
+                test_format(s, s)
             end
         end
 
         @testset "DefaultStyle" begin
             for op in radical_ops
                 s = "3$(op)2"
-                @test bluefmt(s) == s
+                test_format(s, s, BlueStyle())
             end
         end
     end
@@ -1248,23 +1250,23 @@
     @testset "533" begin
         # semicolon should not be added prior to `extrap` since it's a function definition.
         s = "function linterp(x0::T, y0::T, x1::T, y1::T, x::T, extrap::Bool = false)::T where {T<:AbstractFloat} end"
-        @test bluefmt(s; m = 200) == s
-        @test yasfmt(s; m = 200) == s
+        test_format(s, s, BlueStyle(); m = 200)
+        test_format(s, s, YASStyle(); m = 200)
 
         s = "function linterp(x0::T, y0::T, x1::T, y1::T, x::T, extrap::Bool = false)::T end"
-        @test bluefmt(s; m = 200) == s
-        @test yasfmt(s; m = 200) == s
+        test_format(s, s, BlueStyle(); m = 200)
+        test_format(s, s, YASStyle(); m = 200)
     end
 
     @testset "541" begin
         str = """
         [10;]
         """
-        @test fmt(str; align_matrix = true) == str
+        test_format(str, str; align_matrix = true)
         str = """
         [0:0.2:50;]
         """
-        @test fmt(str; align_matrix = true) == str
+        test_format(str, str; align_matrix = true)
     end
 
     @testset "543" begin
@@ -1279,7 +1281,7 @@
             Zero  Zero  H
         ]
         """
-        @test fmt(str_; align_matrix = true) == str
+        test_format(str_, str; align_matrix = true)
 
         str_ = """
         H = [1 1; 1 1]
@@ -1324,7 +1326,7 @@
             Zero  Zero  H
         ]
         """
-        @test fmt(str_; align_matrix = true) == str
+        test_format(str_, str; align_matrix = true)
     end
 
     @testset "546" begin
@@ -1348,14 +1350,9 @@
                                        title_suffix=title_suffix, xaxis_prefix=xaxis_prefix)
         end
         """
-        @test yasfmt(
-            str,
-            4,
-            92;
-            join_lines_based_on_source = true,
+        test_format(str, str_, YASStyle(); indent=4, margin=92, join_lines_based_on_source = true,
             always_use_return = true,
-            whitespace_in_kwargs = false,
-        ) == str_
+            whitespace_in_kwargs = false)
     end
 
     @testset "568" begin
@@ -1374,7 +1371,7 @@
             body
         end
         """
-        @test fmt(s, 4, 19) == s_
+        test_format(s, s_; indent=4, margin=19)
     end
 
     @testset "571" begin
@@ -1386,7 +1383,7 @@
         arraycopy_common(false#=fwd=#, LLVM.Builder(B), orig, origops[1], gutils)
         return nothing
         """
-        @test fmt(s) == s_
+        test_format(s, s_)
 
         s1 = """
         foo(a, b, #=c=#)
@@ -1397,7 +1394,7 @@
             b,#=c=#
         )
         """
-        @test fmt(s1, 4, 1) == s2
+        test_format(s1, s2; indent=4, margin=1)
     end
 
     @testset "604" begin
@@ -1433,7 +1430,7 @@
 
     @testset "636" begin
         s = "a |> M.f"
-        @test fmt(s, 4, 92; pipe_to_function_call = true) == "M.f(a)"
+        test_format(s, "M.f(a)"; indent=4, margin=92, pipe_to_function_call = true)
 
         # -> has a higher precedence than |>
         s = """
@@ -1442,7 +1439,7 @@
         s_ = """
         coordsperm = (x -> CartesianIndex(x.I[[2, 1, 3]])).(coords)
         """
-        @test fmt(s, 4, 92; pipe_to_function_call = true) == s_
+        test_format(s, s_; indent=4, margin=92, pipe_to_function_call = true)
 
         # -> has a higher precedence than |>
         s = """
@@ -1451,7 +1448,7 @@
         s_ = """
         coordsperm = (x -> CartesianIndex.(x.I[[2, 1, 3]])).(coords)
         """
-        @test fmt(s, 4, 92; pipe_to_function_call = true) == s_
+        test_format(s, s_; indent=4, margin=92, pipe_to_function_call = true)
 
         s = """
         coordsperm = coords .|> (x -> x.I[[2, 1, 3]]) .|> CartesianIndex
@@ -1459,7 +1456,7 @@
         s_ = """
         coordsperm = CartesianIndex.((x -> x.I[[2, 1, 3]]).(coords))
         """
-        @test fmt(s, 4, 92; pipe_to_function_call = true) == s_
+        test_format(s, s_; indent=4, margin=92, pipe_to_function_call = true)
 
         s = """
         coordsperm = coords |> (x -> x.I[[2, 1, 3]]) |> CartesianIndex
@@ -1467,7 +1464,7 @@
         s_ = """
         coordsperm = CartesianIndex((x -> x.I[[2, 1, 3]])(coords))
         """
-        @test fmt(s, 4, 92; pipe_to_function_call = true) == s_
+        test_format(s, s_; indent=4, margin=92, pipe_to_function_call = true)
     end
 
     @testset "618" begin
@@ -1477,7 +1474,7 @@
         s_ = """
         (x -> 2x)(2)
         """
-        @test fmt(s, 4, 92; pipe_to_function_call = true) == s_
+        test_format(s, s_; indent=4, margin=92, pipe_to_function_call = true)
     end
 
     @testset "644" begin
@@ -1491,7 +1488,7 @@
         @foo @noinline Base.@constprop :none bbbbbbbbbbbbbbbbbbb()     = 0
         @foo @foo @ccccccccccccccccccccccccccccccccccccccccccccccccc() = 0
         """
-        @test fmt(s, 4, 92; align_assignment = true) == s_
+        test_format(s, s_; indent=4, margin=92, align_assignment = true)
 
         # no manual edit
         s = """
@@ -1499,7 +1496,7 @@
         @foo @noinline Base.@constprop :none bbbbbbbbbbbbbbbbbbbbbbb() = 0
         @foo @foo @ccccccccccccccccccccccccccccccccccccccccccccccccc() = 0
         """
-        @test fmt(s, 4, 92; align_assignment = true) == s
+        test_format(s, s; indent=4, margin=92, align_assignment = true)
     end
 
     @testset "655" begin
@@ -1508,21 +1505,20 @@
           a;
         ]
         """
-        @test fmt(s, 2, 92; join_lines_based_on_source = true) == s
-        @test fmt(s, 2, 1) == s
+        test_format(s, s; indent=2, margin=92, join_lines_based_on_source = true)
+        test_format(s, s; indent=2, margin=1)
         s = """
         [
           a
         ]
         """
-        @test fmt(s, 2, 92; join_lines_based_on_source = true, trailing_comma = nothing) ==
-              s
-        @test fmt(s, 2, 1; trailing_comma = nothing) == s
+        test_format(s, s; indent=2, margin=92, join_lines_based_on_source = true, trailing_comma = nothing)
+        test_format(s, s; indent=2, margin=1, trailing_comma = nothing)
     end
 
     @testset "656" begin
         s = "[x for x in xs if x in 1:length(ys)]"
-        @test fmt(s, 4, 92) == s
+        test_format(s, s; indent=4, margin=92)
     end
 
     @testset "667" begin
@@ -1538,7 +1534,7 @@
         \"""
         @dimension 𝐀 "𝐀" Angle true
         """
-        @test fmt(s; format_docstrings = true) == s
+        test_format(s, s; format_docstrings = true)
     end
 
     @testset "682" begin
@@ -1550,7 +1546,7 @@
                 a;
                 arg = @macrocall b
             )"""
-        @test fmt(str_, 4, 1) == str
+        test_format(str_, str; indent=4, margin=1)
     end
 
     @testset "686" begin
@@ -1564,7 +1560,7 @@
           1
         end
         """
-        @test fmt(s1, 2, 5; short_to_long_function_def = true) == s2
+        test_format(s1, s2; indent=2, margin=5, short_to_long_function_def = true)
     end
 
     @testset "698" begin
@@ -1596,7 +1592,7 @@
             hello()
         end
         """
-        @test fmt(s1, 4, 10; short_to_long_function_def = true) == s2
+        test_format(s1, s2; indent=4, margin=10, short_to_long_function_def = true)
     end
 
     @testset "700" begin
@@ -1612,7 +1608,7 @@
             sum(a_loooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_array_name[:, 1]), :,
         ]
         """
-        @test bluefmt(s1, 4, 92) == s2
+        test_format(s1, s2, BlueStyle(); indent=4, margin=92)
     end
 
     if VERSION >= v"1.8"
@@ -1623,7 +1619,7 @@
                 bcd     :: String
             end
             """
-            @test fmt(s, 4, 92; align_struct_field = true) == s
+            test_format(s, s; indent=4, margin=92, align_struct_field = true)
         end
     end
 
@@ -1634,7 +1630,7 @@
         s2 = """
         [1.0 1; 1 -1]
         """
-        @test fmt(s1, 4, 92; align_matrix = true) == s2
+        test_format(s1, s2; indent=4, margin=92, align_matrix = true)
     end
 
     @testset "714" begin
@@ -1644,7 +1640,7 @@
         s2 = """
         A = [-2 .. -1 3..4; 5..6 7..8]
         """
-        @test fmt(s1, 4, 92) == s2
+        test_format(s1, s2; indent=4, margin=92)
     end
 
     @testset "715" begin
@@ -1653,7 +1649,7 @@
             # empty
         end
         """
-        @test fmt(s, 4, 92; always_use_return = true) == s
+        test_format(s, s; indent=4, margin=92, always_use_return = true)
     end
     @testset "728" begin
         s = """
@@ -1667,7 +1663,7 @@
 
         end
         """
-        @test fmt(s, 4, 92) == s
+        test_format(s, s; indent=4, margin=92)
 
         s = """
         begin
@@ -1675,22 +1671,22 @@
 
         end
         """
-        @test fmt(s, 4, 92) == s
+        test_format(s, s; indent=4, margin=92)
     end
 
     @testset "743" begin
         s = """
         foo(ᶜa) = - ᶜa
         """
-        @test fmt(s, 4, 92) == s
+        test_format(s, s; indent=4, margin=92)
         @test format_text(s, SciMLStyle()) == s
     end
 
     if VERSION >= v"1.8"
         @testset "745" begin
             s = "[;;;]"
-            @test fmt(s, 4, 92) == s
-            @test fmt(s, 4, 1) == s
+            test_format(s, s; indent=4, margin=92)
+            test_format(s, s; indent=4, margin=1)
         end
     end
 
@@ -1707,7 +1703,7 @@
             0.0008014; 0.0001464; 2.67e-05; 4.8e-6; 9e-7; 0.0619917; 1.2444292; 0.0486676;
             199.9383546; 137.4267984; 1.5180203; 1.5180203]
         """
-        @test fmt(str_, 4, 92; join_lines_based_on_source = true) == str
+        test_format(str_, str; indent=4, margin=92, join_lines_based_on_source = true)
     end
 
     @testset "753" begin
@@ -1750,7 +1746,7 @@
 
     @testset "779" begin
         s = "Int <: B where {B} && Int <: C where {C}"
-        fmt(s) == s
+        test_format(s, s)
     end
 
     if VERSION >= v"1.8"
@@ -1760,7 +1756,7 @@
                 const a
             end
             """
-            @test fmt(s, 4, 92; align_struct_field = true) == s
+            test_format(s, s; indent=4, margin=92, align_struct_field = true)
         end
     end
 
@@ -1863,7 +1859,7 @@
             end
         end
         """
-        @test fmt(str) == str
+        test_format(str, str)
     end
 
     if VERSION >= v"1.7"
@@ -1901,14 +1897,14 @@
     @testset "880" begin
         s1 = "constant_list[node_index.val:: UInt16]"
         s2 = "constant_list[node_index.val::UInt16]"
-        @test s1 = fmt(s1, 4, 100, whitespace_ops_in_indices = true) == s2
+        test_format(s1, s2; indent=4, margin=100, whitespace_ops_in_indices = true)
 
         s1 = "constant_list[node_index.val+ UInt16]"
         s2 = "constant_list[node_index.val + UInt16]"
-        @test s1 = fmt(s1, 4, 100, whitespace_ops_in_indices = true) == s2
+        test_format(s1, s2; indent=4, margin=100, whitespace_ops_in_indices = true)
 
         s = ".!purge"
-        @test s = fmt(s, 4, 100) == s
+        test_format(s, s; indent=4, margin=100)
     end
 
     @testset "912" begin
@@ -1921,7 +1917,7 @@
             nothing
         end
         """
-        @test fmt(s, 4, 100) == s
+        test_format(s, s; indent=4, margin=100)
 
         str_ = """
         try
@@ -1945,24 +1941,24 @@
             # comment
         end
         """
-        @test fmt(str_, 4, 100) == s
+        test_format(str_, s; indent=4, margin=100)
     end
 
     @testset "917" begin
         s = "using Foo: ( .. )"
         sf = "using Foo: (..)"
-        @test fmt(s, 4, 100) == sf
+        test_format(s, sf; indent=4, margin=100)
     end
 
     @testset "921" begin
         # These are floating point literals with hexadecimal significands. E.g. 0x1p1 is the
         # float with with 0x1 as the significant and 1 as the exponent.
         s = "0x1p1"
-        @test fmt(s) == s
+        test_format(s, s)
         s = "+0x1p1"
-        @test fmt(s) == s
+        test_format(s, s)
         s = "-0x1p1"
-        @test fmt(s) == s
+        test_format(s, s)
     end
 
     @testset "1025" begin
@@ -1983,6 +1979,8 @@
             end
         end
         """
-        @test fmt(s) == s
+        test_format(s, s)
     end
+end
+
 end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -24,7 +24,7 @@ function run_format(text::String; style = DefaultStyle(), opts = Options())
 end
 
 @testset "GitHub Issues" begin
-    @testset "issue #137" begin
+    @testset "137" begin
         str = """
         (
             let x = f() do
@@ -41,7 +41,9 @@ end
                    x
                end for x in xs
          )"""
-        test_format(str_, str)
+        # https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/1048
+        @test_broken false
+        # test_format(str_, str)
 
         str = """
         (
@@ -60,7 +62,9 @@ end
               end
               x
           end for x in xs)"""
-        test_format(str_, str)
+        # https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/1048
+        @test_broken false
+        # test_format(str_, str)
 
         str = """
         let n = try
@@ -169,7 +173,7 @@ end
         test_format(str_, str)
     end
 
-    @testset "issue #150" begin
+    @testset "150" begin
         str_ = "const SymReg{B,MT} = ArrayReg{B,Basic,MT} where {MT <:AbstractMatrix{Basic}}"
         str = "const SymReg{B,MT} = ArrayReg{B,Basic,MT} where {MT<:AbstractMatrix{Basic}}"
         test_format(str_, str; whitespace_typedefs = false)
@@ -178,7 +182,7 @@ end
         test_format(str_, str; whitespace_typedefs = true)
     end
 
-    @testset "issue #170 - block within comprehension" begin
+    @testset "170" begin
         str_ = """
         ys = ( if p1(x)
                  f1(x)
@@ -199,7 +203,9 @@ end
             end for x in xs
         )
         """
-        test_format(str_, str)
+        # https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/1048
+        @test_broken false
+        # test_format(str_, str)
 
         str = """
         ys = map(xs) do x
@@ -225,7 +231,7 @@ end
             end for i = 1:1
         ]"""
         test_format(str_, str)
-        _, s = run_nest(str_, 100)
+        _, s = run_nest(str_; opts = Options(; margin = 100))
         @test s.line_offset == 1
 
         str_ = """
@@ -239,7 +245,7 @@ end
             end for i = 1:1
         ]"""
         test_format(str_, str)
-        _, s = run_nest(str_, 100)
+        _, s = run_nest(str_; opts = Options(; margin = 100))
         @test s.line_offset == 1
 
         str_ = """
@@ -253,7 +259,7 @@ end
             end for i = 1:1
         ]"""
         test_format(str_, str)
-        _, s = run_nest(str_, 100)
+        _, s = run_nest(str_; opts = Options(; margin = 100))
         @test s.line_offset == 1
     end
 
@@ -829,12 +835,12 @@ end
         test_format(str, str_; margin = 92, short_to_long_function_def = true)
     end
 
-    @testset "issue 440" begin
+    @testset "440" begin
         str = "import Base.+"
         test_format(str, str)
     end
 
-    @testset "issue 444" begin
+    @testset "444" begin
         str_ = """
         function (a,b,c;)
         body
@@ -850,6 +856,15 @@ end
         end
         """
         test_format(str_, str; margin = 1)
+        str = """
+        function (
+            a,
+            b,
+            c;
+        )
+            return body
+        end
+        """
         test_format(str_, str, BlueStyle(); margin = 1)
     end
 
@@ -1071,10 +1086,10 @@ end
     end
 
     @testset "494" begin
-        str = "Base.@deprecate f(x, y = x) g(x, y)\n"
+        str = "Base.@deprecate f(x, y=x) g(x, y)\n"
         test_format(str, str, BlueStyle())
 
-        str = "Base.@deprecate f(x, y) g(x, y = y)\n"
+        str = "Base.@deprecate f(x, y) g(x, y=y)\n"
         test_format(str, str, BlueStyle())
     end
 
@@ -1249,11 +1264,11 @@ end
 
     @testset "533" begin
         # semicolon should not be added prior to `extrap` since it's a function definition.
-        s = "function linterp(x0::T, y0::T, x1::T, y1::T, x::T, extrap::Bool = false)::T where {T<:AbstractFloat} end"
+        s = "function linterp(x0::T, y0::T, x1::T, y1::T, x::T, extrap::Bool=false)::T where {T<:AbstractFloat} end"
         test_format(s, s, BlueStyle(); margin = 200)
         test_format(s, s, YASStyle(); margin = 200)
 
-        s = "function linterp(x0::T, y0::T, x1::T, y1::T, x::T, extrap::Bool = false)::T end"
+        s = "function linterp(x0::T, y0::T, x1::T, y1::T, x::T, extrap::Bool=false)::T end"
         test_format(s, s, BlueStyle(); margin = 200)
         test_format(s, s, YASStyle(); margin = 200)
     end

--- a/test/options.jl
+++ b/test/options.jl
@@ -667,7 +667,10 @@ end
             end"""
         test_format(str_, str)
 
-        t = run_pretty(str_, 80)
+        t = run_pretty(
+            str_;
+            opts = Options(; margin = 80)
+        )
         @test length(t) == 12
 
         str = """
@@ -693,7 +696,10 @@ end
             end"""
         test_format(str_, str)
 
-        t = run_pretty(str_, 80)
+        t = run_pretty(
+            str_;
+            opts = Options(; margin = 80)
+        )
         @test length(t) == 28
 
         str = """
@@ -764,7 +770,7 @@ end
             function f()
                 20
             end"""
-            t = run_pretty(str, 80)
+            t = run_pretty(str; opts = Options(; margin = 80))
             @test length(t) == 12
 
             normalized = """
@@ -846,7 +852,7 @@ end
                      \"""
                      Foo"""
             test_format(str, str)
-            t = run_pretty(str, 80)
+            t = run_pretty(str; opts = Options(; margin = 80))
             @test length(t) == 11
 
             str = """
@@ -1893,7 +1899,17 @@ end
             end
             """
             test_format(str_, str; join_lines_based_on_source = true)
-            test_format(str_, str, BlueStyle(); join_lines_based_on_source = true)
+            str = """
+            function foo(
+                arg1,
+                arg2)
+
+                return body
+            end
+            """
+            # https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/1045
+            @test_broken false
+            # test_format(str_, str, BlueStyle(); join_lines_based_on_source = true)
         end
 
         @testset "binary op" begin
@@ -1946,19 +1962,18 @@ end
             function foo(
                 arg1, arg2
             )
-                body
+                return body
             end
             """
             test_format(str, str, BlueStyle(); indent=4, margin=1000, join_lines_based_on_source = true)
-            @test format_text(str, BlueStyle(); indent=4, margin=1, join_lines_based_on_source = true) ==
-                  format_text(str, BlueStyle(); indent=4, margin=1)
+            test_format(str, str, BlueStyle(); indent=4, margin=15)
 
             str = """
             function foo(
                 arg1,
                 arg2,
             )
-                body
+                return body
             end
             """
             test_format(str, str, BlueStyle(); indent=4, margin=1000, join_lines_based_on_source = true)
@@ -2091,7 +2106,7 @@ end
             ]
             """
             str = """
-            [a for a = 1:10]
+            [a for a in 1:10]
             """
             test_format(str_, str, YASStyle(); join_lines_based_on_source = true)
         end
@@ -2292,34 +2307,24 @@ end
     end
 
     @testset "`separate_kwargs_with_semicolon`" begin
-        str_ = """
-        f(a, b = 10)
-        """
-        str = """
-        f(a; b = 10)
-        """
+        str_ = "f(a, b = 10)"
+        str = "f(a; b = 10)"
         test_format(str_, str; separate_kwargs_with_semicolon = true)
+        str = "f(a; b=10)"
         test_format(str_, str, YASStyle(); separate_kwargs_with_semicolon = true)
 
         str_ = "xy = f(x, y=3)"
         str = "xy = f(x; y = 3)"
         test_format(str_, str; separate_kwargs_with_semicolon = true)
+        str = "xy = f(x; y=3)"
         test_format(str_, str, YASStyle(); separate_kwargs_with_semicolon = true)
 
-        str_ = "xy = f(x=1, y=2)"
-        str = "xy = f(; x = 1, y = 2)"
-        test_format(str_, str; separate_kwargs_with_semicolon = true)
-        test_format(str_, str; separate_kwargs_with_semicolon = true)
-        test_format(str, str; separate_kwargs_with_semicolon = true)
-        test_format(str_, str, YASStyle(); separate_kwargs_with_semicolon = true)
-        test_format(str_, str, YASStyle(); separate_kwargs_with_semicolon = true)
-        test_format(str, str, YASStyle(); separate_kwargs_with_semicolon = true)
-
-        str_ = "xy = f(x = 1; y = 2)"
-        test_format(str_, str; separate_kwargs_with_semicolon = true)
-        test_format(str_, str; separate_kwargs_with_semicolon = true)
-        test_format(str_, str, YASStyle(); separate_kwargs_with_semicolon = true)
-        test_format(str_, str, YASStyle(); separate_kwargs_with_semicolon = true)
+        for str_ in ("xy = f(x=1, y=2)", "xy = f(x = 1; y = 2)")
+            str = "xy = f(; x = 1, y = 2)"
+            test_format(str_, str; separate_kwargs_with_semicolon = true)
+            str = "xy = f(; x=1, y=2)"
+            test_format(str_, str, YASStyle(); separate_kwargs_with_semicolon = true)
+        end
 
         str = """
         function g(x, y = 1)
@@ -2332,8 +2337,16 @@ end
         shortdef2(MatrixT, VectorT = nothing) where {T} = nothing
         """
         test_format(str, str; separate_kwargs_with_semicolon = true)
-        test_format(str, str; separate_kwargs_with_semicolon = true)
-        test_format(str, str, YASStyle(); separate_kwargs_with_semicolon = true)
+        str = """
+        function g(x, y=1)
+            return x + y
+        end
+        macro h(x, y=1)
+            return nothing
+        end
+        shortdef1(MatrixT, VectorT=nothing) = nothing
+        shortdef2(MatrixT, VectorT=nothing) where {T} = nothing
+        """
         test_format(str, str, YASStyle(); separate_kwargs_with_semicolon = true)
 
         str = """
@@ -2345,9 +2358,15 @@ end
         end
         """
         test_format(str, str; separate_kwargs_with_semicolon = true)
-        test_format(str, str; separate_kwargs_with_semicolon = true)
-        test_format(str, str, YASStyle(); separate_kwargs_with_semicolon = true)
-        test_format(str, str, YASStyle(); separate_kwargs_with_semicolon = true)
+        stryas = """
+        function g(x::T, y=1) where {T}
+            return x + y
+        end
+        function g(x::T, y=1)::Int where {T}
+            return x + y
+        end
+        """
+        test_format(str, stryas, YASStyle(); separate_kwargs_with_semicolon = true)
 
         str_ = """
         x = foo(var = "some really really really really really really really really really really long string")
@@ -2358,16 +2377,14 @@ end
         )
         """
         test_format(str_, str; separate_kwargs_with_semicolon = true)
-        test_format(str_, str; separate_kwargs_with_semicolon = true)
 
         str_ = """
         x = foo(var = "some really really really really really really really really really really long string")
         """
         str = """
         x = foo(;
-                var = "some really really really really really really really really really really long string")
+                var="some really really really really really really really really really really long string")
         """
-        test_format(str_, str, YASStyle(); separate_kwargs_with_semicolon = true)
         test_format(str_, str, YASStyle(); separate_kwargs_with_semicolon = true)
     end
 

--- a/test/options.jl
+++ b/test/options.jl
@@ -1,3 +1,19 @@
+module OptionsTests
+
+using JuliaFormatter
+using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, Options, format_text
+using JuliaFormatter.Internal: test_format
+using JuliaSyntax
+using Test
+
+function run_pretty(text::String; style = DefaultStyle(), opts = Options())
+    d = JuliaFormatter.Document(text)
+    s = JuliaFormatter.State(d, opts)
+    g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text)
+    t = JuliaFormatter.pretty(style, g, s)
+    t
+end
+
 @testset "Formatting Options" begin
     @testset "remove extra newlines" begin
         str_ = """
@@ -31,8 +47,8 @@
 
         # hello
         """
-        @test fmt(str_; remove_extra_newlines = true) == str
-        @test fmt(str_; remove_extra_newlines = false) == str_
+        test_format(str_, str; remove_extra_newlines = true)
+        test_format(str_, str_; remove_extra_newlines = false)
 
         str_ = """
         module M
@@ -66,14 +82,14 @@
 
         end
         """
-        @test fmt(str_; remove_extra_newlines = true) == str
-        @test fmt(str_; remove_extra_newlines = false) == str_
+        test_format(str_, str; remove_extra_newlines = true)
+        test_format(str_, str_; remove_extra_newlines = false)
     end
 
     @testset "whitespace in typedefs" begin
         str_ = "Foo{A,B,C}"
         str = "Foo{A, B, C}"
-        @test fmt(str_; whitespace_typedefs = true) == str
+        test_format(str_, str; whitespace_typedefs = true)
 
         str_ = """
         struct Foo{A<:Bar,Union{B<:Fizz,C<:Buzz},<:Any}
@@ -83,7 +99,7 @@
         struct Foo{A <: Bar, Union{B <: Fizz, C <: Buzz}, <:Any}
             a::A
         end"""
-        @test fmt(str_; whitespace_typedefs = true) == str
+        test_format(str_, str; whitespace_typedefs = true)
 
         str_ = """
         function foo() where {A,B,C{D,E,F{G,H,I},J,K},L,M<:N,Y>:Z}
@@ -95,54 +111,54 @@
             body
         end
         """
-        @test fmt(str_; whitespace_typedefs = true) == str
+        test_format(str_, str; whitespace_typedefs = true)
 
         str_ = "foo() where {A,B,C{D,E,F{G,H,I},J,K},L,M<:N,Y>:Z} = body"
         str = "foo() where {A, B, C{D, E, F{G, H, I}, J, K}, L, M <: N, Y >: Z} = body"
-        @test fmt(str_; whitespace_typedefs = true) == str
+        test_format(str_, str; whitespace_typedefs = true)
     end
 
     @testset "whitespace ops in indices" begin
         str = "arr[1 + 2]"
-        @test fmt("arr[1+2]"; m = 1, whitespace_ops_in_indices = true) == str
+        test_format("arr[1+2]", str; margin = 1, whitespace_ops_in_indices = true)
 
         str = "arr[(1 + 2)]"
-        @test fmt("arr[(1+2)]"; m = 1, whitespace_ops_in_indices = true) == str
+        test_format("arr[(1+2)]", str; margin = 1, whitespace_ops_in_indices = true)
 
         str_ = "arr[1:2*num_source*num_dump-1]"
         str = "arr[1:(2 * num_source * num_dump - 1)]"
-        @test fmt(str_; m = 1, whitespace_ops_in_indices = true) == str
+        test_format(str_, str; margin = 1, whitespace_ops_in_indices = true)
 
         str_ = "arr[2*num_source*num_dump-1:1]"
         str = "arr[(2 * num_source * num_dump - 1):1]"
-        @test fmt(str_; m = 1, whitespace_ops_in_indices = true) == str
+        test_format(str_, str; margin = 1, whitespace_ops_in_indices = true)
 
         str = "arr[(a + b):c]"
-        @test fmt("arr[(a+b):c]"; m = 1, whitespace_ops_in_indices = true) == str
+        test_format("arr[(a+b):c]", str; margin = 1, whitespace_ops_in_indices = true)
 
         str = "arr[a in b]"
-        @test fmt(str; m = 1, whitespace_ops_in_indices = true) == str
+        test_format(str, str; margin = 1, whitespace_ops_in_indices = true)
 
         # In v1
         str_ = "a:b+c:d-e"
         str = "a:(b + c):(d - e)"
-        @test fmt(str_; m = 1, whitespace_ops_in_indices = true) == str
+        test_format(str_, str; margin = 1, whitespace_ops_in_indices = true)
         str = "a:(b+c):(d-e)"
-        @test fmt(str_; m = 1, whitespace_ops_in_indices = false) == str
+        test_format(str_, str; margin = 1, whitespace_ops_in_indices = false)
 
         str_ = "s[m+i+1]"
         # issue 180
         str = "s[m+i+1]"
-        @test fmt(str; m = 1, whitespace_ops_in_indices = false) == str
+        test_format(str, str; margin = 1, whitespace_ops_in_indices = false)
 
         str = "s[m + i + 1]"
-        @test fmt(str_; m = 1, whitespace_ops_in_indices = true) == str
+        test_format(str_, str; margin = 1, whitespace_ops_in_indices = true)
     end
 
     @testset "rewrite import to using" begin
         str_ = "import A"
         str = "using A: A"
-        @test fmt(str_; import_to_using = true) == str
+        test_format(str_, str; import_to_using = true)
 
         str_ = """
         import A,
@@ -153,7 +169,7 @@
 
         using B: B
         using C: C"""
-        @test fmt(str_; import_to_using = true) == str
+        test_format(str_, str; import_to_using = true)
 
         str_ = """
         import A,
@@ -164,7 +180,7 @@
         # comment
         using B: B
         using C: C"""
-        @test fmt(str_; import_to_using = true) == str
+        test_format(str_, str; import_to_using = true)
 
         str_ = """
         import A, # inline
@@ -175,7 +191,7 @@
         # comment
         using B: B
         using C: C # inline"""
-        @test fmt(str_; import_to_using = true) == str
+        test_format(str_, str; import_to_using = true)
 
         str_ = """
         import ..A, .B, ...C"""
@@ -183,25 +199,25 @@
         using ..A: A
         using .B: B
         using ...C: C"""
-        @test fmt(str_; import_to_using = true) == str
+        test_format(str_, str; import_to_using = true)
         t = run_pretty(str_; opts = Options(; margin = 80, import_to_using = true))
         @test t.len == 13
 
         # issue 232
         str = """import A.b"""
-        @test fmt(str; import_to_using = true) == str
+        test_format(str, str; import_to_using = true)
 
         str = """import A.b: c"""
-        @test fmt(str; import_to_using = true) == str
+        test_format(str, str; import_to_using = true)
 
         str = """import A.b.c"""
-        @test fmt(str; import_to_using = true) == str
+        test_format(str, str; import_to_using = true)
 
         str = """import A.b.c: d"""
-        @test fmt(str; import_to_using = true) == str
+        test_format(str, str; import_to_using = true)
 
         str = "import ..A"
-        @test fmt(str; import_to_using = true) == str
+        test_format(str, str; import_to_using = true)
     end
 
     @testset "always convert `=` to `in` (for loops)" begin
@@ -213,8 +229,8 @@
         for i in 1:n
             println(i)
         end"""
-        @test fmt(str_; always_for_in = true) == str
-        @test fmt(str; always_for_in = true) == str
+        test_format(str_, str; always_for_in = true)
+        test_format(str, str; always_for_in = true)
 
         str_ = """
         for i = I1, j in I2
@@ -224,8 +240,8 @@
         for i in I1, j in I2
             println(i, j)
         end"""
-        @test fmt(str_; always_for_in = true) == str
-        @test fmt(str; always_for_in = true) == str
+        test_format(str_, str; always_for_in = true)
+        test_format(str, str; always_for_in = true)
 
         str_ = """
         for i = 1:30, j = 100:-2:1
@@ -235,88 +251,89 @@
         for i in 1:30, j in 100:-2:1
             println(i, j)
         end"""
-        @test fmt(str_; always_for_in = true) == str
-        @test fmt(str; always_for_in = true) == str
-        @test fmt(str_; always_for_in = nothing) == str_
-        @test fmt(str; always_for_in = nothing) == str
+        test_format(str_, str; always_for_in = true)
+        test_format(str, str; always_for_in = true)
+        test_format(str_, str_; always_for_in = nothing)
+        test_format(str, str; always_for_in = nothing)
 
         str_ = "[(i,j) for i=I1,j=I2]"
         str = "[(i, j) for i in I1, j in I2]"
-        @test fmt(str_; always_for_in = true) == str
-        @test fmt(str; always_for_in = true) == str
+        test_format(str_, str; always_for_in = true)
+        test_format(str, str; always_for_in = true)
 
         str_ = "((i,j) for i=I1,j=I2)"
         str = "((i, j) for i in I1, j in I2)"
-        @test fmt(str_; always_for_in = true) == str
-        @test fmt(str; always_for_in = true) == str
+        test_format(str_, str; always_for_in = true)
+        test_format(str, str; always_for_in = true)
 
         str_ = "[(i, j) for i = 1:2:10, j = 100:-1:10]"
         str = "[(i, j) for i in 1:2:10, j in 100:-1:10]"
-        @test fmt(str_; always_for_in = true) == str
-        @test fmt(str; always_for_in = true) == str
+        test_format(str_, str; always_for_in = true)
+        test_format(str, str; always_for_in = true)
 
         str_ = "[i for i = 1:10 if i == 2]"
         str = "[i for i in 1:10 if i == 2]"
-        @test fmt(str_; always_for_in = true) == str
-        @test fmt(str; always_for_in = true) == str
+        test_format(str_, str; always_for_in = true)
+        test_format(str, str; always_for_in = true)
 
         str_ = "[(i, j) for i = 1:2:10, j = 100:-1:10]"
         str = "[(i, j) for i in 1:2:10, j in 100:-1:10]"
-        @test yasfmt(str_; always_for_in = true) == str
-        @test yasfmt(str; always_for_in = true) == str
+        test_format(str_, str, YASStyle(); always_for_in = true)
+        test_format(str, str, YASStyle(); always_for_in = true)
 
         str_ = "[i for i = 1:10 if i == 2]"
         str = "[i for i in 1:10 if i == 2]"
-        @test yasfmt(str_; always_for_in = true) == str
-        @test yasfmt(str; always_for_in = true) == str
+        test_format(str_, str, YASStyle(); always_for_in = true)
+        test_format(str, str, YASStyle(); always_for_in = true)
     end
 
     @testset "rewrite x |> f to f(x)" begin
         @testset "basic cases" begin
             for dot in ("", ".")
-                @test fmt("x $dot|> f"; pipe_to_function_call = true) == "f$dot(x)"
-                @test fmt("x $dot|> f()"; pipe_to_function_call = true) == "f()$dot(x)"
-                @test fmt("x $dot|> f(a)"; pipe_to_function_call = true) == "f(a)$dot(x)"
-                @test fmt("x $dot|> M.f"; pipe_to_function_call = true) == "M.f$dot(x)"
-                @test fmt("x $dot|> T{x}"; pipe_to_function_call = true) == "T{x}$dot(x)"
+                test_format("x $dot|> f", "f$dot(x)"; pipe_to_function_call = true)
+                test_format("x $dot|> f()", "f()$dot(x)"; pipe_to_function_call = true)
+                test_format("x $dot|> f(a)", "f(a)$dot(x)"; pipe_to_function_call = true)
+                test_format("x $dot|> M.f", "M.f$dot(x)"; pipe_to_function_call = true)
+                test_format("x $dot|> T{x}", "T{x}$dot(x)"; pipe_to_function_call = true)
                 # Check that callable is parenthesised if necessary
-                @test fmt("x $dot|> y -> y + 1"; pipe_to_function_call = true) == "(y -> y + 1)$dot(x)"
-                @test fmt("x $dot|> f ∘ g"; pipe_to_function_call = true) == "(f ∘ g)$dot(x)"
+                test_format("x $dot|> y -> y + 1", "(y -> y + 1)$dot(x)"; pipe_to_function_call = true)
+                test_format("x $dot|> f ∘ g", "(f ∘ g)$dot(x)"; pipe_to_function_call = true)
             end
         end
 
         @testset "operators on rhs" begin
-            @test fmt("x |> !"; pipe_to_function_call = true) == "!(x)"
-            @test fmt("x .|> !"; pipe_to_function_call = true) == ".!(x)"
+            test_format("x |> !", "!(x)"; pipe_to_function_call = true)
+            test_format("x .|> !", ".!(x)"; pipe_to_function_call = true)
         end
 
         @testset "elision of extra argument parentheses" begin
-            @test fmt("(x) |> f"; pipe_to_function_call = true) == "f(x)"
-            @test fmt("(x) .|> f"; pipe_to_function_call = true) == "f.(x)"
-            @test fmt("(a for a in x) |> f()"; pipe_to_function_call = true) == "f()(a for a in x)"
+            test_format("(x) |> f", "f(x)"; pipe_to_function_call = true)
+            test_format("(x) .|> f", "f.(x)"; pipe_to_function_call = true)
+            test_format("(a for a in x) |> f()", "f()(a for a in x)"; pipe_to_function_call = true)
             # make sure that genuine tuples don't get de-parenthesised
-            @test fmt("(x, y) |> f()"; pipe_to_function_call = true) == "f()((x, y))"
-            @test fmt("(x,) |> f()"; pipe_to_function_call = true) == "f()((x,))"
-            @test fmt("(; x) |> f()"; pipe_to_function_call = true) == "f()((; x))"
+            test_format("(x, y) |> f()", "f()((x, y))"; pipe_to_function_call = true)
+            test_format("(x,) |> f()", "f()((x,))"; pipe_to_function_call = true)
+            test_format("(; x) |> f()", "f()((; x))"; pipe_to_function_call = true)
         end
 
         @testset "chained pipes" begin
             str_ = "var = func1(arg1) |> func2 |> func3 |> func4 |> func5"
             str = "var = func5(func4(func3(func2(func1(arg1)))))"
-            @test fmt(str_; pipe_to_function_call = true) == str
-            @test fmt(str_; pipe_to_function_call = true, margin = 1) == fmt(str)
-            @test fmt("x .|> f .|> g"; pipe_to_function_call = true) == "g.(f.(x))"
-            @test fmt("(x |> f) |> g"; pipe_to_function_call = true) == "g(f(x))"
-            @test fmt("x |> f .|> g"; pipe_to_function_call = true) == "g.(f(x))"
-            @test fmt("x .|> f |> g"; pipe_to_function_call = true) == "g(f.(x))"
-            @test fmt("x |> y -> y |> f"; pipe_to_function_call = true) == "(y -> f(y))(x)"
+            test_format(str_, str; pipe_to_function_call = true)
+            str_nested = format_text(str; margin = 1)
+            test_format(str_, str_nested; pipe_to_function_call = true, margin = 1)
+            test_format("x .|> f .|> g", "g.(f.(x))"; pipe_to_function_call = true)
+            test_format("(x |> f) |> g", "g(f(x))"; pipe_to_function_call = true)
+            test_format("x |> f .|> g", "g.(f(x))"; pipe_to_function_call = true)
+            test_format("x .|> f |> g", "g(f.(x))"; pipe_to_function_call = true)
+            test_format("x |> y -> y |> f", "(y -> f(y))(x)"; pipe_to_function_call = true)
         end
 
         @testset "expressions on lhs" begin
-            @test fmt("f(a, b) |> g"; pipe_to_function_call = true) == "g(f(a, b))"
-            @test fmt("a + b |> f"; pipe_to_function_call = true) == "f(a + b)"
-            @test fmt("[1...] |> f"; pipe_to_function_call = true) == "f([1...])"
-            @test fmt("1:10 |> collect"; pipe_to_function_call = true) == "collect(1:10)"
+            test_format("f(a, b) |> g", "g(f(a, b))"; pipe_to_function_call = true)
+            test_format("a + b |> f", "f(a + b)"; pipe_to_function_call = true)
+            test_format("[1...] |> f", "f([1...])"; pipe_to_function_call = true)
+            test_format("1:10 |> collect", "collect(1:10)"; pipe_to_function_call = true)
         end
 
         @testset "nesting" begin
@@ -325,7 +342,8 @@
                 x = "very_long_variable_name"
                 str_ = "$x $(dot)|> $f"
                 str = "$f$(dot)($x)"
-                @test fmt(str_; pipe_to_function_call = true, margin = 1) == fmt(str; margin = 1)
+                str_nested = format_text(str; margin = 1)
+                test_format(str_, str_nested; pipe_to_function_call = true, margin = 1)
             end
 
             @testset "extra idempotence test" begin
@@ -354,8 +372,8 @@
                         ),
                     )
                 end"""
-                @test fmt(str_; pipe_to_function_call = true) == str
-                @test fmt(str; pipe_to_function_call = true) == str
+                test_format(str_, str; pipe_to_function_call = true)
+                test_format(str, str; pipe_to_function_call = true)
             end
         end
 
@@ -367,7 +385,7 @@
                 str = """g$dot(begin
                     f
                 end)"""
-                @test fmt(str_; pipe_to_function_call = true) == str
+                test_format(str_, str; pipe_to_function_call = true)
             end
         end
 
@@ -383,27 +401,27 @@
                     g(a)
                 end)$dot(x)
                 """
-                @test fmt(str_; pipe_to_function_call = true) == str
+                test_format(str_, str; pipe_to_function_call = true)
             end
         end
 
         @testset "cases where transformation should not happen" begin
             # inside macro
             smacro = "@macro x |> f"
-            @test fmt(smacro; pipe_to_function_call = true) == smacro
+            test_format(smacro, smacro; pipe_to_function_call = true)
             smacro2 = "@macro function f()\n    x |> g\nend"
-            @test fmt(smacro2; pipe_to_function_call = true) == smacro2
+            test_format(smacro2, smacro2; pipe_to_function_call = true)
 
             # inside Expr
             sexpr = ":(x |> f)"
-            @test fmt(sexpr; pipe_to_function_call = true) == sexpr
+            test_format(sexpr, sexpr; pipe_to_function_call = true)
             squote = "quote\n    x |> f\nend"
-            @test fmt(squote; pipe_to_function_call = true) == squote
+            test_format(squote, squote; pipe_to_function_call = true)
 
             # dotted tuple of functions
             # https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/647
             sdotcall = "x .|> (f, g)"
-            @test fmt(sdotcall; pipe_to_function_call = true) == sdotcall
+            test_format(sdotcall, sdotcall; pipe_to_function_call = true)
         end
     end
 
@@ -413,38 +431,28 @@
         function foo(a)
             bodybodybody
         end"""
-        @test fmt(str_, 4, length(str_); short_to_long_function_def = true) == str_
-        @test fmt(str_, 4, length(str_) - 1; short_to_long_function_def = true) == str
+        test_format(str_, str_; indent=4, margin=length(str_), short_to_long_function_def = true)
+        test_format(str_, str; indent=4, margin=length(str_) - 1, short_to_long_function_def = true)
 
         str_ = "foo(a::T) where {T} = bodybodybodybodybodybodyb"
         str = """
         function foo(a::T) where {T}
             bodybodybodybodybodybodyb
         end"""
-        @test fmt(str_, 4, length(str_); short_to_long_function_def = true) == str_
-        @test fmt(str_, 4, length(str_) - 1; short_to_long_function_def = true) == str
+        test_format(str_, str_; indent=4, margin=length(str_), short_to_long_function_def = true)
+        test_format(str_, str; indent=4, margin=length(str_) - 1, short_to_long_function_def = true)
 
         str_ = "foo(a::T)::R where {T} = bodybodybodybodybodybodybody"
         str = """
         function foo(a::T)::R where {T}
             bodybodybodybodybodybodybody
         end"""
-        @test fmt(str_, 4, length(str_); short_to_long_function_def = true) == str_
-        @test fmt(
-            str_,
-            4,
-            length(str_);
-            short_to_long_function_def = true,
-            force_long_function_def = true,
-        ) == str
-        @test fmt(
-            str_,
-            4,
-            length(str_);
-            short_to_long_function_def = false,
-            force_long_function_def = false,
-        ) == str_
-        @test fmt(str_, 4, length(str_) - 1; short_to_long_function_def = true) == str
+        test_format(str_, str_; indent=4, margin=length(str_), short_to_long_function_def = true)
+        test_format(str_, str; indent=4, margin=length(str_), short_to_long_function_def = true,
+            force_long_function_def = true)
+        test_format(str_, str_; indent=4, margin=length(str_), short_to_long_function_def = false,
+            force_long_function_def = false)
+        test_format(str_, str; indent=4, margin=length(str_) - 1, short_to_long_function_def = true)
     end
 
     @testset "function longdef to shortdef" begin
@@ -453,38 +461,38 @@
             bodybodybody
         end"""
         str = "foo(a) = bodybodybody"
-        @test fmt(str_, 4, length(str) - 1; long_to_short_function_def = true) == str_
-        @test fmt(str_, 4, length(str); long_to_short_function_def = true) == str
+        test_format(str_, str_; indent=4, margin=length(str) - 1, long_to_short_function_def = true)
+        test_format(str_, str; indent=4, margin=length(str), long_to_short_function_def = true)
 
         str_ = """
         function foo(a::T) where {T}
             bodybodybodybodybodybodyb
         end"""
         str = "foo(a::T) where {T} = bodybodybodybodybodybodyb"
-        @test fmt(str_, 4, length(str) - 1; long_to_short_function_def = true) == str_
-        @test fmt(str_, 4, length(str); long_to_short_function_def = true) == str
+        test_format(str_, str_; indent=4, margin=length(str) - 1, long_to_short_function_def = true)
+        test_format(str_, str; indent=4, margin=length(str), long_to_short_function_def = true)
 
         str_ = """
         function foo(a::T)::R where {T}
             bodybodybodybodybodybodybody
         end"""
         str = "foo(a::T)::R where {T} = bodybodybodybodybodybodybody"
-        @test fmt(str_, 4, length(str) - 1; long_to_short_function_def = true) == str_
-        @test fmt(str_, 4, length(str); long_to_short_function_def = true) == str
+        test_format(str_, str_; indent=4, margin=length(str) - 1, long_to_short_function_def = true)
+        test_format(str_, str; indent=4, margin=length(str), long_to_short_function_def = true)
 
         str_ = """
         function foo(a)
             return a + 1
         end"""
         str = "foo(a) = a + 1"
-        @test fmt(str_, 4, length(str); long_to_short_function_def = true) == str
+        test_format(str_, str; indent=4, margin=length(str), long_to_short_function_def = true)
 
         str = """
         function foo()
             expr1
             expr2
         end"""
-        @test fmt(str, 4, length(str); long_to_short_function_def = true) == str
+        test_format(str, str; indent=4, margin=length(str), long_to_short_function_def = true)
 
         str_ = """
         function foo(a)
@@ -502,8 +510,8 @@
             else
                 nothing
             end"""
-        @test fmt1(str_, 4, length(str); long_to_short_function_def = true) == str
-        @test fmt(str_, 4, length(str); long_to_short_function_def = true) == str
+        test_format(str_, str; indent=4, margin=length(str), long_to_short_function_def = true)
+        test_format(str_, str; indent=4, margin=length(str), long_to_short_function_def = true)
     end
 
     @testset "always use return" begin
@@ -512,13 +520,8 @@
         function foo(a)
             return bodybodybody
         end"""
-        @test fmt(
-            str_,
-            4,
-            length(str_) - 1;
-            short_to_long_function_def = true,
-            always_use_return = true,
-        ) == str
+        test_format(str_, str; indent=4, margin=length(str_) - 1, short_to_long_function_def = true,
+            always_use_return = true)
 
         str_ = """
         function foo()
@@ -530,7 +533,7 @@
             expr1
             return expr2
         end"""
-        @test fmt(str_, 4, length(str_) - 1; always_use_return = true) == str
+        test_format(str_, str; indent=4, margin=length(str_) - 1, always_use_return = true)
 
         str_ = """
         macro foo()
@@ -542,7 +545,7 @@
             expr1
             return expr2
         end"""
-        @test fmt(str_, 4, length(str_) - 1; always_use_return = true) == str
+        test_format(str_, str; indent=4, margin=length(str_) - 1, always_use_return = true)
 
         str_ = """
         map(arg1, arg2) do x, y
@@ -554,19 +557,19 @@
             expr1
             return expr2
         end"""
-        @test fmt(str_, 4, length(str_) - 1; always_use_return = true) == str
+        test_format(str_, str; indent=4, margin=length(str_) - 1, always_use_return = true)
 
         str = """
         function foo()
             @macrocall(expr2)
         end"""
-        @test fmt(str, 4, 92; always_use_return = true) == str
+        test_format(str, str; indent=4, margin=92, always_use_return = true)
 
         str = """
         function foo()
             @macroblock expr2
         end"""
-        @test fmt(str, 4, 92; always_use_return = true) == str
+        test_format(str, str; indent=4, margin=92, always_use_return = true)
 
         str = """
         function foo()
@@ -574,7 +577,7 @@
                 println(i)
             end
         end"""
-        @test fmt(str, 4, 92; always_use_return = true) == str
+        test_format(str, str; indent=4, margin=92, always_use_return = true)
 
         str = """
         function f(a)
@@ -584,7 +587,7 @@
                 return 1
             end
         end"""
-        @test fmt(str, 4, 92; always_use_return = true) == str
+        test_format(str, str; indent=4, margin=92, always_use_return = true)
 
         @testset "426" begin
             # throw function heuristic
@@ -595,7 +598,7 @@
                 throw(ArgumentError("x must be 1 or 2"))
             end
             """
-            @test fmt(str; always_use_return = true) == str
+            test_format(str, str; always_use_return = true)
         end
 
         @testset "507" begin
@@ -605,39 +608,39 @@
                 (1 + 1; return 2)
             end
             """
-            @test fmt(str; always_use_return = true) == str
+            test_format(str, str; always_use_return = true)
         end
     end
 
     @testset "whitespace in keyword arguments" begin
         str_ = "f(; a = b)"
         str = "f(; a=b)"
-        @test fmt(str_, 4, 92; whitespace_in_kwargs = false) == str
+        test_format(str_, str; indent=4, margin=92, whitespace_in_kwargs = false)
 
         str = "f(; a!) = a!"
-        @test fmt(str, 4, 92; whitespace_in_kwargs = false) == str
+        test_format(str, str; indent=4, margin=92, whitespace_in_kwargs = false)
 
         # issue 242
         str_ = "f(a, b! = 1; c! = 2, d = 3, e! = 4)"
         str = "f(a, (b!)=1; (c!)=2, d=3, (e!)=4)"
-        @test fmt(str_, 4, 92; whitespace_in_kwargs = false) == str
+        test_format(str_, str; indent=4, margin=92, whitespace_in_kwargs = false)
 
         str_ = "( k1 =v1,  k2! = v2)"
         str = "(k1=v1, (k2!)=v2)"
-        @test fmt(str_, 4, 80; style = YASStyle(), whitespace_in_kwargs = false) == str
-        @test fmt(str_, 4, 80; style = DefaultStyle(), whitespace_in_kwargs = false) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=80, whitespace_in_kwargs = false)
+        test_format(str_, str; indent=4, margin=80, whitespace_in_kwargs = false)
 
         str_ = "( k1 =v1,  k2! = v2)"
         str = "(k1 = v1, k2! = v2)"
-        @test fmt(str_, 4, 80; style = YASStyle(), whitespace_in_kwargs = true) == str
-        @test fmt(str_, 4, 80; style = DefaultStyle(), whitespace_in_kwargs = true) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=80, whitespace_in_kwargs = true)
+        test_format(str_, str; indent=4, margin=80, whitespace_in_kwargs = true)
 
         str_ = "(; g = >=(1))"
         str = "(; g=(>=(1)))"
-        @test fmt(str_, 4, 92; whitespace_in_kwargs = false) == str
+        test_format(str_, str; indent=4, margin=92, whitespace_in_kwargs = false)
 
         s = "C(; Vt=Ȳ')"
-        @test fmt(s, 4, 100; whitespace_in_kwargs = false) == s
+        test_format(s, s; indent=4, margin=100, whitespace_in_kwargs = false)
     end
 
     @testset "annotate untyped fields with `Any`" begin
@@ -650,19 +653,19 @@
         struct name
             arg
         end"""
-        @test fmt(str_) == str
+        test_format(str_, str)
 
         str_ = """
         struct name
         arg
         end"""
-        @test fmt(str_) == str
+        test_format(str_, str)
 
         str_ = """
         struct name
                 arg
             end"""
-        @test fmt(str_) == str
+        test_format(str_, str)
 
         t = run_pretty(str_, 80)
         @test length(t) == 12
@@ -676,19 +679,19 @@
         mutable struct name
             reallylongfieldname
         end"""
-        @test fmt(str_) == str
+        test_format(str_, str)
 
         str_ = """
         mutable struct name
         reallylongfieldname
         end"""
-        @test fmt(str_) == str
+        test_format(str_, str)
 
         str_ = """
         mutable struct name
                 reallylongfieldname
             end"""
-        @test fmt(str_) == str
+        test_format(str_, str)
 
         t = run_pretty(str_, 80)
         @test length(t) == 28
@@ -702,19 +705,19 @@
         struct name
             arg
         end"""
-        @test fmt(str_; annotate_untyped_fields_with_any = false) == str
+        test_format(str_, str; annotate_untyped_fields_with_any = false)
 
         str_ = """
         struct name
         arg
         end"""
-        @test fmt(str_; annotate_untyped_fields_with_any = false) == str
+        test_format(str_, str; annotate_untyped_fields_with_any = false)
 
         str_ = """
         struct name
                 arg
             end"""
-        @test fmt(str_; annotate_untyped_fields_with_any = false) == str
+        test_format(str_, str; annotate_untyped_fields_with_any = false)
 
         t = run_pretty(
             str_;
@@ -731,19 +734,19 @@
         mutable struct name
             reallylongfieldname
         end"""
-        @test fmt(str_; annotate_untyped_fields_with_any = false) == str
+        test_format(str_, str; annotate_untyped_fields_with_any = false)
 
         str_ = """
         mutable struct name
         reallylongfieldname
         end"""
-        @test fmt(str_; annotate_untyped_fields_with_any = false) == str
+        test_format(str_, str; annotate_untyped_fields_with_any = false)
 
         str_ = """
         mutable struct name
                 reallylongfieldname
             end"""
-        @test fmt(str_; annotate_untyped_fields_with_any = false) == str
+        test_format(str_, str; annotate_untyped_fields_with_any = false)
 
         t = run_pretty(
             str_;
@@ -778,8 +781,8 @@
             function f()
                 20
             end"""
-            @test fmt(str) == str
-            @test fmt(str; format_docstrings = true) == normalized
+            test_format(str, str)
+            test_format(str, normalized; format_docstrings = true)
 
             str = """
             \"""
@@ -787,16 +790,16 @@
             function f()
                 20
             end"""
-            @test fmt(str) == str
-            @test fmt(str; format_docstrings = true) == normalized
+            test_format(str, str)
+            test_format(str, normalized; format_docstrings = true)
 
             str = """
             \"""doc\"""
             function f()
                 20
             end"""
-            @test fmt(str) == str
-            @test fmt(str; format_docstrings = true) == normalized
+            test_format(str, str)
+            test_format(str, normalized; format_docstrings = true)
 
             str = """
             "doc
@@ -804,8 +807,8 @@
             function f()
                 20
             end"""
-            @test fmt(str) == str
-            @test fmt(str; format_docstrings = true) == normalized
+            test_format(str, str)
+            test_format(str, normalized; format_docstrings = true)
 
             str = """
             "
@@ -813,16 +816,16 @@
             function f()
                 20
             end"""
-            @test fmt(str) == str
-            @test fmt(str; format_docstrings = true) == normalized
+            test_format(str, str)
+            test_format(str, normalized; format_docstrings = true)
 
             str = """
             "doc"
             function f()
                 20
             end"""
-            @test fmt(str) == str
-            @test fmt(str; format_docstrings = true) == normalized
+            test_format(str, str)
+            test_format(str, normalized; format_docstrings = true)
 
             # test aligning to function identation
             str_ = """
@@ -835,14 +838,14 @@
             function f()
                 20
             end"""
-            @test fmt(str_) == str
-            @test fmt(str_; format_docstrings = true) == normalized
+            test_format(str_, str)
+            test_format(str_, normalized; format_docstrings = true)
 
             str = """\"""
                      doc for Foo
                      \"""
                      Foo"""
-            @test fmt(str) == str
+            test_format(str, str)
             t = run_pretty(str, 80)
             @test length(t) == 11
 
@@ -853,8 +856,8 @@
             function f()    #  comment
                 20
             end"""
-            @test fmt(str) == str
-            @test fmt(str; format_docstrings = true) == str
+            test_format(str, str)
+            test_format(str, str; format_docstrings = true)
 
             # Issue 157
             str = raw"""
@@ -862,32 +865,32 @@
                foo()
             \"""
             foo() = bar()"""
-            @test fmt(str) == str
-            @test fmt(str; format_docstrings = true) == str
+            test_format(str, str)
+            test_format(str, str; format_docstrings = true)
 
             str = raw"""
             @doc docϵ\"""
                foo()
             \"""
             foo() = bar()"""
-            @test fmt(str) == str
-            @test fmt(str; format_docstrings = true) == str
+            test_format(str, str)
+            test_format(str, str; format_docstrings = true)
 
             str = raw"""@doc "doc for foo" foo"""
-            @test fmt(str) == str
-            @test fmt(str; format_docstrings = true) == str
+            test_format(str, str)
+            test_format(str, str; format_docstrings = true)
 
             str = raw"""@doc \"""doc for foo\""" foo"""
-            @test fmt(str) == str
-            @test fmt(str; format_docstrings = true) == str
+            test_format(str, str)
+            test_format(str, str; format_docstrings = true)
 
             str = raw"""@doc doc\"""doc for foo\""" foo()"""
-            @test fmt(str) == str
-            @test fmt(str; format_docstrings = true) == str
+            test_format(str, str)
+            test_format(str, str; format_docstrings = true)
 
             str = raw"""@doc foo"""
-            @test fmt(str) == str
-            @test fmt(str; format_docstrings = true) == str
+            test_format(str, str)
+            test_format(str, str; format_docstrings = true)
 
             # issue 160
             str = raw"""
@@ -901,8 +904,8 @@
             foo() = bar()
 
             end # module"""
-            @test fmt(str) == str
-            @test fmt(str; format_docstrings = true) == str
+            test_format(str, str)
+            test_format(str, str; format_docstrings = true)
         end
 
         @testset "with code" begin
@@ -982,7 +985,7 @@
             function test(x)
                 x
             end"""
-            @test fmt(unformatted; format_docstrings = true) == formatted
+            test_format(unformatted, formatted; format_docstrings = true)
         end
 
         @testset "issue 602" begin
@@ -997,7 +1000,7 @@
             \"""
             foo() = nothing
             """
-            @test fmt(s; format_docstrings = true) == s
+            test_format(s, s; format_docstrings = true)
         end
 
         @testset "Multi-line indented code-blocks" begin
@@ -1014,7 +1017,7 @@
                 )
             \"""
             function fmt() end"""
-            @test fmt(unformatted; format_docstrings = true) == formatted
+            test_format(unformatted, formatted; format_docstrings = true)
         end
 
         @testset "Empty line in docstring" begin
@@ -1028,8 +1031,8 @@
             \"""
             \"""
             function test() end"""
-            @test fmt(unformatted; format_docstrings = true) == formatted
-            @test fmt(unformatted; format_docstrings = false) == unformatted
+            test_format(unformatted, formatted; format_docstrings = true)
+            test_format(unformatted, unformatted; format_docstrings = false)
         end
 
         @testset "Indented docstring" begin
@@ -1051,7 +1054,7 @@
                 \"""
                 indented_item
             end"""
-            @test fmt(unformatted; format_docstrings = true) == formatted
+            test_format(unformatted, formatted; format_docstrings = true)
 
             short = """
             begin
@@ -1067,7 +1070,7 @@
                 item
             end
             """
-            @test fmt(short; format_docstrings = true) == short_formatted
+            test_format(short, short_formatted; format_docstrings = true)
         end
 
         @testset "issue 597" begin
@@ -1090,7 +1093,7 @@
             \"""
             foo() = println("hello world")
             """
-            @test fmt(str_; format_docstrings = true) == str
+            test_format(str_, str; format_docstrings = true)
 
             s = """
             \"\"\"
@@ -1105,7 +1108,7 @@
             \"\"\"
             foo() = [1]
             """
-            @test fmt(str; format_docstrings = true) == str
+            test_format(str, str; format_docstrings = true)
         end
     end
 
@@ -1118,7 +1121,7 @@
         struct Foo
             a::T
         end"""
-        @test fmt(str_; align_struct_field = true) == str
+        test_format(str_, str; align_struct_field = true)
 
         str = """
         struct Foo
@@ -1130,8 +1133,8 @@
             a::T
             longfieldname::B
         end"""
-        @test fmt(str; align_struct_field = true) == str
-        @test fmt(str; align_struct_field = false) == str_
+        test_format(str, str; align_struct_field = true)
+        test_format(str, str_; align_struct_field = false)
 
         str_ = """
         Base.@kwdef struct Options
@@ -1177,7 +1180,7 @@
 
             Options() = new()
         end"""
-        @test fmt(str_; align_struct_field = true) == str
+        test_format(str_, str; align_struct_field = true)
 
         str_ = """
         Base.@kwdef struct Options
@@ -1201,8 +1204,8 @@
 
             Options() = new()
         end"""
-        @test fmt(str; align_struct_field = true) == str
-        @test fmt(str; align_struct_field = false) == str_
+        test_format(str, str; align_struct_field = true)
+        test_format(str, str_; align_struct_field = false)
 
         str = """
         Base.@kwdef struct Options
@@ -1229,7 +1232,7 @@
             Options() =
                 new()
         end"""
-        @test fmt(str, 4, 1; align_struct_field = true) == str
+        test_format(str, str; indent=4, margin=1, align_struct_field = true)
     end
 
     @testset "align assignment" begin
@@ -1243,14 +1246,14 @@
         const var2      = 2
         const var3      = 3
         const var4      = 4"""
-        @test fmt(str_; align_assignment = true) == str
+        test_format(str_, str; align_assignment = true)
 
         str = """
         const variable1 = 1
         const variable2 = 2
         const var3 = 3
         const var4 = 4"""
-        @test fmt(str; align_assignment = true) == str
+        test_format(str, str; align_assignment = true)
 
         str_ = """
         module Foo
@@ -1297,8 +1300,8 @@
         const FOO = 1
 
         end"""
-        @test fmt(str_; align_assignment = true) == str
-        @test fmt(str_; align_assignment = true, join_lines_based_on_source = true) == str
+        test_format(str_, str; align_assignment = true)
+        test_format(str_, str; align_assignment = true, join_lines_based_on_source = true)
 
         # the aligned consts will NOT be nestable
         str = """
@@ -1325,9 +1328,8 @@
             1
 
         end"""
-        @test fmt(str_, 4, 1; align_assignment = true) == str
-        @test fmt(str_, 4, 1; align_assignment = true, join_lines_based_on_source = true) ==
-              str
+        test_format(str_, str; indent=4, margin=1, align_assignment = true)
+        test_format(str_, str; indent=4, margin=1, align_assignment = true, join_lines_based_on_source = true)
 
         str = """
         a  = 1
@@ -1336,14 +1338,14 @@
         long_variable = 1
         other_var     = 2
         """
-        @test fmt(str, 4, 1; align_assignment = true) == str
+        test_format(str, str; indent=4, margin=1, align_assignment = true)
 
         str = """
         eclipse  = true
         s̄_b      = SVector{3,T}(0, 0, 0)
         css_axes = :css_axes_eclipse
         """
-        @test fmt(str; align_assignment = true) == str
+        test_format(str, str; align_assignment = true)
 
         str = """
         vcat(X::T...) where {T}         = T[X[i] for i = 1:length(X)]
@@ -1351,9 +1353,8 @@
         hcat(X::T...) where {T}         = T[X[j] for i = 1:1, j = 1:length(X)]
         hcat(X::T...) where {T<:Number} = T[X[j] for i = 1:1, j = 1:length(X)]
         """
-        @test fmt(str, 4, 1; align_assignment = true) == str
-        @test fmt(str, 4, 1; align_assignment = true, join_lines_based_on_source = true) ==
-              str
+        test_format(str, str; indent=4, margin=1, align_assignment = true)
+        test_format(str, str; indent=4, margin=1, align_assignment = true, join_lines_based_on_source = true)
 
         # ambiguous ordering
         str = """
@@ -1361,7 +1362,7 @@
         ms, μs = divrem(μs, 1000)
         s, ms = divrem(ms, 1000)
         """
-        @test fmt(str; align_assignment = true) == str
+        test_format(str, str; align_assignment = true)
 
         str = """
         run = wandb.init(
@@ -1380,15 +1381,10 @@
             anonymous = anonymous ? "allow" : "never",
         )
         """
-        @test fmt(str, 4, 100; align_assignment = true, whitespace_in_kwargs = false) == str
-        @test fmt(
-            str,
-            4,
-            100;
-            align_assignment = true,
+        test_format(str, str; indent=4, margin=100, align_assignment = true, whitespace_in_kwargs = false)
+        test_format(str, str; indent=4, margin=100, align_assignment = true,
             whitespace_in_kwargs = false,
-            join_lines_based_on_source = true,
-        ) == str
+            join_lines_based_on_source = true)
 
         str_ = """
         s           = model.sys
@@ -1402,14 +1398,9 @@
         C            = s.C
         poles        = eigvals(A - K * C)
         """
-        @test fmt(str_, 4, 100; align_assignment = true) == str
-        @test fmt(
-            str_,
-            4,
-            100;
-            align_assignment = true,
-            join_lines_based_on_source = true,
-        ) == str
+        test_format(str_, str; indent=4, margin=100, align_assignment = true)
+        test_format(str_, str; indent=4, margin=100, align_assignment = true,
+            join_lines_based_on_source = true)
 
         str_ = """
         s             = model.sys
@@ -1423,7 +1414,7 @@
         C             = s.C
         const polesss = eigvals(A - K * C)
         """
-        @test fmt(str_, 4, 100; align_assignment = true) == str
+        test_format(str_, str; indent=4, margin=100, align_assignment = true)
 
         str = """
         function stabilize(model)
@@ -1442,14 +1433,9 @@
             model
         end
         """
-        @test fmt(str, 4, 100; align_assignment = true) == str
-        @test fmt(
-            str,
-            4,
-            100;
-            align_assignment = true,
-            join_lines_based_on_source = true,
-        ) == str
+        test_format(str, str; indent=4, margin=100, align_assignment = true)
+        test_format(str, str; indent=4, margin=100, align_assignment = true,
+            join_lines_based_on_source = true)
     end
 
     @testset "align conditionals" begin
@@ -1467,7 +1453,7 @@
             n,
         )
         """
-        @test fmt(str_; align_conditional = true) == str
+        test_format(str_, str; align_conditional = true)
 
         str = """
         index =
@@ -1478,7 +1464,7 @@
                 n,
             )
         """
-        @test fmt(str_, 4, 1; align_conditional = true) == str
+        test_format(str_, str; indent=4, margin=1, align_conditional = true)
 
         str_ = """
         index = zeros(n <= typemax(Int8)  ? Int8 :   # inline
@@ -1500,14 +1486,9 @@
                 n,
             )
         """
-        @test fmt(str_, 4, 1; align_conditional = true) == str
-        @test fmt(
-            str_,
-            4,
-            1;
-            align_conditional = true,
-            join_lines_based_on_source = true,
-        ) == str
+        test_format(str_, str; indent=4, margin=1, align_conditional = true)
+        test_format(str_, str; indent=4, margin=1, align_conditional = true,
+            join_lines_based_on_source = true)
 
         str_ = """
         index = zeros(n <= typemax(Int8)  ? Int8  :    # inline
@@ -1522,14 +1503,9 @@
                 n,
             )
         """
-        @test fmt(str_, 4, 1; align_conditional = true) == str
-        @test fmt(
-            str_,
-            4,
-            1;
-            align_conditional = true,
-            join_lines_based_on_source = true,
-        ) == str
+        test_format(str_, str; indent=4, margin=1, align_conditional = true)
+        test_format(str_, str; indent=4, margin=1, align_conditional = true,
+            join_lines_based_on_source = true)
 
         str_ = """
         index =
@@ -1549,7 +1525,7 @@
                 n,
             )
         """
-        @test fmt(str_, 4, 1; align_conditional = true) == str
+        test_format(str_, str; indent=4, margin=1, align_conditional = true)
 
         str_ = """
         val = cst.kind === Tokens.ABSTRACT ? "abstract" :
@@ -1558,7 +1534,7 @@
         str = """
         val = cst.kind === Tokens.ABSTRACT ? "abstract" : cst.kind === Tokens.BAREMODULE ? "baremodule" : ""
         """
-        @test fmt(str_, 4, 100; align_conditional = true) == str
+        test_format(str_, str; indent=4, margin=100, align_conditional = true)
 
         str_ = """
         val = cst.kind === Tokens.ABSTRACT ? "abstract" :
@@ -1568,28 +1544,18 @@
         val = cst.kind === Tokens.ABSTRACT  ? "abstract" :
               cst.kind === Tokens.BAREMODUL ? "baremodule" : ""
         """
-        @test fmt(str_, 4, 100; align_conditional = true) == str
-        @test fmt(
-            str_,
-            4,
-            100;
-            align_conditional = true,
-            join_lines_based_on_source = true,
-        ) == str
+        test_format(str_, str; indent=4, margin=100, align_conditional = true)
+        test_format(str_, str; indent=4, margin=100, align_conditional = true,
+            join_lines_based_on_source = true)
 
         str = """
         val =
             cst.kind === Tokens.ABSTRACT  ? "abstract" :
             cst.kind === Tokens.BAREMODUL ? "baremodule" : ""
         """
-        @test fmt(str_, 4, 1; align_conditional = true) == str
-        @test fmt(
-            str_,
-            4,
-            1;
-            align_conditional = true,
-            join_lines_based_on_source = true,
-        ) == str
+        test_format(str_, str; indent=4, margin=1, align_conditional = true)
+        test_format(str_, str; indent=4, margin=1, align_conditional = true,
+            join_lines_based_on_source = true)
     end
 
     @testset "align pair arrow `=>`" begin
@@ -1621,7 +1587,7 @@
             "API Reference"       => "api.md",
         ]
         """
-        @test fmt(str_, 4, 100; align_pair_arrow = true) == str
+        test_format(str_, str; indent=4, margin=100, align_pair_arrow = true)
 
         str = """
         pages =
@@ -1638,16 +1604,15 @@
                 "API Reference"       => "api.md",
             ]
         """
-        @test fmt(str_, 4, 1; align_pair_arrow = true) == str
-        @test fmt(str_, 4, 1; align_pair_arrow = true, join_lines_based_on_source = true) ==
-              str
+        test_format(str_, str; indent=4, margin=1, align_pair_arrow = true)
+        test_format(str_, str; indent=4, margin=1, align_pair_arrow = true, join_lines_based_on_source = true)
     end
 
     @testset "conditional to `if` block" begin
         str_ = """
         E ? A : B
         """
-        @test fmt(str_, 2, 9; conditional_to_if = true) == str_
+        test_format(str_, str_; indent=2, margin=9, conditional_to_if = true)
 
         str = """
         if E
@@ -1656,14 +1621,14 @@
           B
         end
         """
-        @test fmt(str_, 2, 8; conditional_to_if = true) == str
+        test_format(str_, str; indent=2, margin=8, conditional_to_if = true)
 
         str_ = """
         begin
             E1 ? A : E2 ? B : foo(E333, E444) ? D : E
         end
         """
-        @test fmt(str_, 4, 45; conditional_to_if = true) == str_
+        test_format(str_, str_; indent=4, margin=45, conditional_to_if = true)
 
         str = """
         begin
@@ -1678,8 +1643,8 @@
             end
         end
         """
-        @test fmt(str_, 4, 44; conditional_to_if = true) == str
-        @test fmt(str_, 4, 26; conditional_to_if = true) == str
+        test_format(str_, str; indent=4, margin=44, conditional_to_if = true)
+        test_format(str_, str; indent=4, margin=26, conditional_to_if = true)
 
         str = """
         begin
@@ -1697,7 +1662,7 @@
             end
         end
         """
-        @test fmt(str_, 4, 25; conditional_to_if = true) == str
+        test_format(str_, str; indent=4, margin=25, conditional_to_if = true)
 
         str_ = """
         foobar = some_big_long_thing * 10_000 == 2 ?
@@ -1716,7 +1681,7 @@
             another_big_long_thing * 10^300 / this_things_here
         end
         """
-        @test fmt(str_; conditional_to_if = true) == str
+        test_format(str_, str; conditional_to_if = true)
     end
 
     @testset "normalize_line_endings" begin
@@ -1725,20 +1690,20 @@
         mixed_windows_str = "a\r\nb\r\nc\nd"
         mixed_unix_str = "a\r\nb\nc\nd"
 
-        @test fmt(windows_str; normalize_line_endings = "auto") == windows_str
-        @test fmt(unix_str; normalize_line_endings = "auto") == unix_str
-        @test fmt(mixed_windows_str; normalize_line_endings = "auto") == windows_str
-        @test fmt(mixed_unix_str; normalize_line_endings = "auto") == unix_str
+        test_format(windows_str, windows_str; normalize_line_endings = "auto")
+        test_format(unix_str, unix_str; normalize_line_endings = "auto")
+        test_format(mixed_windows_str, windows_str; normalize_line_endings = "auto")
+        test_format(mixed_unix_str, unix_str; normalize_line_endings = "auto")
 
-        @test fmt(windows_str; normalize_line_endings = "unix") == unix_str
-        @test fmt(unix_str; normalize_line_endings = "unix") == unix_str
-        @test fmt(mixed_windows_str; normalize_line_endings = "unix") == unix_str
-        @test fmt(mixed_unix_str; normalize_line_endings = "unix") == unix_str
+        test_format(windows_str, unix_str; normalize_line_endings = "unix")
+        test_format(unix_str, unix_str; normalize_line_endings = "unix")
+        test_format(mixed_windows_str, unix_str; normalize_line_endings = "unix")
+        test_format(mixed_unix_str, unix_str; normalize_line_endings = "unix")
 
-        @test fmt(windows_str; normalize_line_endings = "windows") == windows_str
-        @test fmt(unix_str; normalize_line_endings = "windows") == windows_str
-        @test fmt(mixed_windows_str; normalize_line_endings = "windows") == windows_str
-        @test fmt(mixed_unix_str; normalize_line_endings = "windows") == windows_str
+        test_format(windows_str, windows_str; normalize_line_endings = "windows")
+        test_format(unix_str, windows_str; normalize_line_endings = "windows")
+        test_format(mixed_windows_str, windows_str; normalize_line_endings = "windows")
+        test_format(mixed_unix_str, windows_str; normalize_line_endings = "windows")
     end
 
     @testset "align matrix" begin
@@ -1750,13 +1715,13 @@
             2 α b
         ]
         """
-        @test fmt(fmt(str); align_matrix = true) == str
+        test_format(str, str; align_matrix = true)
         str_ = """
         a = [100 300 400
              1 eee 40000
              2 α b]
         """
-        @test fmt(fmt(str); align_matrix = true, style = YASStyle()) == str_
+        test_format(str, str_, YASStyle(); align_matrix = true)
 
         # left-aligned
         str = """
@@ -1766,13 +1731,13 @@
             2   α   b
         ]
         """
-        @test fmt(str; align_matrix = true) == str
+        test_format(str, str; align_matrix = true)
         str_ = """
         a = [100 300 400
              1   eee 40000
              2   α   b]
         """
-        @test fmt(str; align_matrix = true, style = YASStyle()) == str_
+        test_format(str, str_, YASStyle(); align_matrix = true)
 
         # right-aligned
         str = """
@@ -1782,13 +1747,13 @@
               2    α 40000
         ]
         """
-        fmt(str; align_matrix = true) == str
+        test_format(str, str; align_matrix = true)
         str_ = """
         a = [100 3000   400
                1  eee     b
                2    α 40000]
         """
-        @test fmt(str; align_matrix = true, style = YASStyle()) == str_
+        test_format(str, str_, YASStyle(); align_matrix = true)
     end
 
     @testset "trailing commas" begin
@@ -1800,15 +1765,15 @@
         )"""
 
         str_ = "funccall(arg1, arg2, arg3)"
-        @test fmt(str_, 4, 1; trailing_comma = false) == str
+        test_format(str_, str; indent=4, margin=1, trailing_comma = false)
 
         # last comma is removed
 
         str_ = "funccall(arg1, arg2, arg3,)"
-        @test fmt(str_, 4, 1; trailing_comma = false) == str
+        test_format(str_, str; indent=4, margin=1, trailing_comma = false)
 
         str = "funccall(arg1, arg2, arg3)"
-        @test fmt(str_; trailing_comma = false) == str
+        test_format(str_, str; trailing_comma = false)
 
         # corner case - if the comma is removed it is no longer a tuple
         str_ = "(tuple,)"
@@ -1816,7 +1781,7 @@
         (
             tuple,
         )"""
-        @test fmt(str_, 4, 1; trailing_comma = false) == str
+        test_format(str_, str; indent=4, margin=1, trailing_comma = false)
 
         str = """
         funccall(
@@ -1826,7 +1791,7 @@
         )"""
 
         str_ = "funccall(arg1, arg2, arg3)"
-        @test fmt(str_, 4, 1; trailing_comma = nothing) == str
+        test_format(str_, str; indent=4, margin=1, trailing_comma = nothing)
 
         # last comma is stays
         str_ = "funccall(arg1, arg2, arg3,)"
@@ -1836,8 +1801,8 @@
             arg2,
             arg3,
         )"""
-        @test fmt(str_, 4, 1; trailing_comma = nothing) == str
-        @test fmt(str_, 4, 100; trailing_comma = nothing) == str_
+        test_format(str_, str; indent=4, margin=1, trailing_comma = nothing)
+        test_format(str_, str_; indent=4, margin=100, trailing_comma = nothing)
 
         # corner case - if the comma is removed it is no longer a tuple
         str_ = "(tuple,)"
@@ -1845,36 +1810,30 @@
         (
             tuple,
         )"""
-        @test fmt(str_, 4, 1; trailing_comma = nothing) == str
+        test_format(str_, str; indent=4, margin=1, trailing_comma = nothing)
     end
 
     @testset "ignore maximum width" begin
         @testset "maintain original structure" begin
             for m in (:module, :baremodule)
                 str_ = "$m M body end"
-                @test fmt(str_; join_lines_based_on_source = true) == fmt(str_)
+                test_format(str_, format_text(str_); join_lines_based_on_source = true)
             end
 
             str_ = "struct S body end"
-            @test fmt(
-                str_;
-                join_lines_based_on_source = true,
-                annotate_untyped_fields_with_any = false,
-            ) == fmt(str_; annotate_untyped_fields_with_any = false)
+            test_format(str_, format_text(str_; annotate_untyped_fields_with_any = false); join_lines_based_on_source = true,
+                annotate_untyped_fields_with_any = false)
 
             str_ = "mutable struct S body end"
-            @test fmt(
-                str_;
-                join_lines_based_on_source = true,
-                annotate_untyped_fields_with_any = false,
-            ) == fmt(str_; annotate_untyped_fields_with_any = false)
+            test_format(str_, format_text(str_; annotate_untyped_fields_with_any = false); join_lines_based_on_source = true,
+                annotate_untyped_fields_with_any = false)
 
             str_ = """
             abstract type
             foo
 
               end"""
-            @test fmt(str_; join_lines_based_on_source = true) == fmt(str_)
+            test_format(str_, format_text(str_); join_lines_based_on_source = true)
 
             str_ = """
             primitive type
@@ -1883,30 +1842,30 @@
             64
 
               end"""
-            @test fmt(str_; join_lines_based_on_source = true) == fmt(str_)
+            test_format(str_, format_text(str_); join_lines_based_on_source = true)
 
             str_ = """
             function foo
 
               end"""
-            @test fmt(str_; join_lines_based_on_source = true) == fmt(str_)
+            test_format(str_, format_text(str_); join_lines_based_on_source = true)
 
             for f in (:function, :macro)
                 str_ = "$f foo() body end"
-                @test fmt(str_; join_lines_based_on_source = true) == fmt(str_)
+                test_format(str_, format_text(str_); join_lines_based_on_source = true)
             end
 
             str_ = "try a catch e finally c end"
-            @test fmt(str_; join_lines_based_on_source = true) == fmt(str_)
+            test_format(str_, format_text(str_); join_lines_based_on_source = true)
 
             str_ = "if a body1 elseif b body2 elseif c body3 else body4 end"
-            @test fmt(str_; join_lines_based_on_source = true) == fmt(str_)
+            test_format(str_, format_text(str_); join_lines_based_on_source = true)
 
             str_ = "begin a;b;c end"
-            @test fmt(str_; join_lines_based_on_source = true) == fmt(str_)
+            test_format(str_, format_text(str_); join_lines_based_on_source = true)
 
             str_ = "function foo() a;b;c end"
-            @test fmt(str_; join_lines_based_on_source = true) == fmt(str_)
+            test_format(str_, format_text(str_); join_lines_based_on_source = true)
         end
 
         @testset "misc" begin
@@ -1915,7 +1874,7 @@
                 body
             end
             """
-            @test fmt(str, 4, 84; join_lines_based_on_source = true) == str
+            test_format(str, str; indent=4, margin=84, join_lines_based_on_source = true)
 
             str_ = """
             function foo(
@@ -1933,8 +1892,8 @@
                 body
             end
             """
-            @test fmt(str_; join_lines_based_on_source = true) == str
-            @test bluefmt(str_; join_lines_based_on_source = true) == str
+            test_format(str_, str; join_lines_based_on_source = true)
+            test_format(str_, str, BlueStyle(); join_lines_based_on_source = true)
         end
 
         @testset "binary op" begin
@@ -1946,13 +1905,13 @@
             a =
                 b
             """
-            @test fmt(str_; join_lines_based_on_source = true) == str
-            @test bluefmt(str_; join_lines_based_on_source = true) == str
+            test_format(str_, str; join_lines_based_on_source = true)
+            test_format(str_, str, BlueStyle(); join_lines_based_on_source = true)
 
             str = """
             a = b
             """
-            @test yasfmt(str_; join_lines_based_on_source = true) == str
+            test_format(str_, str, YASStyle(); join_lines_based_on_source = true)
 
             str_ = """
             a =
@@ -1962,13 +1921,13 @@
             a =
                 (b, c)
             """
-            @test fmt(str_; join_lines_based_on_source = true) == str
+            test_format(str_, str; join_lines_based_on_source = true)
 
             str = """
             a = (b, c)
             """
-            @test yasfmt(str_; join_lines_based_on_source = true) == str
-            @test bluefmt(str_; join_lines_based_on_source = true) == str
+            test_format(str_, str, YASStyle(); join_lines_based_on_source = true)
+            test_format(str_, str, BlueStyle(); join_lines_based_on_source = true)
 
             str_ = """
             a =
@@ -1977,9 +1936,9 @@
             str = """
             a = "hello"
             """
-            @test fmt(str_; join_lines_based_on_source = true) == str
-            @test bluefmt(str_; join_lines_based_on_source = true) == str
-            @test yasfmt(str_; join_lines_based_on_source = true) == str
+            test_format(str_, str; join_lines_based_on_source = true)
+            test_format(str_, str, BlueStyle(); join_lines_based_on_source = true)
+            test_format(str_, str, YASStyle(); join_lines_based_on_source = true)
         end
 
         @testset "blue style" begin
@@ -1990,9 +1949,9 @@
                 body
             end
             """
-            @test bluefmt(str, 4, 1000; join_lines_based_on_source = true) == str
-            @test bluefmt(str, 4, 1; join_lines_based_on_source = true) ==
-                  bluefmt(str, 4, 1)
+            test_format(str, str, BlueStyle(); indent=4, margin=1000, join_lines_based_on_source = true)
+            @test format_text(str, BlueStyle(); indent=4, margin=1, join_lines_based_on_source = true) ==
+                  format_text(str, BlueStyle(); indent=4, margin=1)
 
             str = """
             function foo(
@@ -2002,7 +1961,7 @@
                 body
             end
             """
-            @test bluefmt(str, 4, 1000; join_lines_based_on_source = true) == str
+            test_format(str, str, BlueStyle(); indent=4, margin=1000, join_lines_based_on_source = true)
         end
 
         @testset "yas style" begin
@@ -2017,8 +1976,8 @@
                 body
             end
             """
-            @test yasfmt(str_; join_lines_based_on_source = true) ==
-                  yasfmt(str_, 4, 1; join_lines_based_on_source = false)
+            @test format_text(str_, YASStyle(); join_lines_based_on_source = true) ==
+                  format_text(str_, YASStyle(); indent=4, margin=1, join_lines_based_on_source = false)
 
             str_ = """
             @foo(
@@ -2030,7 +1989,7 @@
             @foo(arg1,
                  arg2,)
             """
-            @test yasfmt(str_; join_lines_based_on_source = true) == str
+            test_format(str_, str, YASStyle(); join_lines_based_on_source = true)
 
             str_ = """
             (
@@ -2042,7 +2001,7 @@
             (arg1,
              arg2)
             """
-            @test yasfmt(str_; join_lines_based_on_source = true) == str
+            test_format(str_, str, YASStyle(); join_lines_based_on_source = true)
 
             str_ = """
             [
@@ -2054,7 +2013,7 @@
             [arg1,
              arg2]
             """
-            @test yasfmt(str_; join_lines_based_on_source = true) == str
+            test_format(str_, str, YASStyle(); join_lines_based_on_source = true)
 
             str_ = """
             A[
@@ -2066,7 +2025,7 @@
             A[arg1,
               arg2]
             """
-            @test yasfmt(str_; join_lines_based_on_source = true) == str
+            test_format(str_, str, YASStyle(); join_lines_based_on_source = true)
 
             str_ = """
             {
@@ -2078,7 +2037,7 @@
             {arg1,
              arg2}
             """
-            @test yasfmt(str_; join_lines_based_on_source = true) == str
+            test_format(str_, str, YASStyle(); join_lines_based_on_source = true)
 
             str_ = """
             A{
@@ -2090,7 +2049,7 @@
             A{arg1,
               arg2}
             """
-            @test yasfmt(str_; join_lines_based_on_source = true) == str
+            test_format(str_, str, YASStyle(); join_lines_based_on_source = true)
 
             str_ = """
             (
@@ -2100,7 +2059,7 @@
             str = """
             (invisbrackets)
             """
-            @test yasfmt(str_; join_lines_based_on_source = true) == str
+            test_format(str_, str, YASStyle(); join_lines_based_on_source = true)
 
             str_ = """
             [
@@ -2112,7 +2071,7 @@
             [row1;
              row2;]
             """
-            @test yasfmt(str_; join_lines_based_on_source = true) == str
+            test_format(str_, str, YASStyle(); join_lines_based_on_source = true)
 
             str_ = """
             T[
@@ -2124,7 +2083,7 @@
             T[row1;
               row2;]
             """
-            @test yasfmt(str_; join_lines_based_on_source = true) == str
+            test_format(str_, str, YASStyle(); join_lines_based_on_source = true)
 
             str_ = """
             [
@@ -2134,7 +2093,7 @@
             str = """
             [a for a = 1:10]
             """
-            @test yasfmt(str_; join_lines_based_on_source = true) == str
+            test_format(str_, str, YASStyle(); join_lines_based_on_source = true)
         end
 
         @testset "imports" begin
@@ -2146,7 +2105,7 @@
             using A,  #inline
               # comment
               B, C#inline"""
-            @test fmt(str_, 2, 80; join_lines_based_on_source = true) == str
+            test_format(str_, str; indent=2, margin=80, join_lines_based_on_source = true)
 
             str_ = """
             using CommonMark:
@@ -2167,8 +2126,8 @@
                 Parser,
                 Rule, TableRule
             """
-            @test fmt(str_, 4, 37; join_lines_based_on_source = true) == str_
-            @test fmt(str_, 4, 36; join_lines_based_on_source = true) == str
+            test_format(str_, str_; indent=4, margin=37, join_lines_based_on_source = true)
+            test_format(str_, str; indent=4, margin=36, join_lines_based_on_source = true)
 
             str = """
             using CommonMark:
@@ -2179,7 +2138,7 @@
                               Parser,
                               Rule, TableRule
             """
-            @test yasfmt(str_, 4, 51; join_lines_based_on_source = true) == str
+            test_format(str_, str, YASStyle(); indent=4, margin=51, join_lines_based_on_source = true)
 
             str = """
             using CommonMark:
@@ -2191,7 +2150,7 @@
                               Parser,
                               Rule, TableRule
             """
-            @test yasfmt(str_, 4, 50; join_lines_based_on_source = true) == str
+            test_format(str_, str, YASStyle(); indent=4, margin=50, join_lines_based_on_source = true)
         end
 
         # NOTE: not sure since test makes sense anymore.
@@ -2205,7 +2164,7 @@
             str = """
             T[a b Expr();
                 d e Expr();]"""
-            @test fmt(str_; join_lines_based_on_source = true) == str
+            test_format(str_, str; join_lines_based_on_source = true)
         end
 
         @testset "function defs" begin
@@ -2213,13 +2172,13 @@
             function foo()
             end
             """
-            @test fmt(s; join_lines_based_on_source = true) == s
+            test_format(s, s; join_lines_based_on_source = true)
 
             s = """
             function foo
             end
             """
-            @test fmt(s; join_lines_based_on_source = true) == s
+            test_format(s, s; join_lines_based_on_source = true)
         end
 
         @testset "macro defs" begin
@@ -2227,13 +2186,13 @@
             macro foo()
             end
             """
-            @test fmt(s; join_lines_based_on_source = true) == s
+            test_format(s, s; join_lines_based_on_source = true)
 
             s = """
             macro foo
             end
             """
-            @test fmt(s; join_lines_based_on_source = true) == s
+            test_format(s, s; join_lines_based_on_source = true)
         end
 
         @testset "typedefs" begin
@@ -2241,13 +2200,13 @@
             struct S
             end
             """
-            @test fmt(s; join_lines_based_on_source = true) == s
+            test_format(s, s; join_lines_based_on_source = true)
 
             s = """
             mutable struct S
             end
             """
-            @test fmt(s; join_lines_based_on_source = true) == s
+            test_format(s, s; join_lines_based_on_source = true)
         end
 
         @testset "modules" begin
@@ -2255,13 +2214,13 @@
             module M
             end
             """
-            @test fmt(s; join_lines_based_on_source = true) == s
+            test_format(s, s; join_lines_based_on_source = true)
 
             s = """
             baremodule BM
             end
             """
-            @test fmt(s; join_lines_based_on_source = true) == s
+            test_format(s, s; join_lines_based_on_source = true)
         end
     end
 
@@ -2306,7 +2265,7 @@
 
         end
         """
-        @test fmt(str_, 2, 22; indent_submodule = true) == str
+        test_format(str_, str; indent=2, margin=22, indent_submodule = true)
 
         str = """
         "doc"
@@ -2329,7 +2288,7 @@
 
         end
         """
-        @test fmt(str_, 2, 21; indent_submodule = true) == str
+        test_format(str_, str; indent=2, margin=21, indent_submodule = true)
     end
 
     @testset "`separate_kwargs_with_semicolon`" begin
@@ -2339,28 +2298,28 @@
         str = """
         f(a; b = 10)
         """
-        @test fmt(str_; separate_kwargs_with_semicolon = true) == str
-        @test yasfmt(str_; separate_kwargs_with_semicolon = true) == str
+        test_format(str_, str; separate_kwargs_with_semicolon = true)
+        test_format(str_, str, YASStyle(); separate_kwargs_with_semicolon = true)
 
         str_ = "xy = f(x, y=3)"
         str = "xy = f(x; y = 3)"
-        @test fmt(str_; separate_kwargs_with_semicolon = true) == str
-        @test yasfmt(str_; separate_kwargs_with_semicolon = true) == str
+        test_format(str_, str; separate_kwargs_with_semicolon = true)
+        test_format(str_, str, YASStyle(); separate_kwargs_with_semicolon = true)
 
         str_ = "xy = f(x=1, y=2)"
         str = "xy = f(; x = 1, y = 2)"
-        @test fmt1(str_; separate_kwargs_with_semicolon = true) == str
-        @test fmt(str_; separate_kwargs_with_semicolon = true) == str
-        @test fmt(str; separate_kwargs_with_semicolon = true) == str
-        @test yasfmt1(str_; separate_kwargs_with_semicolon = true) == str
-        @test yasfmt(str_; separate_kwargs_with_semicolon = true) == str
-        @test yasfmt(str; separate_kwargs_with_semicolon = true) == str
+        test_format(str_, str; separate_kwargs_with_semicolon = true)
+        test_format(str_, str; separate_kwargs_with_semicolon = true)
+        test_format(str, str; separate_kwargs_with_semicolon = true)
+        test_format(str_, str, YASStyle(); separate_kwargs_with_semicolon = true)
+        test_format(str_, str, YASStyle(); separate_kwargs_with_semicolon = true)
+        test_format(str, str, YASStyle(); separate_kwargs_with_semicolon = true)
 
         str_ = "xy = f(x = 1; y = 2)"
-        @test fmt1(str_; separate_kwargs_with_semicolon = true) == str
-        @test fmt(str_; separate_kwargs_with_semicolon = true) == str
-        @test yasfmt1(str_; separate_kwargs_with_semicolon = true) == str
-        @test yasfmt(str_; separate_kwargs_with_semicolon = true) == str
+        test_format(str_, str; separate_kwargs_with_semicolon = true)
+        test_format(str_, str; separate_kwargs_with_semicolon = true)
+        test_format(str_, str, YASStyle(); separate_kwargs_with_semicolon = true)
+        test_format(str_, str, YASStyle(); separate_kwargs_with_semicolon = true)
 
         str = """
         function g(x, y = 1)
@@ -2372,10 +2331,10 @@
         shortdef1(MatrixT, VectorT = nothing) = nothing
         shortdef2(MatrixT, VectorT = nothing) where {T} = nothing
         """
-        @test fmt1(str; separate_kwargs_with_semicolon = true) == str
-        @test fmt(str; separate_kwargs_with_semicolon = true) == str
-        @test yasfmt1(str; separate_kwargs_with_semicolon = true) == str
-        @test yasfmt(str; separate_kwargs_with_semicolon = true) == str
+        test_format(str, str; separate_kwargs_with_semicolon = true)
+        test_format(str, str; separate_kwargs_with_semicolon = true)
+        test_format(str, str, YASStyle(); separate_kwargs_with_semicolon = true)
+        test_format(str, str, YASStyle(); separate_kwargs_with_semicolon = true)
 
         str = """
         function g(x::T, y = 1) where {T}
@@ -2385,10 +2344,10 @@
             return x + y
         end
         """
-        @test fmt1(str; separate_kwargs_with_semicolon = true) == str
-        @test fmt(str; separate_kwargs_with_semicolon = true) == str
-        @test yasfmt1(str; separate_kwargs_with_semicolon = true) == str
-        @test yasfmt(str; separate_kwargs_with_semicolon = true) == str
+        test_format(str, str; separate_kwargs_with_semicolon = true)
+        test_format(str, str; separate_kwargs_with_semicolon = true)
+        test_format(str, str, YASStyle(); separate_kwargs_with_semicolon = true)
+        test_format(str, str, YASStyle(); separate_kwargs_with_semicolon = true)
 
         str_ = """
         x = foo(var = "some really really really really really really really really really really long string")
@@ -2398,8 +2357,8 @@
             var = "some really really really really really really really really really really long string",
         )
         """
-        @test fmt1(str_; separate_kwargs_with_semicolon = true) == str
-        @test fmt(str_; separate_kwargs_with_semicolon = true) == str
+        test_format(str_, str; separate_kwargs_with_semicolon = true)
+        test_format(str_, str; separate_kwargs_with_semicolon = true)
 
         str_ = """
         x = foo(var = "some really really really really really really really really really really long string")
@@ -2408,8 +2367,8 @@
         x = foo(;
                 var = "some really really really really really really really really really really long string")
         """
-        @test yasfmt1(str_; separate_kwargs_with_semicolon = true) == str
-        @test yasfmt(str_; separate_kwargs_with_semicolon = true) == str
+        test_format(str_, str, YASStyle(); separate_kwargs_with_semicolon = true)
+        test_format(str_, str, YASStyle(); separate_kwargs_with_semicolon = true)
     end
 
     @testset "`surround_whereop_typeparameters`" begin
@@ -2418,24 +2377,24 @@
             foo
         end
         """
-        @test fmt(s; surround_whereop_typeparameters = false) == s
+        test_format(s, s; surround_whereop_typeparameters = false)
 
         s = """
         function NotificationType(method::AbstractString, ::Type{TPARAM})::R where TPARAM
             foo
         end
         """
-        @test fmt(s; surround_whereop_typeparameters = false, m = 100) == s
+        test_format(s, s; surround_whereop_typeparameters = false, margin = 100)
 
         s = """
         NotificationType(method::AbstractString, ::Type{TPARAM}) where TPARAM = foo
         """
-        @test fmt(s; surround_whereop_typeparameters = false) == s
+        test_format(s, s; surround_whereop_typeparameters = false)
 
         s = """
         NotificationType(method::AbstractString, ::Type{TPARAM})::R where TPARAM = foo
         """
-        @test fmt(s; surround_whereop_typeparameters = false) == s
+        test_format(s, s; surround_whereop_typeparameters = false)
     end
 
     @testset "for_in_replacement" begin
@@ -2447,42 +2406,42 @@
         for a ∈ b
         end
         """
-        @test fmt(str_; always_for_in = true, for_in_replacement = "∈") == str
+        test_format(str_, str; always_for_in = true, for_in_replacement = "∈")
 
         # generator
         str_ = "[(i, j) for i = 1:2:10, j = 100:-1:10]"
         str = "[(i, j) for i ∈ 1:2:10, j ∈ 100:-1:10]"
-        @test fmt(str_; always_for_in = true, for_in_replacement = "∈") == str
+        test_format(str_, str; always_for_in = true, for_in_replacement = "∈")
 
         str_ = "[i for i = 1:10 if i == 2]"
         str = "[i for i ∈ 1:10 if i == 2]"
-        @test fmt(str_; always_for_in = true, for_in_replacement = "∈") == str
+        test_format(str_, str; always_for_in = true, for_in_replacement = "∈")
 
         str_ = "[(i, j) for i = 1:2:10, j = 100:-1:10]"
         str = "[(i, j) for i ∈ 1:2:10, j ∈ 100:-1:10]"
-        @test yasfmt(str_; always_for_in = true, for_in_replacement = "∈") == str
+        test_format(str_, str, YASStyle(); always_for_in = true, for_in_replacement = "∈")
 
         str_ = "[i for i = 1:10 if i == 2]"
         str = "[i for i ∈ 1:10 if i == 2]"
-        @test yasfmt(str_; always_for_in = true, for_in_replacement = "∈") == str
+        test_format(str_, str, YASStyle(); always_for_in = true, for_in_replacement = "∈")
 
-        @test_throws AssertionError fmt(
-            str_,
+        @test_throws AssertionError format_text(
+            str_;
             always_for_in = true,
             for_in_replacement = "ni!",
         )
     end
 
     @testset "trailing zero" begin
-        @test fmt("1e-2"; trailing_zero = true) == "1e-2"
-        @test fmt("1f0"; trailing_zero = true) == "1.0f0"
-        @test fmt("1."; trailing_zero = true) == "1.0"
-        @test fmt("0x1.fp0"; trailing_zero = true) == "0x1.fp0"
+        test_format("1e-2", "1e-2"; trailing_zero = true)
+        test_format("1f0", "1.0f0"; trailing_zero = true)
+        test_format("1.", "1.0"; trailing_zero = true)
+        test_format("0x1.fp0", "0x1.fp0"; trailing_zero = true)
 
-        @test fmt("1e-2"; trailing_zero = false) == "1e-2"
-        @test fmt("1f0"; trailing_zero = false) == "1f0"
-        @test fmt("1."; trailing_zero = false) == "1."
-        @test fmt("0x1.fp0"; trailing_zero = false) == "0x1.fp0"
+        test_format("1e-2", "1e-2"; trailing_zero = false)
+        test_format("1f0", "1f0"; trailing_zero = false)
+        test_format("1.", "1."; trailing_zero = false)
+        test_format("0x1.fp0", "0x1.fp0"; trailing_zero = false)
     end
 
     @testset "noindent blocks" begin
@@ -2510,7 +2469,7 @@
             end
         end
         """
-        @test fmt(s) == s_
+        test_format(s, s_)
 
         s = raw"""
         begin
@@ -2544,7 +2503,7 @@
             end
         end
         """
-        @test fmt(s) == s_
+        test_format(s, s_)
 
         # recursive
         s = raw"""
@@ -2587,7 +2546,7 @@
             end
         end
         """
-        @test fmt(s) == s_
+        test_format(s, s_)
     end
 
     @testset "short/lazy circuit to if" begin
@@ -2605,7 +2564,7 @@
             end
         end
         """
-        @test fmt(s_, 4, 92; short_circuit_to_if = true) == s
+        test_format(s_, s; indent=4, margin=92, short_circuit_to_if = true)
 
         s_ = """
             begin
@@ -2621,7 +2580,7 @@
             end
         end
         """
-        @test fmt(s_, 4, 11; short_circuit_to_if = true) == s
+        test_format(s_, s; indent=4, margin=11, short_circuit_to_if = true)
 
         s = """
         begin
@@ -2634,7 +2593,7 @@
             end
         end
         """
-        @test fmt(s_, 4, 10; short_circuit_to_if = true) == s
+        test_format(s_, s; indent=4, margin=10, short_circuit_to_if = true)
 
         # > 1
         s_ = """
@@ -2651,7 +2610,7 @@
             end
         end
         """
-        @test fmt(s_, 4, 92; short_circuit_to_if = true) == s
+        test_format(s_, s; indent=4, margin=92, short_circuit_to_if = true)
 
         s_ = """
             begin
@@ -2667,7 +2626,7 @@
             end
         end
         """
-        @test fmt(s_, 4, 21; short_circuit_to_if = true) == s1
+        test_format(s_, s1; indent=4, margin=21, short_circuit_to_if = true)
 
         s2 = """
         begin
@@ -2680,15 +2639,15 @@
             end
         end
         """
-        @test fmt(s_, 4, 20; short_circuit_to_if = true) == s2
+        test_format(s_, s2; indent=4, margin=20, short_circuit_to_if = true)
 
         s_ = """
             begin
             (a && b && c) || d
             end
         """
-        @test fmt(s_, 4, 21; short_circuit_to_if = true) == s1
-        @test fmt(s_, 4, 20; short_circuit_to_if = true) == s2
+        test_format(s_, s1; indent=4, margin=21, short_circuit_to_if = true)
+        test_format(s_, s2; indent=4, margin=20, short_circuit_to_if = true)
 
         s_ = """
         function foo()
@@ -2704,7 +2663,7 @@
             end
         end
         """
-        @test fmt(s_, 4, 92; short_circuit_to_if = true) == s
+        test_format(s_, s; indent=4, margin=92, short_circuit_to_if = true)
 
         s_ = """
         function foo(a)
@@ -2722,7 +2681,7 @@
             "hello"
         end
         """
-        @test fmt(s_, 4, 92; short_circuit_to_if = true) == s
+        test_format(s_, s; indent=4, margin=92, short_circuit_to_if = true)
 
         s_ = """
         function foo(a, b)
@@ -2748,7 +2707,7 @@
             end
         end
         """
-        @test fmt(s_, 4, 92; short_circuit_to_if = true) == s
+        test_format(s_, s; indent=4, margin=92, short_circuit_to_if = true)
     end
 
     @testset "disallow single arg nesting" begin
@@ -2769,6 +2728,8 @@
         {key =>
           value("String value")}
         """
-        @test fmt(s1, 2, 1; disallow_single_arg_nesting = true) == s2
+        test_format(s1, s2; indent=2, margin=1, disallow_single_arg_nesting = true)
     end
+end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using JuliaFormatter
-using JuliaFormatter: DefaultStyle, YASStyle, Options, options, CONFIG_FILE_NAME
+using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, Options, options, CONFIG_FILE_NAME
+using JuliaFormatter: format_text
+using JuliaFormatter.Internal: test_format
 using Test
 using JuliaSyntax
 
@@ -21,26 +23,6 @@ function fmt(s; i = 4, m = 80, kwargs...)
     return fmt1(s1; kws..., i = i, m = m)
 end
 fmt(s, i, m; kwargs...) = fmt(s; kwargs..., i = i, m = m)
-
-function yasfmt1(str; kwargs...)
-    fmt1(str; style = YASStyle(), options(DefaultStyle())..., kwargs...)
-end
-function yasfmt(str; i = 4, m = 80, kwargs...)
-    fmt(str; i = i, m = m, style = YASStyle(), kwargs...)
-end
-yasfmt(str, i::Int, m::Int; kwargs...) = yasfmt(str; i = i, m = m, kwargs...)
-
-bluefmt1(str) = fmt1(str; style = BlueStyle(), options(DefaultStyle())...)
-function bluefmt(str; i = 4, m = 80, kwargs...)
-    fmt(str; i = i, m = m, style = BlueStyle(), kwargs...)
-end
-bluefmt(str, i::Int, m::Int; kwargs...) = bluefmt(str; i = i, m = m, kwargs...)
-
-minimalfmt1(str) = fmt1(str; style = MinimalStyle(), options(DefaultStyle())...)
-function minimalfmt(str; i = 4, m = 92, kwargs...)
-    fmt(str; i = i, m = m, style = MinimalStyle(), kwargs...)
-end
-minimalfmt(str, i::Int, m::Int; kwargs...) = minimalfmt(str; i = i, m = m, kwargs...)
 
 function run_pretty(text::String; style = DefaultStyle(), opts = Options())
     d = JuliaFormatter.Document(text)

--- a/test/yas_style.jl
+++ b/test/yas_style.jl
@@ -8,7 +8,7 @@ using JuliaFormatter: format_text
 @testset "YAS Style" begin
     @testset "basic" begin
         str_ = "foo(; k =v)"
-        str = "foo(; k = v)"
+        str = "foo(; k=v)"
         test_format(str_, str, YASStyle(); indent=4, margin=80)
 
         str_ = "[a,]"
@@ -253,7 +253,7 @@ using JuliaFormatter: format_text
         str = """
         function func(arg1::Type1, arg2::Type2,
                       arg3) where {Type1,Type2}
-          body
+          return body
         end"""
         test_format(str_, str, YASStyle(); indent=2, margin=64)
         test_format(str_, str, YASStyle(); indent=2, margin=39)
@@ -263,7 +263,7 @@ using JuliaFormatter: format_text
                       arg2::Type2,
                       arg3) where {Type1,
                                    Type2}
-          body
+          return body
         end"""
         test_format(str_, str, YASStyle(); indent=2, margin=31)
         test_format(str_, str, YASStyle(); indent=2, margin=1)
@@ -286,21 +286,21 @@ using JuliaFormatter: format_text
         str_ =
             raw"""ecg_signal = signal_from_template(eeg_signal; channel_names=[:avl, :avr], file_extension=Symbol("lpcm.zst"))"""
         str = raw"""
-        ecg_signal = signal_from_template(eeg_signal; channel_names = [:avl, :avr],
-                                          file_extension = Symbol("lpcm.zst"))"""
+        ecg_signal = signal_from_template(eeg_signal; channel_names=[:avl, :avr],
+                                          file_extension=Symbol("lpcm.zst"))"""
         test_format(str_, str, YASStyle(); indent=4, margin=length(str_) - 1)
         test_format(str_, str, YASStyle(); indent=4, margin=75)
 
         str = raw"""
         ecg_signal = signal_from_template(eeg_signal;
-                                          channel_names = [:avl, :avr],
-                                          file_extension = Symbol("lpcm.zst"))"""
-        test_format(str_, str, YASStyle(); indent=4, margin=73)
+                                          channel_names=[:avl, :avr],
+                                          file_extension=Symbol("lpcm.zst"))"""
+        test_format(str_, str, YASStyle(); indent=4, margin=71)
         str = raw"""
         ecg_signal = signal_from_template(eeg_signal;
-                                          channel_names = [:avl,
-                                                           :avr],
-                                          file_extension = Symbol("lpcm.zst"))"""
+                                          channel_names=[:avl,
+                                                         :avr],
+                                          file_extension=Symbol("lpcm.zst"))"""
         test_format(str_, str, YASStyle(); indent=4, margin=1)
     end
 
@@ -346,20 +346,20 @@ using JuliaFormatter: format_text
                   x = a * b + c
                   y = x^2 + 3x # comment 1
                 end
-                for a = 1:10,  # comment 2
-                    b = 11:20, c = 300:400]"""
+                for a in 1:10,  # comment 2
+                    b in 11:20, c in 300:400]"""
         test_format(str_, str, YASStyle(); indent=2, margin=80, join_lines_based_on_source = false)
-        test_format(str_, str, YASStyle(); indent=2, margin=35, join_lines_based_on_source = false)
+        test_format(str_, str, YASStyle(); indent=2, margin=38, join_lines_based_on_source = false)
 
         str = """
         comp = [begin
                   x = a * b + c
                   y = x^2 + 3x # comment 1
                 end
-                for a = 1:10,  # comment 2
-                    b = 11:20,
-                    c = 300:400]"""
-        test_format(str_, str, YASStyle(); indent=2, margin=34)
+                for a in 1:10,  # comment 2
+                    b in 11:20,
+                    c in 300:400]"""
+        test_format(str_, str, YASStyle(); indent=2, margin=36)
 
         str_ = """
         ys = ( if p1(x)
@@ -394,13 +394,13 @@ using JuliaFormatter: format_text
         str = """
         foo(a, b) = (arg1, arg2,
                      arg3)"""
-        test_format(str_, str, YASStyle(); indent=2, margin=length(str_) - 1)
+        test_format(str_, str, YASStyle(); indent=2, margin=length(str_) - 1, short_to_long_function_def=false)
 
         str = """
         foo(a, b) = (arg1,
                      arg2,
                      arg3)"""
-        test_format(str_, str, YASStyle(); indent=2, margin=1)
+        test_format(str_, str, YASStyle(); indent=2, margin=1, short_to_long_function_def=false)
 
         str_ = """
         fooooooooooooooooooo(arg1, arg2,
@@ -418,8 +418,8 @@ using JuliaFormatter: format_text
         # parsing error is newline is placed front of `for` here
         str_ = "var = ((x, y) for x = 1:10, y = 1:10)"
         str = """
-        var = ((x, y) for x = 1:10,
-                          y = 1:10)"""
+        var = ((x, y) for x in 1:10,
+                          y in 1:10)"""
         test_format(str_, str, YASStyle(); indent=4, margin=length(str_) - 1)
     end
 
@@ -455,7 +455,7 @@ using JuliaFormatter: format_text
               (b * y_hat - delta[i] * y_hat) * gamma_hat[i] +
               (b_hat - y_hat) * delta[i] +
               (b - y) * delta_hat[i] - delta[i] * delta_hat[i]
-              for i = 1:8]"""
+              for i in 1:8]"""
         test_format(str_, str, YASStyle(); indent=2, margin=60, join_lines_based_on_source = false)
     end
 
@@ -562,7 +562,7 @@ using JuliaFormatter: format_text
 
     @testset "imports no placeholder, no error" begin
         str = "import A"
-        test_format(str, str, YASStyle())
+        test_format(str, "using A: A", YASStyle())
 
         str = "export A"
         test_format(str, str, YASStyle())

--- a/test/yas_style.jl
+++ b/test/yas_style.jl
@@ -1,154 +1,161 @@
+module YasStyleTests
+
+using JuliaFormatter.Internal: test_format
+using Test
+using JuliaFormatter: YASStyle
+using JuliaFormatter: format_text
+
 @testset "YAS Style" begin
     @testset "basic" begin
         str_ = "foo(; k =v)"
         str = "foo(; k = v)"
-        @test yasfmt(str_, 4, 80) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=80)
 
         str_ = "[a,]"
         str = "[a]"
-        @test yasfmt(str_, 4, 92) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=92)
 
         str_ = "T[a,]"
         str = "T[a]"
-        @test yasfmt(str_, 4, 92) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=92)
 
         str_ = "{a,}"
         str = "{a}"
-        @test yasfmt(str_, 4, 92) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=92)
 
         str_ = "T{a,}"
         str = "T{a}"
-        @test yasfmt(str_, 4, 92) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=92)
 
         str_ = "T(a,)"
         str = "T(a)"
-        @test yasfmt(str_, 4, 92) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=92)
 
         str_ = "(a,)"
         str = "(a,)"
-        @test yasfmt(str_, 4, 92) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=92)
 
         str_ = "@foo(a,)"
         str = "@foo(a,)"
-        @test yasfmt(str_, 4, 92) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=92)
 
         str_ = "a = (arg1, arg2, arg3)"
         str = """
         a = (arg1, arg2,
              arg3)"""
-        @test yasfmt(str_, 4, length(str_) - 1) == str
-        @test yasfmt(str_, 4, 16) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=length(str_) - 1)
+        test_format(str_, str, YASStyle(); indent=4, margin=16)
 
         str = """
         a = (arg1,
              arg2,
              arg3)"""
-        @test yasfmt(str_, 4, 15) == str
-        @test yasfmt(str_, 4, 1) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=15)
+        test_format(str_, str, YASStyle(); indent=4, margin=1)
 
         str_ = "a = [arg1, arg2, arg3]"
         str = """
         a = [arg1, arg2,
              arg3]"""
-        @test yasfmt(str_, 4, length(str_) - 1) == str
-        @test yasfmt(str_, 4, 16) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=length(str_) - 1)
+        test_format(str_, str, YASStyle(); indent=4, margin=16)
 
         str = """
         a = [arg1,
              arg2,
              arg3]"""
-        @test yasfmt(str_, 4, 15) == str
-        @test yasfmt(str_, 4, 1) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=15)
+        test_format(str_, str, YASStyle(); indent=4, margin=1)
 
         str_ = "a = {arg1,arg2,arg3}"
         str = """
         a = {arg1, arg2, arg3}"""
-        @test yasfmt(str_, 4, 22) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=22)
 
         str = """
         a = {arg1, arg2,
              arg3}"""
-        @test yasfmt(str_, 4, 21) == str
-        @test yasfmt(str_, 4, 16) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=21)
+        test_format(str_, str, YASStyle(); indent=4, margin=16)
 
         str = """
         a = {arg1,
              arg2,
              arg3}"""
-        @test yasfmt(str_, 4, 15) == str
-        @test yasfmt(str_, 4, 1) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=15)
+        test_format(str_, str, YASStyle(); indent=4, margin=1)
 
         str_ = "a = Union{arg1, arg2, arg3}"
         str = """
         a = Union{arg1,arg2,arg3}"""
-        @test yasfmt(str_, 4, 25) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=25)
 
         str = """
         a = Union{arg1,arg2,
                   arg3}"""
-        @test yasfmt(str_, 4, 24) == str
-        @test yasfmt(str_, 4, 20) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=24)
+        test_format(str_, str, YASStyle(); indent=4, margin=20)
 
         str = """
         a = Union{arg1,
                   arg2,
                   arg3}"""
-        @test yasfmt(str_, 4, 19) == str
-        @test yasfmt(str_, 4, 1) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=19)
+        test_format(str_, str, YASStyle(); indent=4, margin=1)
 
         str_ = "a = fcall(arg1,arg2,arg3)"
         str = """
         a = fcall(arg1, arg2, arg3)"""
-        @test yasfmt(str_, 4, length(str)) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=length(str))
 
         str = """
         a = fcall(arg1, arg2,
                   arg3)"""
-        @test yasfmt(str_, 4, 26) == str
-        @test yasfmt(str_, 4, 21) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=26)
+        test_format(str_, str, YASStyle(); indent=4, margin=21)
 
         str = """
         a = fcall(arg1,
                   arg2,
                   arg3)"""
-        @test yasfmt(str_, 4, 20) == str
-        @test yasfmt(str_, 4, 1) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=20)
+        test_format(str_, str, YASStyle(); indent=4, margin=1)
 
         str_ = "a = @call(arg1,arg2,arg3)"
         str = """
         a = @call(arg1, arg2, arg3)"""
-        @test yasfmt(str_, 4, length(str)) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=length(str))
 
         str = """
         a = @call(arg1, arg2,
                   arg3)"""
-        @test yasfmt(str_, 4, 26) == str
-        @test yasfmt(str_, 4, 21) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=26)
+        test_format(str_, str, YASStyle(); indent=4, margin=21)
 
         str = """
         a = @call(arg1,
                   arg2,
                   arg3)"""
-        @test yasfmt(str_, 4, 20) == str
-        @test yasfmt(str_, 4, 1) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=20)
+        test_format(str_, str, YASStyle(); indent=4, margin=1)
 
         str_ = "a = array[arg1,arg2,arg3]"
         str = """
         a = array[arg1, arg2, arg3]"""
-        @test yasfmt(str_, 4, length(str)) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=length(str))
 
         str = """
         a = array[arg1, arg2,
                   arg3]"""
-        @test yasfmt(str_, 4, 26) == str
-        @test yasfmt(str_, 4, 21) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=26)
+        test_format(str_, str, YASStyle(); indent=4, margin=21)
 
         str = """
         a = array[arg1,
                   arg2,
                   arg3]"""
-        @test yasfmt(str_, 4, 20) == str
-        @test yasfmt(str_, 4, 1) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=20)
+        test_format(str_, str, YASStyle(); indent=4, margin=1)
 
         str_ = """
         using Cassette: A, B, C"""
@@ -156,7 +163,7 @@
         using Cassette: A,
                         B,
                         C"""
-        @test yasfmt(str_, 4, 1) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=1)
     end
 
     # more complicated samples
@@ -165,14 +172,14 @@
         str = """
         comp = [a * b
                 for a in 1:10, b in 11:20]"""
-        @test yasfmt(str_, 2, length(str_) - 1; always_for_in = true) == str
-        @test yasfmt(str_, 2, 34; always_for_in = true) == str
+        test_format(str_, str, YASStyle(); indent=2, margin=length(str_) - 1, always_for_in = true)
+        test_format(str_, str, YASStyle(); indent=2, margin=34, always_for_in = true)
 
         str = """
         comp = [a * b
                 for a in 1:10,
                     b in 11:20]"""
-        @test yasfmt(str_, 2, 33; always_for_in = true) == str
+        test_format(str_, str, YASStyle(); indent=2, margin=33, always_for_in = true)
 
         str = """
         comp = [a *
@@ -181,20 +188,20 @@
                     1:10,
                     b in
                     11:20]"""
-        @test yasfmt(str_, 2, 1; always_for_in = true) == str
+        test_format(str_, str, YASStyle(); indent=2, margin=1, always_for_in = true)
 
         str_ = "comp = Typed[a * b for a in 1:10, b in 11:20]"
         str = """
         comp = Typed[a * b
                      for a in 1:10, b in 11:20]"""
-        @test yasfmt(str_, 2, length(str_) - 1; always_for_in = true) == str
-        @test yasfmt(str_, 2, 39; always_for_in = true) == str
+        test_format(str_, str, YASStyle(); indent=2, margin=length(str_) - 1, always_for_in = true)
+        test_format(str_, str, YASStyle(); indent=2, margin=39, always_for_in = true)
 
         str = """
         comp = Typed[a * b
                      for a in 1:10,
                          b in 11:20]"""
-        @test yasfmt(str_, 2, 38; always_for_in = true) == str
+        test_format(str_, str, YASStyle(); indent=2, margin=38, always_for_in = true)
 
         str = """
         comp = Typed[a *
@@ -203,31 +210,31 @@
                          1:10,
                          b in
                          11:20]"""
-        @test yasfmt(str_, 2, 1; always_for_in = true) == str
+        test_format(str_, str, YASStyle(); indent=2, margin=1, always_for_in = true)
 
         str_ = "foo(arg1, arg2, arg3) == bar(arg1, arg2, arg3)"
         str = """
         foo(arg1, arg2, arg3) ==
         bar(arg1, arg2, arg3)"""
         # change in default behavior
-        @test yasfmt(str, 2, length(str_); join_lines_based_on_source = false) == str_
-        @test yasfmt(str_, 2, length(str_) - 1) == str
-        @test yasfmt(str_, 2, 24) == str
+        test_format(str, str_, YASStyle(); indent=2, margin=length(str_), join_lines_based_on_source = false)
+        test_format(str_, str, YASStyle(); indent=2, margin=length(str_) - 1)
+        test_format(str_, str, YASStyle(); indent=2, margin=24)
 
         str = """
         foo(arg1, arg2,
             arg3) ==
         bar(arg1, arg2, arg3)"""
-        @test yasfmt(str_, 2, 23) == str
-        @test yasfmt(str_, 2, 21) == str
+        test_format(str_, str, YASStyle(); indent=2, margin=23)
+        test_format(str_, str, YASStyle(); indent=2, margin=21)
 
         str = """
         foo(arg1, arg2,
             arg3) ==
         bar(arg1, arg2,
             arg3)"""
-        @test yasfmt(str_, 2, 20) == str
-        @test yasfmt(str_, 2, 15) == str
+        test_format(str_, str, YASStyle(); indent=2, margin=20)
+        test_format(str_, str, YASStyle(); indent=2, margin=15)
 
         str = """
         foo(arg1,
@@ -236,8 +243,8 @@
         bar(arg1,
             arg2,
             arg3)"""
-        @test yasfmt(str_, 2, 14) == str
-        @test yasfmt(str_, 2, 1) == str
+        test_format(str_, str, YASStyle(); indent=2, margin=14)
+        test_format(str_, str, YASStyle(); indent=2, margin=1)
 
         str_ = """
         function func(arg1::Type1, arg2::Type2, arg3) where {Type1,Type2}
@@ -248,8 +255,8 @@
                       arg3) where {Type1,Type2}
           body
         end"""
-        @test yasfmt(str_, 2, 64) == str
-        @test yasfmt(str_, 2, 39) == str
+        test_format(str_, str, YASStyle(); indent=2, margin=64)
+        test_format(str_, str, YASStyle(); indent=2, margin=39)
 
         str = """
         function func(arg1::Type1,
@@ -258,43 +265,43 @@
                                    Type2}
           body
         end"""
-        @test yasfmt(str_, 2, 31) == str
-        @test yasfmt(str_, 2, 1) == str
+        test_format(str_, str, YASStyle(); indent=2, margin=31)
+        test_format(str_, str, YASStyle(); indent=2, margin=1)
 
         str_ = """
         @test TimeSpan(spike_annotation) == TimeSpan(first(spike_annotation), last(spike_annotation))"""
         str = """
         @test TimeSpan(spike_annotation) ==
               TimeSpan(first(spike_annotation), last(spike_annotation))"""
-        @test yasfmt(str_, 4, length(str_) - 1) == str
-        @test yasfmt(str_, 4, 63) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=length(str_) - 1)
+        test_format(str_, str, YASStyle(); indent=4, margin=63)
         str_ = """
         @test TimeSpan(spike_annotation) == TimeSpan(first(spike_annotation), last(spike_annotation))"""
         str = """
         @test TimeSpan(spike_annotation) ==
               TimeSpan(first(spike_annotation),
                        last(spike_annotation))"""
-        @test yasfmt(str_, 4, 62) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=62)
 
         str_ =
             raw"""ecg_signal = signal_from_template(eeg_signal; channel_names=[:avl, :avr], file_extension=Symbol("lpcm.zst"))"""
         str = raw"""
         ecg_signal = signal_from_template(eeg_signal; channel_names = [:avl, :avr],
                                           file_extension = Symbol("lpcm.zst"))"""
-        @test yasfmt(str_, 4, length(str_) - 1) == str
-        @test yasfmt(str_, 4, 75) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=length(str_) - 1)
+        test_format(str_, str, YASStyle(); indent=4, margin=75)
 
         str = raw"""
         ecg_signal = signal_from_template(eeg_signal;
                                           channel_names = [:avl, :avr],
                                           file_extension = Symbol("lpcm.zst"))"""
-        @test yasfmt(str_, 4, 73) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=73)
         str = raw"""
         ecg_signal = signal_from_template(eeg_signal;
                                           channel_names = [:avl,
                                                            :avr],
                                           file_extension = Symbol("lpcm.zst"))"""
-        @test yasfmt(str_, 4, 1) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=1)
     end
 
     @testset "inline comments with arguments" begin
@@ -305,15 +312,15 @@
         str = """
         var = fcall(arg1, arg2, arg3, # comment
                     arg4, arg5)"""
-        @test yasfmt(str_, 4, 80; join_lines_based_on_source = false) == str
-        @test yasfmt(str_, 4, 29; join_lines_based_on_source = false) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=80, join_lines_based_on_source = false)
+        test_format(str_, str, YASStyle(); indent=4, margin=29, join_lines_based_on_source = false)
 
         str = """
         var = fcall(arg1, arg2,
                     arg3, # comment
                     arg4, arg5)"""
-        @test yasfmt(str_, 4, 28; join_lines_based_on_source = false) == str
-        @test yasfmt(str_, 4, 23; join_lines_based_on_source = false) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=28, join_lines_based_on_source = false)
+        test_format(str_, str, YASStyle(); indent=4, margin=23, join_lines_based_on_source = false)
 
         str = """
         var = fcall(arg1,
@@ -321,8 +328,8 @@
                     arg3, # comment
                     arg4,
                     arg5)"""
-        @test yasfmt(str_, 4, 22) == str
-        @test yasfmt(str_, 4, 1) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=22)
+        test_format(str_, str, YASStyle(); indent=4, margin=1)
 
         str_ = """
         comp = [
@@ -341,8 +348,8 @@
                 end
                 for a = 1:10,  # comment 2
                     b = 11:20, c = 300:400]"""
-        @test yasfmt(str_, 2, 80; join_lines_based_on_source = false) == str
-        @test yasfmt(str_, 2, 35; join_lines_based_on_source = false) == str
+        test_format(str_, str, YASStyle(); indent=2, margin=80, join_lines_based_on_source = false)
+        test_format(str_, str, YASStyle(); indent=2, margin=35, join_lines_based_on_source = false)
 
         str = """
         comp = [begin
@@ -352,7 +359,7 @@
                 for a = 1:10,  # comment 2
                     b = 11:20,
                     c = 300:400]"""
-        @test yasfmt(str_, 2, 34) == str
+        test_format(str_, str, YASStyle(); indent=2, margin=34)
 
         str_ = """
         ys = ( if p1(x)
@@ -373,27 +380,27 @@
               end
               for x in xs)
         """
-        @test yasfmt(str_, 2, 80) == str
+        test_format(str_, str, YASStyle(); indent=2, margin=80)
 
         str_ = """spike_annotation = first(ann for ann in recording.annotations if ann.value == "epileptiform_spike")"""
         str = """
         spike_annotation = first(ann
                                  for ann in recording.annotations
                                  if ann.value == "epileptiform_spike")"""
-        @test yasfmt(str_, 2, 80) == str
+        test_format(str_, str, YASStyle(); indent=2, margin=80)
 
         # only that
         str_ = "foo(a, b) = (arg1, arg2, arg3)"
         str = """
         foo(a, b) = (arg1, arg2,
                      arg3)"""
-        @test yasfmt(str_, 2, length(str_) - 1) == str
+        test_format(str_, str, YASStyle(); indent=2, margin=length(str_) - 1)
 
         str = """
         foo(a, b) = (arg1,
                      arg2,
                      arg3)"""
-        @test yasfmt(str_, 2, 1) == str
+        test_format(str_, str, YASStyle(); indent=2, margin=1)
 
         str_ = """
         fooooooooooooooooooo(arg1, arg2,
@@ -406,14 +413,14 @@
                              x -> begin
                                  body
                              end)"""
-        @test yasfmt(str_, 4, 32) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=32)
 
         # parsing error is newline is placed front of `for` here
         str_ = "var = ((x, y) for x = 1:10, y = 1:10)"
         str = """
         var = ((x, y) for x = 1:10,
                           y = 1:10)"""
-        @test yasfmt(str_, 4, length(str_) - 1) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=length(str_) - 1)
     end
 
     @testset "invisbrackets" begin
@@ -431,7 +438,7 @@
              aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa))
           nothing
         end"""
-        @test yasfmt(str_, 2, 92) == str
+        test_format(str_, str, YASStyle(); indent=2, margin=92)
     end
 
     @testset "issue 189" begin
@@ -449,7 +456,7 @@
               (b_hat - y_hat) * delta[i] +
               (b - y) * delta_hat[i] - delta[i] * delta_hat[i]
               for i = 1:8]"""
-        @test yasfmt(str_, 2, 60; join_lines_based_on_source = false) == str
+        test_format(str_, str, YASStyle(); indent=2, margin=60, join_lines_based_on_source = false)
     end
 
     @testset "issue 237" begin
@@ -461,20 +468,20 @@
         for x in (arg1, arg2)
             @info "Test"
         end"""
-        @test yasfmt(str_, 4, 92) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=92)
     end
 
     @testset "issue 320" begin
         str_ = "[x[i] for i = 1:length(x)]"
         str = "[x[i] for i in 1:length(x)]"
-        @test yasfmt(str_, 4, 92; always_for_in = true) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=92, always_for_in = true)
     end
 
     @testset "issue 321 - exponential inline comments !!!" begin
         str = """
         scaled_ticks, mini, maxi = optimize_ticks(scale_func(lmin), scale_func(lmax); k_min=4, # minimum number of ticks
                                                   k_max=8)"""
-        @test yasfmt(str, 4, 92; whitespace_in_kwargs = false) == str
+        test_format(str, str, YASStyle(); indent=4, margin=92, whitespace_in_kwargs = false)
     end
 
     @testset "issue 355 - vcat/typedvcat" begin
@@ -486,7 +493,7 @@
                         @acrule(~x::ismpoly * ~y::ismpoly => ~x * ~y)
                         @rule(*(~x) => ~x)
                         @rule((~x::ismpoly)^(~a::isnonnegint) => (~x)^(~a))]"""
-        @test yasfmt(str) == str
+        test_format(str, str, YASStyle())
 
         str = """
         mpoly_rules = [@rule(~x::ismpoly - ~y::ismpoly => ~x + -1 * (~y))
@@ -496,21 +503,21 @@
                        @acrule(~x::ismpoly * ~y::ismpoly => ~x * ~y)
                        @rule(*(~x) => ~x)
                        @rule((~x::ismpoly)^(~a::isnonnegint) => (~x)^(~a))]"""
-        @test yasfmt(str) == str
+        test_format(str, str, YASStyle())
 
         str_ = """
         [10 20; 30 40; 50 60;
          10
          10]"""
-        @test yasfmt(str_, 4, 21) == str_
+        test_format(str_, str_, YASStyle(); indent=4, margin=21)
 
         str = """
         [10 20; 30 40;
          50 60;
          10
          10]"""
-        @test yasfmt(str_, 4, 20) == str
-        @test yasfmt(str_, 4, 14) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=20)
+        test_format(str_, str, YASStyle(); indent=4, margin=14)
 
         str = """
         [10 20;
@@ -518,21 +525,21 @@
          50 60;
          10
          10]"""
-        @test yasfmt(str_, 4, 13) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=13)
 
         str_ = """
         T[10 20; 30 40; 50 60;
           10
           10]"""
-        @test yasfmt(str_, 4, 22) == str_
+        test_format(str_, str_, YASStyle(); indent=4, margin=22)
 
         str = """
         T[10 20; 30 40;
           50 60;
           10
           10]"""
-        @test yasfmt(str_, 4, 21) == str
-        @test yasfmt(str_, 4, 15) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=21)
+        test_format(str_, str, YASStyle(); indent=4, margin=15)
 
         str = """
         T[10 20;
@@ -540,35 +547,35 @@
           50 60;
           10
           10]"""
-        @test yasfmt(str_, 4, 14) == str
+        test_format(str_, str, YASStyle(); indent=4, margin=14)
 
         str = "(T[10 20; 30 40; 50 60;])"
-        @test yasfmt(str, 4, 25) == str
+        test_format(str, str, YASStyle(); indent=4, margin=25)
         str = "(T[10 20; 30 40; 50 60])"
-        @test yasfmt(str, 4, 24) == str
+        test_format(str, str, YASStyle(); indent=4, margin=24)
 
         str_ = """
         (T[10 20; 30 40;
            50 60])"""
-        @test yasfmt(str, 4, 23) == str_
+        test_format(str, str_, YASStyle(); indent=4, margin=23)
     end
 
     @testset "imports no placeholder, no error" begin
         str = "import A"
-        @test yasfmt(str) == str
+        test_format(str, str, YASStyle())
 
         str = "export A"
-        @test yasfmt(str) == str
+        test_format(str, str, YASStyle())
 
         str = "using A"
-        @test yasfmt(str) == str
+        test_format(str, str, YASStyle())
     end
 
     if VERSION >= v"1.7"
         @testset "issue 582 - vcat" begin
-            @test yasfmt("[sts...;]") == "[sts...;]"
-            @test yasfmt("[a;b;]") == "[a; b;]"
-            @test yasfmt("[a;b;;]") == "[a; b;;]"
+            test_format("[sts...;]", "[sts...;]", YASStyle())
+            test_format("[a;b;]", "[a; b;]", YASStyle())
+            test_format("[a;b;;]", "[a; b;;]", YASStyle())
         end
     end
 
@@ -801,4 +808,6 @@
         @test format_text(str, YASStyle(); variable_call_indent = ["SVector", "test"]) ==
               formatted_str2
     end
+end
+
 end


### PR DESCRIPTION
Closes #1042

I got Claude to do the boring textual replacements, but that spawned a new bunch of test failures, which I looked at individually. Some of them are just because of the default style options being injected, so I changed the expected output accordingly. Some of the test failures surfaced other genuine bugs, which I'm not happy with -- however, this isn't the PR to fix them, so I've opened separate issues.