### PR TITLE
Force JuliaSyntax to parse everything up to 1.12

### DIFF
--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,3 +1,7 @@
+# v2.6.4
+
+Fixed a bug where running JuliaFormatter on Julia v1.10 would error on syntax that was only valid in Julia v1.11, such as the `public` keyword. (#890, #1055)
+
 # v2.6.3
 
 Fixed a bug where formatting binary expressions with extraneous blank lines was not idempotent. (#1049, #1050)

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.6.3"
+version = "2.6.4"
 authors = ["Dominique Luna <dluna132@gmail.com> and contributors"]
 
 [deps]

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -209,7 +209,7 @@ function format_text(text::AbstractString, style::AbstractStyle, opts::Options)
     if opts.always_for_in == true
         @assert valid_for_in_op(opts.for_in_replacement) "`for_in_replacement` is set to an invalid operator \"$(opts.for_in_replacement)\", valid operators are $(VALID_FOR_IN_OPERATORS). Change it to one of the valid operators and then reformat."
     end
-    t = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; ignore_warnings = true)
+    t = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; ignore_warnings = true, version=v"1.12")
     state = State(Document(text), opts)
     text = format_text(t, style, state)
     return text
@@ -275,7 +275,7 @@ function format_text(node::JuliaSyntax.GreenNode, style::AbstractStyle, s::State
     text = normalize_line_ending(text, replacer)
 
     try
-        _ = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; ignore_warnings = true)
+        _ = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; ignore_warnings = true, version=v"1.12")
     catch err
         @warn "Formatted text is not parsable ... no change made."
         rethrow(err)

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -36,6 +36,11 @@ export format,
 
 haschildren(node::JuliaSyntax.GreenNode) = !JuliaSyntax.is_leaf(node)
 
+# The Julia syntax version we pass to JuliaSyntax.parseall. This should be kept
+# at the latest stable Julia release so that JuliaSyntax can parse all valid
+# syntax up to that version.
+const SUPPORTED_SYNTAX_VERSION = v"1.12"
+
 struct Configuration
     args::Dict{String,Any}
     file::Dict{String,Any}
@@ -209,7 +214,12 @@ function format_text(text::AbstractString, style::AbstractStyle, opts::Options)
     if opts.always_for_in == true
         @assert valid_for_in_op(opts.for_in_replacement) "`for_in_replacement` is set to an invalid operator \"$(opts.for_in_replacement)\", valid operators are $(VALID_FOR_IN_OPERATORS). Change it to one of the valid operators and then reformat."
     end
-    t = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; ignore_warnings = true, version=v"1.12")
+    t = JuliaSyntax.parseall(
+        JuliaSyntax.GreenNode,
+        text;
+        ignore_warnings = true,
+        version = SUPPORTED_SYNTAX_VERSION,
+    )
     state = State(Document(text), opts)
     text = format_text(t, style, state)
     return text
@@ -275,7 +285,12 @@ function format_text(node::JuliaSyntax.GreenNode, style::AbstractStyle, s::State
     text = normalize_line_ending(text, replacer)
 
     try
-        _ = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; ignore_warnings = true, version=v"1.12")
+        _ = JuliaSyntax.parseall(
+            JuliaSyntax.GreenNode,
+            text;
+            ignore_warnings = true,
+            version = SUPPORTED_SYNTAX_VERSION,
+        )
     catch err
         @warn "Formatted text is not parsable ... no change made."
         rethrow(err)

--- a/src/internal/utils.jl
+++ b/src/internal/utils.jl
@@ -59,7 +59,7 @@ function format_to_stage(
     options...,
 )
     # :cst
-    cst = JS.parseall(JS.GreenNode, text)
+    cst = JS.parseall(JS.GreenNode, text; version=v"1.12")
     stage in (:gn, :cst) && return cst[1]
 
     # :fst

--- a/src/internal/utils.jl
+++ b/src/internal/utils.jl
@@ -59,7 +59,7 @@ function format_to_stage(
     options...,
 )
     # :cst
-    cst = JS.parseall(JS.GreenNode, text; version=v"1.12")
+    cst = JS.parseall(JS.GreenNode, text; version = JF.SUPPORTED_SYNTAX_VERSION)
     stage in (:gn, :cst) && return cst[1]
 
     # :fst

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -8,7 +8,7 @@ using JuliaFormatter.Internal: test_format
 function run_pretty(text::String; style = DefaultStyle(), opts = Options())
     d = JuliaFormatter.Document(text)
     s = JuliaFormatter.State(d, opts)
-    g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; version=v"1.12")
+    g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; version=JuliaFormatter.SUPPORTED_SYNTAX_VERSION)
     t = JuliaFormatter.pretty(style, g, s)
     t
 end
