### PR TITLE
FormatBot improvements and docs

### DIFF
--- a/.github/workflows/FormatBot.yml
+++ b/.github/workflows/FormatBot.yml
@@ -7,10 +7,9 @@ on:
 jobs:
   format:
     name: FormatBot
-    # TODO: Let other people trigger the bot as well. It's restricted for now so that I can test.
     if: >-
       github.event.issue.pull_request
-      && github.actor == 'penelopeysm'
+      && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
       && startsWith(github.event.comment.body, '!formatbot')
     runs-on: ubuntu-latest
     permissions:
@@ -98,11 +97,17 @@ jobs:
           target_dir = "target"
           subdir = None
           use_config = False
+          against = "basefmt"
           for token in opts:
               if token.startswith("subdir="):
                   subdir = token.split("=", 1)[1]
               elif token.startswith("use_config="):
                   use_config = token.split("=", 1)[1].lower() == "true"
+              elif token.startswith("against="):
+                  against = token.split("=", 1)[1]
+          if against not in ("basefmt", "nofmt"):
+              print(f"::error::Unknown against value: {against}. Valid: basefmt, nofmt.")
+              sys.exit(1)
           uid = uuid.uuid4().hex[:8]
           branch_clean = f"formatbot-clean-{uid}"
           branch_base = f"formatbot-base-{uid}"
@@ -181,7 +186,7 @@ jobs:
                           post_comment(f"{header}\n**Error:** Unknown style `{val}`. Valid: {', '.join(style_shortcuts)}.")
                           sys.exit(1)
                       style = style_shortcuts[val]
-                  elif token.startswith("subdir=") or token.startswith("use_config="):
+                  elif token.startswith("subdir=") or token.startswith("use_config=") or token.startswith("against="):
                       pass
                   else:
                       kwargs.append(token)
@@ -202,18 +207,27 @@ jobs:
               )
 
               # --- Format with base, commit to branch ---
