### PR TITLE
Fix stack overflow on format()

### DIFF
--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -4,6 +4,8 @@ Fixed a bug where formatting binary expressions with extraneous blank lines was 
 
 Fixed a bug where formatting expressions with semicolons (e.g. `a1; a2`) inside a `try`/`catch` block was not idempotent. (#1051, #1050)
 
+Improved the error message emitted when calling `JuliaFormatter.format()` with an invalid argument. (#830, #1047)
+
 # v2.6.2
 
 Re-enabled `always_use_return=true` for BlueStyle, in line with the Blue style guide. (#906, #1041)

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -391,6 +391,11 @@ function format(paths, options::Configuration)::Bool
     # Don't parallelize this, since there could be a race condition on a
     # subdirectory that is included in both paths
     for path in paths
+        if !(path isa AbstractString) && !(path isa Module)
+            error(
+                "`format()` only accepts paths, modules, or collections thereof, but got an element of type $(typeof(path))",
+            )
+        end
         already_formatted &= format(path, options)
     end
     return already_formatted


### PR DESCRIPTION
Closes #830

```julia
julia> format('.')
ERROR: `format()` only accepts a path or collection of paths, but got an element of type Char
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] format(paths::Char, options::JuliaFormatter.Configuration)
   @ JuliaFormatter ~/jl/JuliaFormatter.jl/src/JuliaFormatter.jl:395
 [3] format(paths::Char; options::@Kwargs{})
   @ JuliaFormatter ~/jl/JuliaFormatter.jl/src/JuliaFormatter.jl:387
 [4] format(paths::Char)
   @ JuliaFormatter ~/jl/JuliaFormatter.jl/src/JuliaFormatter.jl:386
 [5] top-level scope
   @ REPL[2]:1
```

I would prefer to tighten the `::Any` type parameter to `Union{AbstractString,AbstractVector{<:AbstractString}}`, but that's breaking as it would exclude e.g. other iterables of strings. One for 3.0.