@@ -17,7 +17,7 @@ run_pretty(text::String, margin::Int) = run_pretty(text, opts = Options(margin =
 function run_nest(text::String; opts = Options(), style = DefaultStyle())
     d = JuliaFormatter.Document(text)
     s = JuliaFormatter.State(d, opts)
-    g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; version=v"1.12")
+    g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; version=JuliaFormatter.SUPPORTED_SYNTAX_VERSION)
     t = JuliaFormatter.pretty(style, g, s)
     JuliaFormatter.nest!(style, t, s)
     t, s
@@ -477,7 +477,7 @@ run_nest(text::String, margin::Int) = run_nest(text, opts = Options(margin = mar
         text = "a + b"
         d = JuliaFormatter.Document(text)
         s = JuliaFormatter.State(d, Options())
-        g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; version=v"1.12")
+        g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; version=JuliaFormatter.SUPPORTED_SYNTAX_VERSION)
         op = JuliaSyntax.children(only(JuliaSyntax.children(g)))[3]
         @test JuliaFormatter.source_op_kind_from_offset(s, op, UInt32(3)) ===
               JuliaSyntax.Kind("+")

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -8,7 +8,7 @@ using JuliaFormatter.Internal: test_format
 function run_pretty(text::String; style = DefaultStyle(), opts = Options())
     d = JuliaFormatter.Document(text)
     s = JuliaFormatter.State(d, opts)
-    g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text)
+    g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; version=v"1.12")
     t = JuliaFormatter.pretty(style, g, s)
     t
 end
@@ -17,7 +17,7 @@ run_pretty(text::String, margin::Int) = run_pretty(text, opts = Options(margin =
 function run_nest(text::String; opts = Options(), style = DefaultStyle())
     d = JuliaFormatter.Document(text)
     s = JuliaFormatter.State(d, opts)
-    g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text)
+    g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; version=v"1.12")
     t = JuliaFormatter.pretty(style, g, s)
     JuliaFormatter.nest!(style, t, s)
     t, s
@@ -477,7 +477,7 @@ run_nest(text::String, margin::Int) = run_nest(text, opts = Options(margin = mar
         text = "a + b"
         d = JuliaFormatter.Document(text)
         s = JuliaFormatter.State(d, Options())
-        g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text)
+        g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; version=v"1.12")
         op = JuliaSyntax.children(only(JuliaSyntax.children(g)))[3]
         @test JuliaFormatter.source_op_kind_from_offset(s, op, UInt32(3)) ===
               JuliaSyntax.Kind("+")

--- a/test/internal_utils.jl
+++ b/test/internal_utils.jl
@@ -9,7 +9,7 @@ import JuliaSyntax as JS
     function parsed_node(text)
         doc = JF.Document(text)
         state = JF.State(doc, JF.Options())
-        root = JS.parseall(JS.GreenNode, text; version=v"1.12")
+        root = JS.parseall(JS.GreenNode, text; version=JF.SUPPORTED_SYNTAX_VERSION)
         nodes = filter(n -> !JS.is_whitespace(n), JS.children(root))
         return doc, state, only(nodes)
     end
@@ -161,7 +161,7 @@ end
 @testset "predicates on GreenNodes" begin
     @testset "unary_info" begin
         # [1] to index into the actual node we care about
-        p(x) = JS.parseall(JS.GreenNode, strip(x); version=v"1.12")[1]
+        p(x) = JS.parseall(JS.GreenNode, strip(x); version=JF.SUPPORTED_SYNTAX_VERSION)[1]
         # Prefix operator
         @test JF.unary_info(p("+(x)")) === true
         @test JF.unary_info(p("+x")) === true
@@ -190,7 +190,7 @@ end
     end
 
     @testset "first_nonws_leaf_and_offset" begin
-        p(x) = JS.parseall(JS.GreenNode, x; version=v"1.12")
+        p(x) = JS.parseall(JS.GreenNode, x; version=JF.SUPPORTED_SYNTAX_VERSION)
         # Simple identifier
         let result = JF.first_nonws_leaf_and_offset(p("x")[1])
             @test result !== nothing
@@ -211,7 +211,7 @@ end
 
     @testset "source_begins_with_op_needing_parens" begin
         function check(code)
-            node = JS.parseall(JS.GreenNode, code; version=v"1.12")[1]
+            node = JS.parseall(JS.GreenNode, code; version=JF.SUPPORTED_SYNTAX_VERSION)[1]
             opts = JF.Options()
             s = JF.State(JF.Document(code), opts)
             return JF.source_begins_with_op_needing_parens(s, node, s.offset)