-              git("checkout", "-b", branch_base)
-              base_result = subprocess.run(
-                  ["julia", "--project=formatter-base", "format.jl", format_path],
-              )
-              if base_result.returncode != 0:
-                  post_comment(
-                      f"{header}\n**Error:** Formatting with base failed. "
-                      f"See [workflow run]({run_url})."
+              if against == "basefmt":
+                  git("checkout", "-b", branch_base)
+                  base_result = subprocess.run(
+                      ["julia", "--project=formatter-base", "format.jl", format_path],
                   )
-                  sys.exit(1)
-              git("add", "-A")
-              git("commit", "--allow-empty", "-m", "formatted with base")
+                  if base_result.returncode != 0:
+                      post_comment(
+                          f"{header}\n**Error:** Formatting with base failed. "
+                          f"See [workflow run]({run_url})."
+                      )
+                      sys.exit(1)
+                  git("add", "-A")
+                  git("commit", "--allow-empty", "-m", "formatted with base")
+                  subprocess.run(
+                      ["julia", "--project=formatter-base", "format.jl", format_path],
+                      check=True,
+                  )
+                  base_idempotent = subprocess.run(
+                      ["git", "-C", target_dir, "diff", "--exit-code"],
+                  ).returncode == 0
+                  git("checkout", "--", ".")
 
               # --- Format with PR, commit to branch ---
               git("checkout", branch_clean)
@@ -230,16 +244,43 @@ jobs:
               git("add", "-A")
               git("commit", "--allow-empty", "-m", "formatted with pr")
 
+              # --- Check idempotence ---
+              subprocess.run(
+                  ["julia", "--project=formatter-pr", "format.jl", format_path],
+                  check=True,
+              )
+              pr_idempotent = subprocess.run(
+                  ["git", "-C", target_dir, "diff", "--exit-code"],
+              ).returncode == 0
+              git("checkout", "--", ".")
+
               # --- Compute diff ---
               diff_result = subprocess.run(
-                  ["git", "-C", target_dir, "diff", "--diff-algorithm=histogram", branch_base, branch_pr],
+                  ["git", "-C", target_dir, "diff", "--diff-algorithm=histogram",
+                   branch_base if against == "basefmt" else branch_clean, branch_pr],
                   capture_output=True,
                   text=True,
               )
               diff_text = diff_result.stdout
 
+              Path(os.environ["RUNNER_TEMP"], "diff.patch").write_text(diff_text)
+
+              # --- Build idempotence warning ---
+              non_idempotent = []
+              if against == "basefmt" and not base_idempotent:
+                  non_idempotent.append("base")
+              if not pr_idempotent:
+                  non_idempotent.append("PR")
+              if non_idempotent:
+                  idempotency_warning = (
+                      f"\n\n> [!CAUTION]\n"
+                      f"> Formatting with **{' and '.join(non_idempotent)}** is not idempotent!\n"
+                  )
+              else:
+                  idempotency_warning = ""
+
               if not diff_text:
-                  post_comment(f"{header}\nNo formatting differences.")
+                  post_comment(f"{header}{idempotency_warning}\nNo formatting differences.")
               else:
                   diff_bytes = len(diff_text.encode())
                   if diff_bytes > 50000:
@@ -249,7 +290,7 @@ jobs:
                       diff_display = diff_text
                       warning = ""
                   post_comment(
-                      f"{header}{warning}\n<details>\n<summary>Diff ({diff_bytes} bytes)</summary>"
+                      f"{header}{idempotency_warning}{warning}\n<details>\n<summary>Diff ({diff_bytes} bytes)</summary>"
                       f"\n\n```````diff\n{diff_display}\n```````\n\n</details>"
                   )
 
@@ -269,6 +310,15 @@ jobs:
               except Exception:
                   pass
               sys.exit(1)
+
+      - name: Print diff
+        if: always()
+        run: |
+          if [ -f "$RUNNER_TEMP/diff.patch" ]; then
+            cat "$RUNNER_TEMP/diff.patch"
+          else
+            echo "Diff not found (script may have errored before computing diff)"
+          fi
 
       - name: Add completion reaction
         env:

--- a/.github/workflows/FormatBot.yml
+++ b/.github/workflows/FormatBot.yml
@@ -319,10 +319,3 @@ jobs:
           else
             echo "Diff not found (script may have errored before computing diff)"
           fi
-
-      - name: Add completion reaction
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
-            -f content=rocket

--- a/.github/workflows/FormatBot.yml
+++ b/.github/workflows/FormatBot.yml
@@ -314,8 +314,10 @@ jobs:
       - name: Print diff
         if: always()
         run: |
-          if [ -f "$RUNNER_TEMP/diff.patch" ]; then
-            cat "$RUNNER_TEMP/diff.patch"
-          else
+          if [ ! -f "$RUNNER_TEMP/diff.patch" ]; then
             echo "Diff not found (script may have errored before computing diff)"
+            exit 0
           fi
+          curl -sL https://github.com/dandavison/delta/releases/download/0.19.2/delta-0.19.2-x86_64-unknown-linux-gnu.tar.gz \
+            | tar xz --strip-components=1 -C "$RUNNER_TEMP" delta-0.19.2-x86_64-unknown-linux-gnu/delta
+          "$RUNNER_TEMP/delta" < "$RUNNER_TEMP/diff.patch"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,6 +1,6 @@
 # API Documentation
 
 ```@autodocs
-Modules = [JuliaFormatter, JuliaFormatter.Internal]
+Modules = [JuliaFormatter]
 Filter = t -> (t != YASStyle && t != BlueStyle && t != SciMLStyle)  # on their own pages
 ```

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -14,6 +14,20 @@ However, the complexity comes from the fact that:
 
 I'm happy to help with any questions about how best to implement stuff, although please note I'm also finding my way around the codebase myself, so I might not always have the best answer.
 
+## The `JuliaFormatter.Internal` module
+
+JuliaFormatter contains some useful utilities which are explicitly marked as internal (i.e., not semver-compliant), inside the `JuliaFormatter.Internal` module.
+
+There are currently two functions.
+`format_to_stage` is more of a helper function for investigating what goes on during the formatting process.
+However, `test_format` is used extensively in the test suite.
+**Please note that all new tests that check the output of formatting should be written using `test_format`.**
+
+```@docs
+JuliaFormatter.Internal.format_to_stage
+JuliaFormatter.Internal.test_format
+```
+
 ## Issue triage
 
 Issues (and sometimes PRs) will be assigned a priority label, with a larger number indicating more important.

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -63,6 +63,8 @@ When invoked on a JuliaFormatter PR, FormatBot will:
    - Run the formatter on the target repository again, with the same style options, and save *those* changes to a different branch (let's call it `headfmt`);
 1. If `against=basefmt`, diff the `basefmt` and `headfmt` branches and post the results as a comment on the PR. If `against=nofmt`, diff the `nofmt` and `headfmt` branches instead.
 
+FormatBot will also include a warning if formatting is not idempotent, or fails.
+
 ### Issue triage
 
 Issues (and sometimes PRs) will be assigned a priority label, with a larger number indicating more important.

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -28,7 +28,42 @@ JuliaFormatter.Internal.format_to_stage
 JuliaFormatter.Internal.test_format
 ```
 
-## Issue triage
+## GitHub-specific things
+
+### FormatBot
+
+JuliaFormatter has a small GitHub workflow, called FormatBot, which can be invoked on PRs with the following syntax:
+
+```
+!formatbot
+    owner/repo[@REV]
+    [against=basefmt|nofmt]   (default: basefmt)
+    [use_config=true|false]   (default: false)
+    [subdir=SUBDIR]           (default: top-level dir of repo)
+    [style=STYLE]
+    [arg1=val1 arg2=val2...]
+```
+
+where `STYLE` is `default|yas|sciml|blue|minimal` (or omitted to use `DefaultStyle`), and remaining keyword arguments are directly interpolated (**as text**) into `JuliaFormatter.format()`.
+
+`use_config` is a special argument, which indicates whether the `.JuliaFormatter.toml` file in the target repository should be used.
+By default this is `false`, i.e., the formatter will *ignore* any existing configuration file in the target repository.
+
+!!! note "Security"
+    Because the keyword arguments are interpolated directly, this allows for arbitrary code execution, including printing the contents of environment variables.
+    Thus, this command can only be invoked by users with write access to the repository.
+
+When invoked on a JuliaFormatter PR, FormatBot will:
+
+1. Clone the target repository at the specified revision (or the default branch if no revision is specified). Let's call this branch `nofmt`, i.e., no formatting.
+1. Check out the base of the JuliaFormatter PR (i.e., usually the current release of JuliaFormatter).
+   - Run the formatter on the target repository, with the specified style options, and save those changes to a branch (let's call it `basefmt`).
+1. Reset the target repository to `nofmt`.
+1. Check out the head of the JuliaFormatter PR (i.e., the proposed changes).
+   - Run the formatter on the target repository again, with the same style options, and save *those* changes to a different branch (let's call it `headfmt`);
+1. If `against=basefmt`, diff the `basefmt` and `headfmt` branches and post the results as a comment on the PR. If `against=nofmt`, diff the `nofmt` and `headfmt` branches instead.
+
+### Issue triage
 
 Issues (and sometimes PRs) will be assigned a priority label, with a larger number indicating more important.
 The exact label for an issue is left to my discretion, but generally these are the categories that they will fall into:


### PR DESCRIPTION
- Documents FormatBot.
- Documents internal helpers including the expectation that all tests are written with test_format going forwards.
- Adds the `against=basefmt|nofmt` option to FormatBot. Running with `against=nofmt` will diff the unformatted repo with the formatted-with-current-PR repo.
- FormatBot workflow now unconditionally prints the diff to the workflow log (previously if the diff was too long for a GitHub coment it would just not have it anywhere.)
- FormatBot now adds a warning to the comment if formatting is not idempotent.

Closes #1060
Closes #1030 