--- a/test/internal_utils.jl
+++ b/test/internal_utils.jl
@@ -9,7 +9,7 @@ import JuliaSyntax as JS
     function parsed_node(text)
         doc = JF.Document(text)
         state = JF.State(doc, JF.Options())
-        root = JS.parseall(JS.GreenNode, text)
+        root = JS.parseall(JS.GreenNode, text; version=v"1.12")
         nodes = filter(n -> !JS.is_whitespace(n), JS.children(root))
         return doc, state, only(nodes)
     end
@@ -161,7 +161,7 @@ end
 @testset "predicates on GreenNodes" begin
     @testset "unary_info" begin
         # [1] to index into the actual node we care about
-        p(x) = JS.parseall(JS.GreenNode, strip(x))[1]
+        p(x) = JS.parseall(JS.GreenNode, strip(x); version=v"1.12")[1]
         # Prefix operator
         @test JF.unary_info(p("+(x)")) === true
         @test JF.unary_info(p("+x")) === true
@@ -190,7 +190,7 @@ end
     end
 
     @testset "first_nonws_leaf_and_offset" begin
-        p(x) = JS.parseall(JS.GreenNode, x)
+        p(x) = JS.parseall(JS.GreenNode, x; version=v"1.12")
         # Simple identifier
         let result = JF.first_nonws_leaf_and_offset(p("x")[1])
             @test result !== nothing
@@ -211,7 +211,7 @@ end
 
     @testset "source_begins_with_op_needing_parens" begin
         function check(code)
-            node = JS.parseall(JS.GreenNode, code)[1]
+            node = JS.parseall(JS.GreenNode, code; version=v"1.12")[1]
             opts = JF.Options()
             s = JF.State(JF.Document(code), opts)
             return JF.source_begins_with_op_needing_parens(s, node, s.offset)

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -11,7 +11,7 @@ ALL_STYLES = (DefaultStyle(), YASStyle(), BlueStyle(), MinimalStyle(), SciMLStyl
 function run_nest(text::String; opts = Options(), style = DefaultStyle())
     d = JuliaFormatter.Document(text)
     s = JuliaFormatter.State(d, opts)
-    g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text)
+    g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; version=v"1.12")
     t = JuliaFormatter.pretty(style, g, s)
     JuliaFormatter.nest!(style, t, s)
     t, s
@@ -20,7 +20,7 @@ end
 function run_format(text::String; style = DefaultStyle(), opts = Options())
     d = JuliaFormatter.Document(text)
     s = JuliaFormatter.State(d, opts)
-    g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text)
+    g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; version=v"1.12")
     JuliaFormatter.format_text(g, style, s)
     s
 end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -11,7 +11,7 @@ ALL_STYLES = (DefaultStyle(), YASStyle(), BlueStyle(), MinimalStyle(), SciMLStyl
 function run_nest(text::String; opts = Options(), style = DefaultStyle())
     d = JuliaFormatter.Document(text)
     s = JuliaFormatter.State(d, opts)
-    g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; version=v"1.12")
+    g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; version=JuliaFormatter.SUPPORTED_SYNTAX_VERSION)
     t = JuliaFormatter.pretty(style, g, s)
     JuliaFormatter.nest!(style, t, s)
     t, s
@@ -20,7 +20,7 @@ end
 function run_format(text::String; style = DefaultStyle(), opts = Options())
     d = JuliaFormatter.Document(text)
     s = JuliaFormatter.State(d, opts)
-    g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; version=v"1.12")
+    g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; version=JuliaFormatter.SUPPORTED_SYNTAX_VERSION)
     JuliaFormatter.format_text(g, style, s)
     s
 end

--- a/test/options.jl
+++ b/test/options.jl
@@ -9,7 +9,7 @@ using Test
 function run_pretty(text::String; style = DefaultStyle(), opts = Options())
     d = JuliaFormatter.Document(text)
     s = JuliaFormatter.State(d, opts)
-    g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; version=v"1.12"))
+    g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; version=JuliaFormatter.SUPPORTED_SYNTAX_VERSION)
     t = JuliaFormatter.pretty(style, g, s)
     t
 end

--- a/test/options.jl
+++ b/test/options.jl
@@ -9,7 +9,7 @@ using Test
 function run_pretty(text::String; style = DefaultStyle(), opts = Options())
     d = JuliaFormatter.Document(text)
     s = JuliaFormatter.State(d, opts)
-    g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text)
+    g = JuliaSyntax.parseall(JuliaSyntax.GreenNode, text; version=v"1.12"))
     t = JuliaFormatter.pretty(style, g, s)
     t
 end


### PR DESCRIPTION
This ensures that, for example, `public Foo` is parsed correctly even when running JuliaFormatter with Julia 1.10, even though that string is not valid Julia on 1.10.

Closes #890 (properly)