### PR TITLE
Fix disappearing comments on YASStyle

### DIFF
--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,3 +1,7 @@
+# v2.6.8
+
+Fixed a bug where end-of-line comments were being silently dropped in YASStyle. (#690, #1046, #1068)
+
 # v2.6.7
 
 Improve separation of inline comments from code. (#1064, #1065)

--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -2,6 +2,11 @@
 
 Fixed a bug where end-of-line comments were being silently dropped in YASStyle. (#690, #1046, #1068)
 
+Fixed a bug where the `trailing_comma` option was being ignored with YASStyle.
+Prior to #1068 there was never a need for trailing commas at the end of a function argument list, since the closing parenthesis would always follow the final argument (and silently delete any comments in the way).
+However, if the last argument has a comment after it, the closing parenthesis is forced to the next line.
+This fix ensures that a trailing comma is inserted. (#1068)
+
 # v2.6.7
 
 Improve separation of inline comments from code. (#1064, #1065)

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.6.7"
+version = "2.6.8"
 authors = ["Dominique Luna <dluna132@gmail.com> and contributors"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Width-sensitive formatter for Julia code.
 Inspired by gofmt, refmt, and black.
 
 > [!NOTE]
-> Recent versions of JuliaFormatter (v2+) still have some rough edges.
-  If you require absolute stability, please consider pinning the version of JuliaFormatter, and possibly downgrading to v1.
+> Recent versions of JuliaFormatter (v2+) still have a number of rough edges!
+  I'm putting a lot of effort into fixing these, but if you require absolute stability, please consider pinning the version of JuliaFormatter, and possibly downgrading to v1.
   See also the [Project Status](https://juliaeditorsupport.github.io/JuliaFormatter.jl/stable/status) section of the docs for more details.
 
 ## Installation

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -65,7 +65,7 @@ When invoked on a JuliaFormatter PR, FormatBot will:
 
 FormatBot will also include a warning if formatting is not idempotent, or fails.
 
-### Issue triage
+### [Issue triage](@id issue-triage)
 
 Issues (and sometimes PRs) will be assigned a priority label, with a larger number indicating more important.
 The exact label for an issue is left to my discretion, but generally these are the categories that they will fall into:

--- a/docs/src/status.md
+++ b/docs/src/status.md
@@ -42,11 +42,26 @@ I'd like to add some of these checks into CI.
 However, this of course means that I have to hardcode some combinations of repositories + formatting options.
 **Nominations for codebases are very welcome.**
 
-## Long-term goals
+## The road ahead
 
-I would very much like for JuliaFormatter v3 to start offering some stability guarantees.
-I'm yet unsure of the exact form of this: there has to be some balance between stability, and the ability to make improvements to the codebase.
+For v2, my immediate plan is to fix extremely high-priority bugs: essentially anything labelled as P5 or P4 on the issue tracker.
+(See the [contributing docs](@ref issue-triage) for more details on the priority labels.)
+I might try to fix P3 bugs as well, but it's very likely that P3 bugs will be prioritised only for DefaultStyle.
+(Of course, contributions are more than welcome.)
 
-I also would not recommend holding your breath for a v3 release.
-This is a project I work on in my spare time, and although I think I'm a pretty decent software engineer, this is naturally a difficult codebase because of the combinatorial nature of source code.
+*However, as stated above, I also believe that some refactoring will make JuliaFormatter easier to maintain and easier to improve.*
+In particular, JuliaSyntax's CST is an extremely thin layer on top of the original source code.
+It does contain all the information that JuliaFormatter needs, but it's not always in the right shape or form, and that means that downstream code is quite complex.
+It would be much easier to work with an augmented form of the CST that baked in some of this information.
+(I believe that the FST data structure is mostly fine: there is probably some general code cleanup to be done there, but conceptually it's good.)
+
+I think that this is work that is just as important: it's quite tricky to really make improvements to the codebase without making it worse in some other sense.
+Consequently, I believe that once the most critical bugs are fixed I will start working on some of that refactoring.
+
+## What to look forward to in v3?
+
+[You can see this issue for more info about what I'd generally like to have in v3.](https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/1033)
+
+I would not recommend holding your breath for a v3 release, though.
+This is a project I work on in my spare time, and although I think I'm a pretty decent software engineer, this is naturally a difficult codebase.
 I really do recognise that this is an important project for the Julia ecosystem, and I will indeed try my best(!), but I *cannot* over-promise things: note that I want to protect myself against open-source burnout as well.

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -196,7 +196,7 @@ function show(
         end
     else
         printstyled(io, "$(fst.typ)"; color = color, bold = true)
-        printstyled(io, " val=$(repr(fst.val))\n"; color = color)
+        printstyled(io, " lines=$(fst.startline)-$(fst.endline) val=$(repr(fst.val))\n"; color = color)
         _print_prefix(io, prefix)
         printstyled(io, "$(extra_indent)line_offset=$(fst.line_offset)"; color = color)
         printstyled(io, " indent=$(fst.indent)\n"; color = color)
@@ -1184,11 +1184,13 @@ function add_node!(
             # swap PLACEHOLDER (will be NEWLINE) with INLINECOMMENT node
             idx = length(tnodes)
             tnodes[idx-1], tnodes[idx] = tnodes[idx], tnodes[idx-1]
-        elseif nt === WHITESPACE &&
-               hascomment(s.doc, current_line) &&
+        elseif hascomment(s.doc, current_line) &&
                current_line != n.startline
-            # rely on the whitespace tracked for the inline comment
-            tnodes[end] = Whitespace(0)
+            if nt === WHITESPACE
+                # Avoid printing excess whitespace before the comment, since
+                # print_inlinecomment will handle the spacing before the comment.
+                tnodes[end] = Whitespace(0)
+            end
             add_node!(t, InlineComment(current_line), s)
             add_node!(t, Newline(; nest_behavior = AlwaysNest), s)
         end

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -938,11 +938,20 @@ function is_lazy_op(t::Union{JuliaSyntax.GreenNode,JuliaSyntax.Kind})
     kind(t) in KSet"|| &&"
 end
 
-function needs_placeholder(::Tuple{}, _, _)
+function has_more_args_to_come(::Tuple{}, _, _)
     return false
 end
 
-function needs_placeholder(
+"""
+    has_more_args_to_come
+
+Searches `childs[start_index:end]` for the first non-whitespace node and returns whether it
+is not of kind `stop_kind`.
+
+If the first non-whitespace node is of kind `stop_kind`, that implies that there are no more
+arguments to process in the current argument list / indexing expression / etc.
+"""
+function has_more_args_to_come(
     childs::Vector{JuliaSyntax.GreenNode{T}},
     start_index::Int,
     stop_kind::JuliaSyntax.Kind,

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -196,7 +196,11 @@ function show(
         end
     else
         printstyled(io, "$(fst.typ)"; color = color, bold = true)
-        printstyled(io, " lines=$(fst.startline)-$(fst.endline) val=$(repr(fst.val))\n"; color = color)
+        printstyled(
+            io,
+            " lines=$(fst.startline)-$(fst.endline) val=$(repr(fst.val))\n";
+            color = color,
+        )
         _print_prefix(io, prefix)
         printstyled(io, "$(extra_indent)line_offset=$(fst.line_offset)"; color = color)
         printstyled(io, " indent=$(fst.indent)\n"; color = color)
@@ -1184,8 +1188,7 @@ function add_node!(
             # swap PLACEHOLDER (will be NEWLINE) with INLINECOMMENT node
             idx = length(tnodes)
             tnodes[idx-1], tnodes[idx] = tnodes[idx], tnodes[idx-1]
-        elseif hascomment(s.doc, current_line) &&
-               current_line != n.startline
+        elseif hascomment(s.doc, current_line) && current_line != n.startline
             if nt === WHITESPACE
                 # Avoid printing excess whitespace before the comment, since
                 # print_inlinecomment will handle the spacing before the comment.

--- a/src/styles/blue/nest.jl
+++ b/src/styles/blue/nest.jl
@@ -190,7 +190,7 @@ function n_parameters!(
 )
     n_tuple!(bs, fst, s, lineage)
 end
-function n_invisbrackets!(
+function n_parens!(
     bs::BlueStyle,
     fst::FST,
     s::State,

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -127,7 +127,7 @@ function nest!(
     elseif fst.typ === BracesCat
         n_bracescat!(style, fst, s, lineage)
     elseif fst.typ === Brackets
-        n_invisbrackets!(style, fst, s, lineage)
+        n_parens!(style, fst, s, lineage)
     elseif fst.typ === Comprehension
         n_comprehension!(style, fst, s, lineage)
     elseif fst.typ === TypedComprehension
@@ -482,7 +482,7 @@ function n_parameters!(
     n_tuple!(ds, fst, s, lineage)
 end
 
-function n_invisbrackets!(
+function n_parens!(
     ds::AbstractStyle,
     fst::FST,
     s::State,

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -409,7 +409,7 @@ function pretty(
     elseif k === K"iteration"
         p_iteration(style, node, s, ctx, lineage)
     elseif k === K"parens"
-        p_invisbrackets(style, node, s, ctx, lineage)
+        p_parens(style, node, s, ctx, lineage)
     elseif k === K"curly"
         p_curly(style, node, s, ctx, lineage)
     elseif is_macrostr(node)
@@ -2920,7 +2920,7 @@ function p_call(
     t
 end
 
-function p_invisbrackets(
+function p_parens(
     ds::AbstractStyle,
     cst::JuliaSyntax.GreenNode,
     s::State,

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -977,7 +977,7 @@ function p_macrocall(
             add_node!(t, n, s; join_lines = true)
         elseif kind(a) === K","
             add_node!(t, n, s; join_lines = true)
-            if needs_placeholder(childs, i + 1, K")")
+            if has_more_args_to_come(childs, i + 1, K")")
                 add_node!(t, Placeholder(1), s)
             end
         elseif JuliaSyntax.is_whitespace(a)
@@ -1081,7 +1081,7 @@ function p_block(
                 add_node!(t, n, s; join_lines = true)
             elseif kind(a) === K","
                 add_node!(t, n, s; join_lines = true)
-                if needs_placeholder(childs, i + 1, K")")
+                if has_more_args_to_come(childs, i + 1, K")")
                     add_node!(t, Whitespace(1), s)
                 end
             elseif JuliaSyntax.is_whitespace(a)
@@ -1095,7 +1095,7 @@ function p_block(
         elseif single_line
             if kind(a) in KSet", ;"
                 add_node!(t, n, s; join_lines = true)
-                if needs_placeholder(childs, i + 1, K")")
+                if has_more_args_to_come(childs, i + 1, K")")
                     add_node!(t, Placeholder(1), s)
                 end
             else
@@ -1104,7 +1104,7 @@ function p_block(
         else
             if kind(a) === K","
                 add_node!(t, n, s; join_lines = true)
-                if join_body && needs_placeholder(childs, i + 1, K")")
+                if join_body && has_more_args_to_come(childs, i + 1, K")")
                     add_node!(t, Placeholder(1), s)
                 end
             elseif kind(a) === K";"
@@ -1858,7 +1858,7 @@ function p_iteration(
         n = pretty(style, c, s, ctx, lineage)
         if kind(c) === K","
             add_node!(t, n, s; join_lines = true)
-            if needs_placeholder(childs, i + 1, K")")
+            if has_more_args_to_come(childs, i + 1, K")")
                 add_node!(t, Placeholder(1), s)
             end
         elseif !JuliaSyntax.is_whitespace(c)
@@ -2717,7 +2717,7 @@ function p_whereopcall(
             s.indent -= s.opts.indent
         elseif kind(a) === K","
             add_node!(t, pretty(style, a, s, ctx, lineage), s; join_lines = true)
-            if needs_placeholder(childs, i + 1, K"}")
+            if has_more_args_to_come(childs, i + 1, K"}")
                 add_node!(t, Placeholder(nws), s)
             end
         elseif JuliaSyntax.is_whitespace(a)
@@ -2845,7 +2845,7 @@ function p_curly(
             add_node!(t, n, s; join_lines = true)
         elseif kind(a) === K","
             add_node!(t, n, s; join_lines = true)
-            if needs_placeholder(childs, i + 1, K"}")
+            if has_more_args_to_come(childs, i + 1, K"}")
                 add_node!(t, Placeholder(nws), s)
             end
         else
@@ -2905,7 +2905,7 @@ function p_call(
             add_node!(t, n, s; join_lines = true)
 
             # figure out if we need to put a placeholder
-            if needs_placeholder(childs, i + 1, K")")
+            if has_more_args_to_come(childs, i + 1, K")")
                 add_node!(t, Placeholder(1), s)
             end
         else
@@ -3016,7 +3016,7 @@ function p_tupleblock(
             add_node!(t, n, s; join_lines = true)
         elseif kind(a) in KSet", ;"
             add_node!(t, n, s; join_lines = true)
-            if needs_placeholder(childs, i + 1, K")")
+            if has_more_args_to_come(childs, i + 1, K")")
                 add_node!(t, Placeholder(1), s)
             end
         else
@@ -3069,7 +3069,7 @@ function p_tuple(
             add_node!(t, n, s; join_lines = true)
         elseif kind(a) in KSet", ;"
             add_node!(t, n, s; join_lines = true)
-            if needs_placeholder(childs, i + 1, K")")
+            if has_more_args_to_come(childs, i + 1, K")")
                 add_node!(t, Placeholder(1), s)
             end
         else
@@ -3114,7 +3114,7 @@ function p_braces(
             add_node!(t, n, s; join_lines = true)
         elseif kind(a) === K","
             add_node!(t, n, s; join_lines = true)
-            if needs_placeholder(childs, i + 1, K"}")
+            if has_more_args_to_come(childs, i + 1, K"}")
                 add_node!(t, Placeholder(nws), s)
             end
         else
@@ -3159,7 +3159,7 @@ function p_bracescat(
             end
             add_node!(t, n, s; join_lines = true)
         elseif kind(a) === K";"
-            if needs_placeholder(childs, i + 1, K"}")
+            if has_more_args_to_come(childs, i + 1, K"}")
                 add_node!(t, n, s; join_lines = true)
                 add_node!(t, Placeholder(nws), s)
             end
@@ -3205,7 +3205,7 @@ function p_vect(
             add_node!(t, n, s; join_lines = true)
         elseif kind(a) === K","
             add_node!(t, n, s; join_lines = true)
-            if needs_placeholder(childs, i + 1, K"]")
+            if has_more_args_to_come(childs, i + 1, K"]")
                 add_node!(t, Placeholder(1), s)
             end
         else
@@ -3297,7 +3297,7 @@ function p_parameters(
 
         if kind(a) in KSet", ;"
             add_node!(t, n, s; join_lines = true)
-            if needs_placeholder(childs, i + 1, K")")
+            if has_more_args_to_come(childs, i + 1, K")")
                 add_node!(t, Placeholder(nws), s)
             end
         else
@@ -3460,7 +3460,7 @@ function p_ref(
             end
         elseif kind(a) === K","
             add_node!(t, pretty(style, a, s, ctx, lineage), s; join_lines = true)
-            if needs_placeholder(childs, i + 1, K"]")
+            if has_more_args_to_come(childs, i + 1, K"]")
                 add_node!(t, Placeholder(1), s)
             end
         elseif is_opcall(a)
@@ -3937,7 +3937,7 @@ function p_generator(
             add_node!(t, Placeholder(1), s)
         elseif kind(a) === K","
             add_node!(t, n, s; join_lines = true)
-            if needs_placeholder(childs, i + 1, K")")
+            if has_more_args_to_come(childs, i + 1, K")")
                 add_node!(t, Placeholder(1), s)
             end
         else

--- a/src/styles/sciml/nest.jl
+++ b/src/styles/sciml/nest.jl
@@ -232,7 +232,7 @@ for f in [
     :n_macrocall!,
     :n_braces!,
     :n_parameters!,
-    :n_invisbrackets!,
+    :n_parens!,
     :n_bracescat!,
 ]
     @eval function $f(

--- a/src/styles/sciml/pretty.jl
+++ b/src/styles/sciml/pretty.jl
@@ -91,7 +91,7 @@ for f in [
     :p_braces,
     # :p_vect, don't use YAS style vector formatting with `yas_style_nesting = true`
     :p_parameters,
-    :p_invisbrackets,
+    :p_parens,
     :p_bracescat,
 ]
     @eval function $f(

--- a/src/styles/sciml/pretty.jl
+++ b/src/styles/sciml/pretty.jl
@@ -167,7 +167,7 @@ function p_macrocall(
             add_node!(t, n, s; join_lines = true)
         elseif kind(a) === K","
             add_node!(t, n, s; join_lines = true)
-            if needs_placeholder(childs, i + 1, K")")
+            if has_more_args_to_come(childs, i + 1, K")")
                 add_node!(t, Placeholder(1), s)
             end
         elseif JuliaSyntax.is_whitespace(a)

--- a/src/styles/yas/nest.jl
+++ b/src/styles/yas/nest.jl
@@ -50,6 +50,19 @@ function n_call!(
             fst.indent = s.line_offset + 1
         end
 
+        if n.typ === TRAILINGCOMMA
+            # Unconditionally materialise the trailing comma. If we don't need it
+            # we'll get rid of it.
+            n.val = ","
+            n.len = 1
+        elseif is_closer(n) && n.startline == fst[end].startline
+            # Get rid of trailing comma if it's just before the closing paren.
+            if fst[i-1].typ === TRAILINGCOMMA
+                fst[i-1].val = ""
+                fst[i-1].len = 0
+            end
+        end
+
         if n.typ === NEWLINE
             s.line_offset = fst.indent
         elseif n.typ === PLACEHOLDER

--- a/src/styles/yas/nest.jl
+++ b/src/styles/yas/nest.jl
@@ -194,7 +194,7 @@ function n_parameters!(
 )
     n_tuple!(ys, fst, s, lineage)
 end
-function n_invisbrackets!(
+function n_parens!(
     ys::YASStyle,
     fst::FST,
     s::State,

--- a/src/styles/yas/nest.jl
+++ b/src/styles/yas/nest.jl
@@ -9,18 +9,21 @@ function n_call!(
     # With `variable_call_indent`, check if the caller is in the list
     if caller_in_list(fst, s.opts.variable_call_indent) &&
        length(fst.nodes::Vector{FST}) > 5
-        # Check if the call is of the form `caller(something,...)`
-        # or of the form `caller(\n...)`.
-        # There may be a comment or both an inline comment and a comment in a separate line
-        # before the first argument, so check for that as well.
+        # Determine whether the call has the form `caller(something,...)` or
+        # `caller(\n...)`. There may be a comment or both an inline comment and a comment in
+        # a separate line before the first argument, so check for that as well.
         notcode(n) = n.typ === NOTCODE || n.typ === INLINECOMMENT || n.typ === PLACEHOLDER
-        linebreak_definition =
+        # The first three nodes must be the caller, the opening paren, and a placeholder.
+        # TODO(penelopeysm): Can we make this cleaner, e.g. checking the source line of the
+        # opening paren and the first argument (if it exists)...?
+        has_linebreak_after_parens =
             fst[4].typ === NEWLINE ||
             notcode(fst[4]) && fst[5].typ === NEWLINE ||
             notcode(fst[4]) && notcode(fst[5]) && fst[6].typ === NEWLINE
 
-        if linebreak_definition
-            # With a line break in the definition, don't align with the opening parenthesis
+        # If it's the latter, we can defer to DefaultStyle -- no need to align with the
+        # opening parenthesis
+        if has_linebreak_after_parens
             return n_call!(DefaultStyle(ys), fst, s, lineage)
         end
     end
@@ -50,19 +53,6 @@ function n_call!(
             fst.indent = s.line_offset + 1
         end
 
-        if n.typ === TRAILINGCOMMA
-            # Unconditionally materialise the trailing comma. If we don't need it
-            # we'll get rid of it.
-            n.val = ","
-            n.len = 1
-        elseif is_closer(n) && n.startline == fst[end].startline
-            # Get rid of trailing comma if it's just before the closing paren.
-            if fst[i-1].typ === TRAILINGCOMMA
-                fst[i-1].val = ""
-                fst[i-1].len = 0
-            end
-        end
-
         if n.typ === NEWLINE
             s.line_offset = fst.indent
         elseif n.typ === PLACEHOLDER
@@ -80,6 +70,26 @@ function n_call!(
             nested |= nest!(style, n, s, lineage)
         end
     end
+
+    # Now that we've performed nesting, we can check if the trailing comma needs to be
+    # materialised.
+    trailing_comma_idx = findlast(n -> n.typ === TRAILINGCOMMA, nodes)
+    if trailing_comma_idx !== nothing
+        for idx in (trailing_comma_idx+1):length(nodes)
+            if nodes[idx].typ === NEWLINE
+                # The closing paren will be on a new line, so we need to materialise the
+                # trailing comma.
+                nodes[trailing_comma_idx].val = ","
+                nodes[trailing_comma_idx].len = 1
+                break
+            elseif is_closer(nodes[idx])
+                # The closing paren is right after the trailing comma, so no need to
+                # materialise it.
+                break
+            end
+        end
+    end
+
     return nested
 end
 

--- a/src/styles/yas/nest.jl
+++ b/src/styles/yas/nest.jl
@@ -72,7 +72,9 @@ function n_call!(
     end
 
     # Now that we've performed nesting, we can check if the trailing comma needs to be
-    # materialised.
+    # materialised. Note that by doing this after nesting, we ensure that the length of the
+    # comma is not taken into account when calculating whether the (un-nested) line would go
+    # over the margin or not.
     trailing_comma_idx = findlast(n -> n.typ === TRAILINGCOMMA, nodes)
     if trailing_comma_idx !== nothing
         for idx in (trailing_comma_idx+1):length(nodes)

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -152,7 +152,7 @@ function p_curly(
         override = (i == first_arg_idx) || kind(a) === K"}"
 
         if kind(a) === K","
-            if needs_placeholder(childs, i + 1, K"}")
+            if has_more_args_to_come(childs, i + 1, K"}")
                 add_node!(t, n, s; join_lines = true)
                 add_node!(t, Placeholder(nws), s)
             end
@@ -195,7 +195,7 @@ function p_braces(
         override = (i == first_arg_idx) || kind(a) === K"}"
 
         if kind(a) === K","
-            if needs_placeholder(childs, i + 1, K"}")
+            if has_more_args_to_come(childs, i + 1, K"}")
                 add_node!(t, n, s; join_lines = true)
                 add_node!(t, Placeholder(nws), s)
             end
@@ -238,7 +238,7 @@ function p_bracescat(
         override = (i == first_arg_idx) || kind(a) === K"}"
 
         if kind(a) === K";"
-            if needs_placeholder(childs, i + 1, K"}")
+            if has_more_args_to_come(childs, i + 1, K"}")
                 add_node!(t, n, s; join_lines = true)
                 add_node!(t, Placeholder(nws), s)
             end
@@ -286,7 +286,7 @@ function p_tupleblock(
         if kind(a) in KSet"; ,"
             if nargs == 1
                 add_node!(t, n, s; join_lines = true)
-            elseif needs_placeholder(childs, i + 1, K")")
+            elseif has_more_args_to_come(childs, i + 1, K")")
                 add_node!(t, n, s; join_lines = true)
                 add_node!(t, Placeholder(1), s)
             end
@@ -334,7 +334,7 @@ function p_tuple(
         if kind(a) === K","
             if nargs == 1
                 add_node!(t, n, s; join_lines = true)
-            elseif needs_placeholder(childs, i + 1, K")")
+            elseif has_more_args_to_come(childs, i + 1, K")")
                 add_node!(t, n, s; join_lines = true)
                 add_node!(t, Placeholder(1), s)
             end
@@ -437,12 +437,17 @@ function p_call(
         override = (i == first_arg_idx) || k === K")"
 
         if k === K","
-            # figure out if we need to put a placeholder
-            if needs_placeholder(childs, i + 1, K")")
+            if has_more_args_to_come(childs, i + 1, K")")
                 add_node!(t, n, s; join_lines = true)
                 add_node!(t, Placeholder(1), s)
             end
         else
+            # For YAS style, the trailing comma usually won't be seen, because the closing
+            # paren should be placed on the same line as the last argument. However, in the
+            # case where the last argument is followed by a comment, the closing paren will
+            # be placed on the next line, and in that case we want to allow a trailing
+            # comma.
+            k === K")" && add_node!(t, TrailingComma(), s)
             add_node!(
                 t,
                 n,
@@ -484,7 +489,7 @@ function p_vect(
         override = (i == first_arg_idx) || k === K"]"
 
         if kind(a) === K","
-            if needs_placeholder(childs, i + 1, K"]")
+            if has_more_args_to_come(childs, i + 1, K"]")
                 add_node!(t, n, s; join_lines = true)
                 add_node!(t, Placeholder(1), s)
             end
@@ -616,7 +621,7 @@ function p_ref(
         override = (i == first_arg_idx) || kind(a) === K"]"
 
         if kind(a) === K","
-            if needs_placeholder(childs, i + 1, K"]")
+            if has_more_args_to_come(childs, i + 1, K"]")
                 add_node!(t, n, s; join_lines = true)
                 add_node!(t, Placeholder(1), s)
             end
@@ -721,7 +726,7 @@ function p_macrocall(
             add_node!(t, n, s; join_lines = true)
         elseif kind(a) === K","
             add_node!(t, n, s; join_lines = true)
-            if needs_placeholder(childs, i + 1, K")")
+            if has_more_args_to_come(childs, i + 1, K")")
                 add_node!(t, Placeholder(1), s)
             end
         elseif JuliaSyntax.is_whitespace(a)
@@ -810,7 +815,7 @@ function p_whereopcall(
             )
             s.indent -= s.opts.indent
         elseif kind(a) === K","
-            if needs_placeholder(childs, i + 1, K"}")
+            if has_more_args_to_come(childs, i + 1, K"}")
                 add_node!(t, pretty(style, a, s, ctx, lineage), s; join_lines = true)
                 add_node!(t, Placeholder(nws), s)
             end
@@ -887,7 +892,7 @@ function p_generator(
             add_node!(t, n, s; join_lines = true)
             add_node!(t, Whitespace(1), s)
         elseif kind(a) === K","
-            if needs_placeholder(childs, i + 1, K")")
+            if has_more_args_to_come(childs, i + 1, K")")
                 add_node!(t, n, s; join_lines = true)
                 add_node!(t, Placeholder(1), s)
             end

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -405,19 +405,14 @@ function p_call(
     # and use `p_call` from `DefaultStyle` instead to allow both
     # `caller(something,...)` and `caller(\n,...)`.
     if length(s.opts.variable_call_indent) > 0
-        offset = if kind(childs[1]) === K"curly" && haschildren(childs[1])
-            childs2 = children(childs[1])::Vector{JuliaSyntax.GreenNode{JuliaSyntax.SyntaxHead}}
-            if length(childs2) > 0
-                span(childs2[1]) + span(childs[2]) - 2
-            else
-                0
-            end
-        elseif length(childs) > 1
-            span(childs[1]) + span(childs[2]) - 2
+        # Need to check whether the caller is of the form f(...) or f{T}(...). In both
+        # cases, we need to extract only `f`, and not `f{T}` in the latter case.
+        caller_span = if kind(childs[1]) === K"curly"
+            span(childs[1][1])
         else
-            0
+            span(childs[1])
         end
-        val = getsrcval(s.doc, (s.offset):(s.offset+offset))
+        val = getsrcval(s.doc, (s.offset):(s.offset+caller_span-1))
         if val in s.opts.variable_call_indent
             return p_call(DefaultStyle(style), cst, s, ctx, lineage)
         end

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -352,7 +352,7 @@ function p_tuple(
 end
 
 # Brackets
-function p_invisbrackets(
+function p_parens(
     ys::YASStyle,
     cst::JuliaSyntax.GreenNode,
     s::State,

--- a/src/styles/yas/pretty.jl
+++ b/src/styles/yas/pretty.jl
@@ -351,7 +351,6 @@ function p_tuple(
     t
 end
 
-# Brackets
 function p_parens(
     ys::YASStyle,
     cst::JuliaSyntax.GreenNode,

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -4047,7 +4047,7 @@ run_nest(text::String, margin::Int) = run_nest(text, opts = Options(margin = mar
         test_format(str_, str; indent=4, margin=1)
     end
 
-    @testset "invisbrackets" begin
+    @testset "parens" begin
         str = """
         some_function(
             (((
@@ -4096,7 +4096,7 @@ some_function(
         test_format(str, str; indent=8, margin=92)
 
         #
-        # Don't nest the op if an arg is invisbrackets
+        # Don't nest the op if an arg is parens
         #
 
         str_ = """

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1448,7 +1448,7 @@ end
     @testset "609 comments being swallowed" begin
         s = "f(\n    q = 2  # this comment will not be removed\n)"
         test_format(s, s, SciMLStyle())
-        s2 = "f(; q=2  # this comment will not be removed\n  )"
+        s2 = "f(; q=2,  # this comment will not be removed\n  )"
         test_format(s, s2, YASStyle())
     end
 

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1778,6 +1778,41 @@ end
         )
         """
         test_format(s_, s, SciMLStyle())
+
+        s_ = """
+        if (# opening inline
+            some_exceedingly_long_variable_name > some_other_fairly_long_variable_name # another inline
+            # stand-alone
+            || some_additional_long_variable_name > some_other_fairly_long_variable_name # closing inline
+        )
+            print("something")
+        end
+        """
+        s = """
+        if (# opening inline
+            some_exceedingly_long_variable_name > some_other_fairly_long_variable_name # another inline
+            # stand-alone
+            ||
+            some_additional_long_variable_name > some_other_fairly_long_variable_name # closing inline
+            )
+            print("something")
+        end
+        """
+        test_format(s_, s, YASStyle(); margin=120)
+
+        s60 = """
+        if (# opening inline
+            some_exceedingly_long_variable_name >
+            some_other_fairly_long_variable_name # another inline
+            # stand-alone
+            ||
+            some_additional_long_variable_name >
+            some_other_fairly_long_variable_name # closing inline
+            )
+            print("something")
+        end
+        """
+        test_format(s_, s60, YASStyle(); margin=60)
     end
 
     @testset "698" begin

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1445,6 +1445,13 @@ end
         test_format(str, str_, SciMLStyle())
     end
 
+    @testset "609 comments being swallowed" begin
+        s = "f(\n    q = 2  # this comment will not be removed\n)"
+        test_format(s, s, SciMLStyle())
+        s2 = "f(; q=2  # this comment will not be removed\n  )"
+        test_format(s, s2, YASStyle())
+    end
+
     @testset "613" begin
         s = """
         x = ```
@@ -2451,6 +2458,23 @@ end
         )
         # macroblocks without a closer are unaffected
         test_format("@testset \"x\" begin\n    a\nend", "@testset \"x\" begin\n    a\nend")
+    end
+
+    @testset "1046 comments being swallowed" begin
+        s = """
+        if (# opening inline
+            a # another inline
+            # stand-alone
+            &&
+            c # closing inline
+            )
+            foo
+        end
+        """ |> strip
+        test_format(s, s, YASStyle())
+
+        s2 = """f(# hi\n  a)"""
+        test_format(s2, s2, YASStyle())
     end
 
     @testset "1062 docstring indent on rhs of short function def" begin

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1390,8 +1390,6 @@ end
         end
         """
         # no trailing comma since (arg) is semantically different from (arg,) !!!
-        # NOTE: as of CSTParser 3.4.0 this is no longe parsed as a tuple but as invisbrackets
-        # so we don't need to worry about it
         s_ = """
         function (func(
             arg,

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -2495,7 +2495,7 @@ end
         test_format("@testset \"x\" begin\n    a\nend", "@testset \"x\" begin\n    a\nend")
     end
 
-    @testset "1046 comments being swallowed" begin
+    @testset "1046 YAS comments being swallowed" begin
         s = """
         if (# opening inline
             a # another inline
@@ -2510,6 +2510,14 @@ end
 
         s2 = """f(# hi\n  a)"""
         test_format(s2, s2, YASStyle())
+
+        # test some hash-eq comments for good measure
+        s = """
+        f( #= hi =# aaa,
+          bbb,
+          ccc #= hi =#)
+        """
+        test_format(s, s, YASStyle())
     end
 
     @testset "1062 docstring indent on rhs of short function def" begin

--- a/test/options.jl
+++ b/test/options.jl
@@ -1695,63 +1695,6 @@ end
         test_format(str, str_, YASStyle(); align_matrix = true)
     end
 
-    @testset "trailing commas" begin
-        str = """
-        funccall(
-            arg1,
-            arg2,
-            arg3
-        )"""
-
-        str_ = "funccall(arg1, arg2, arg3)"
-        test_format(str_, str; indent=4, margin=1, trailing_comma = false)
-
-        # last comma is removed
-
-        str_ = "funccall(arg1, arg2, arg3,)"
-        test_format(str_, str; indent=4, margin=1, trailing_comma = false)
-
-        str = "funccall(arg1, arg2, arg3)"
-        test_format(str_, str; trailing_comma = false)
-
-        # corner case - if the comma is removed it is no longer a tuple
-        str_ = "(tuple,)"
-        str = """
-        (
-            tuple,
-        )"""
-        test_format(str_, str; indent=4, margin=1, trailing_comma = false)
-
-        str = """
-        funccall(
-            arg1,
-            arg2,
-            arg3
-        )"""
-
-        str_ = "funccall(arg1, arg2, arg3)"
-        test_format(str_, str; indent=4, margin=1, trailing_comma = nothing)
-
-        # last comma is stays
-        str_ = "funccall(arg1, arg2, arg3,)"
-        str = """
-        funccall(
-            arg1,
-            arg2,
-            arg3,
-        )"""
-        test_format(str_, str; indent=4, margin=1, trailing_comma = nothing)
-        test_format(str_, str_; indent=4, margin=100, trailing_comma = nothing)
-
-        # corner case - if the comma is removed it is no longer a tuple
-        str_ = "(tuple,)"
-        str = """
-        (
-            tuple,
-        )"""
-        test_format(str_, str; indent=4, margin=1, trailing_comma = nothing)
-    end
-
     @testset "ignore maximum width" begin
         @testset "maintain original structure" begin
             for m in (:module, :baremodule)

--- a/test/options/trailing_comma.jl
+++ b/test/options/trailing_comma.jl
@@ -4,7 +4,6 @@ using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyl
 using JuliaFormatter.Internal: test_format
 using Test
 
-
 @testset "trailing_comma" begin
     @testset "remove trailing comma" begin
         for str_ in (
@@ -87,4 +86,6 @@ using Test
           ccccccccc)"""
         test_format(s2_, s2, YASStyle(); margin=2)
     end
+end
+
 end # module

--- a/test/options/trailing_comma.jl
+++ b/test/options/trailing_comma.jl
@@ -1,0 +1,90 @@
+module TrailingCommaTests
+
+using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyle, format_text
+using JuliaFormatter.Internal: test_format
+using Test
+
+
+@testset "trailing_comma" begin
+    @testset "remove trailing comma" begin
+        for str_ in (
+            "funccall(arg1, arg2, arg3,)",
+            "funccall(arg1, arg2, arg3)",
+        )
+            str = """
+            funccall(
+                arg1,
+                arg2,
+                arg3
+            )"""
+            test_format(str_, str; margin=1, trailing_comma = false)
+        end
+
+        str_ = "funccall(arg1, arg2, arg3,)"
+        str = "funccall(arg1, arg2, arg3)"
+        test_format(str_, str; trailing_comma = false)
+    end
+
+    @testset "doesn't change tuples" begin
+        str_ = "(tuple,)"
+        str = """
+        (
+            tuple,
+        )"""
+        test_format(str_, str; margin=1, trailing_comma = true)
+        test_format(str_, str; margin=1, trailing_comma = false)
+        test_format(str_, str; indent=4, margin=1, trailing_comma = nothing)
+    end
+
+    @testset "trailing_comma=nothing" begin
+        str = """
+        funccall(
+            arg1,
+            arg2,
+            arg3
+        )"""
+        str_ = "funccall(arg1, arg2, arg3)"
+        test_format(str_, str; indent=4, margin=1, trailing_comma = nothing)
+
+        # last comma is stays
+        str_ = "funccall(arg1, arg2, arg3,)"
+        str = """
+        funccall(
+            arg1,
+            arg2,
+            arg3,
+        )"""
+        test_format(str_, str; indent=4, margin=1, trailing_comma = nothing)
+        test_format(str_, str_; indent=4, margin=100, trailing_comma = nothing)
+    end
+
+    @testset "YASStyle" begin
+        # Ordinarily with YAS, the closing paren is placed on the same line as the last
+        # argument, meaning that there are no trailing commas. But if the last argument is
+        # followed by a comment, the closing paren will be on the next line, and a trailing
+        # comma should be added (or to be precise, the `trailing_comma` option should be
+        # respected).
+        s1 = """
+        f(aaaaaaa,
+          bbbbbbbbb,
+          ccccccccc # comment
+        )"""
+        s1 = """
+        f(aaaaaaa,
+          bbbbbbbbb,
+          ccccccccc, # comment
+          )"""
+        test_format(s1, s1, YASStyle(); margin=2)
+
+        s2_ = """
+        f(aaaaaaa,
+          bbbbbbbbb,
+          ccccccccc
+        )"""
+        s2 = """
+        f(aaaaaaa,
+          bbbbbbbbb,
+          ccccccccc)"""
+        test_format(s2_, s2, YASStyle(); margin=2)
+    end
+end # module

--- a/test/yas_style.jl
+++ b/test/yas_style.jl
@@ -571,12 +571,10 @@ using JuliaFormatter: format_text
         test_format(str, str, YASStyle())
     end
 
-    if VERSION >= v"1.7"
-        @testset "issue 582 - vcat" begin
-            test_format("[sts...;]", "[sts...;]", YASStyle())
-            test_format("[a;b;]", "[a; b;]", YASStyle())
-            test_format("[a;b;;]", "[a; b;;]", YASStyle())
-        end
+    @testset "issue 582 - vcat" begin
+        test_format("[sts...;]", "[sts...;]", YASStyle())
+        test_format("[a;b;]", "[a; b;]", YASStyle())
+        test_format("[a;b;;]", "[a; b;;]", YASStyle())
     end
 
     @testset "variable_call_indent" begin

--- a/test/yas_style.jl
+++ b/test/yas_style.jl
@@ -423,7 +423,7 @@ using JuliaFormatter: format_text
         test_format(str_, str, YASStyle(); indent=4, margin=length(str_) - 1)
     end
 
-    @testset "invisbrackets" begin
+    @testset "parens" begin
         str_ = """
         if ((
           aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ||

--- a/test/yas_style.jl
+++ b/test/yas_style.jl
@@ -586,63 +586,51 @@ using JuliaFormatter: format_text
         """
 
         # This should be valid with and without `Dict` in `variable_call_indent`
-        @test format_text(str, YASStyle()) == str
-        @test format_text(str, YASStyle(); variable_call_indent = ["Dict"]) == str
+        test_format(str, str, YASStyle())
+        test_format(str, str, YASStyle(); variable_call_indent = ["Dict"])
 
         str = raw"""
         SVector(1.0,
                 2.0)
         """
-
-        # Test the same with different callers
-        @test format_text(str, YASStyle(); variable_call_indent = ["Dict"]) == str
-        @test format_text(str, YASStyle(); variable_call_indent = ["SVector", "test2"]) ==
-              str
+        test_format(str, str, YASStyle())
+        test_format(str, str, YASStyle(); variable_call_indent = ["SVector", "test2"])
+        test_format(str, str, YASStyle(); variable_call_indent = ["Dict"])
 
         str = raw"""
         Dict{Int,Int}(
         1 => 2,
                 3 => 4)
         """
-
         formatted_str1 = raw"""
         Dict{Int,Int}(1 => 2,
                       3 => 4)
         """
-
         formatted_str2 = raw"""
         Dict{Int,Int}(
             1 => 2,
             3 => 4)
         """
-
         # `variable_call_indent` keeps the line break and doesn't align
-        @test format_text(str, YASStyle()) == formatted_str1
-        @test format_text(str, YASStyle(); variable_call_indent = ["Dict"]) ==
-              formatted_str2
+        test_format(str, formatted_str1, YASStyle())
+        test_format(str, formatted_str2, YASStyle(); variable_call_indent = ["Dict"])
 
         str = raw"""
         SVector(
         1.0,
                 2.0)
         """
-
         formatted_str1 = raw"""
         SVector(1.0,
                 2.0)
         """
-
         formatted_str2 = raw"""
         SVector(
             1.0,
             2.0)
         """
-
-        # Test the same with different callers
-        @test format_text(str, YASStyle(); variable_call_indent = ["Dict"]) ==
-              formatted_str1
-        @test format_text(str, YASStyle(); variable_call_indent = ["test", "SVector"]) ==
-              formatted_str2
+        test_format(str, formatted_str1, YASStyle(); variable_call_indent = ["Dict"])
+        test_format(str, formatted_str2, YASStyle(); variable_call_indent = ["test", "SVector"])
 
         str = raw"""
         Dict{Int,Int}(
@@ -650,15 +638,12 @@ using JuliaFormatter: format_text
             3 => 4,
         )
         """
-
         formatted_str = raw"""
         Dict{Int,Int}(1 => 2,
                       3 => 4)
         """
-
-        # This is already valid with `variable_call_indent`
-        @test format_text(str, YASStyle()) == formatted_str
-        @test format_text(str, YASStyle(); variable_call_indent = ["Dict"]) == str
+        test_format(str, formatted_str, YASStyle())
+        test_format(str, str, YASStyle(); variable_call_indent = ["Dict"])
 
         str = raw"""
         SomeLongerTypeThanJustString = String
@@ -682,6 +667,8 @@ using JuliaFormatter: format_text
 
         # Here, `variable_call_indent` forces the line break because the line is too long.
         # For some reason, this has to be formatted twice.
+        # (TODO penelopeysm -- isn't this an idempotence bug?)
+        @test_broken false
         @test format_text(str, YASStyle()) == formatted_str1
         intermediate_str = format_text(str, YASStyle(); variable_call_indent = ["Dict"])
         @test format_text(intermediate_str, YASStyle(); variable_call_indent = ["Dict"]) ==
@@ -693,17 +680,15 @@ using JuliaFormatter: format_text
                       1 => 2,
                       3 => 4)
         """
-
         formatted_str = raw"""
         Dict{Int,Int}(
             # Comment
             1 => 2,
             3 => 4)
         """
-
         # Test `variable_call_indent` with a comment in a separate line
-        @test format_text(str, YASStyle()) == str
-        @test format_text(str, YASStyle(); variable_call_indent = ["Dict"]) == formatted_str
+        test_format(str, str, YASStyle())
+        test_format(str, formatted_str, YASStyle(); variable_call_indent = ["Dict"])
 
         str = raw"""
         SVector(
@@ -711,41 +696,34 @@ using JuliaFormatter: format_text
                 1.0,
                 2.0)
         """
-
         formatted_str = raw"""
         SVector(
             # Comment
             1.0,
             2.0)
         """
-
         # Test the same with different callers
-        @test format_text(str, YASStyle()) == str
-        @test format_text(str, YASStyle(); variable_call_indent = ["SVector"]) ==
-              formatted_str
+        test_format(str, str, YASStyle())
+        test_format(str, formatted_str, YASStyle(); variable_call_indent = ["SVector"])
 
         str = raw"""
         Dict{Int,Int}(# Comment
                     1 => 2,
                     3 => 4)
         """
-
         formatted_str1 = raw"""
         Dict{Int,Int}(# Comment
                       1 => 2,
                       3 => 4)
         """
-
         formatted_str2 = raw"""
         Dict{Int,Int}(# Comment
             1 => 2,
             3 => 4)
         """
-
         # Test `variable_call_indent` with an inline comment after the opening parenthesis
-        @test format_text(str, YASStyle()) == formatted_str1
-        @test format_text(str, YASStyle(); variable_call_indent = ["Dict"]) ==
-              formatted_str2
+        test_format(str, formatted_str1, YASStyle())
+        test_format(str, formatted_str2, YASStyle(); variable_call_indent = ["Dict"])
 
         str = raw"""
         Dict{Int,Int}( # Comment
@@ -754,7 +732,6 @@ using JuliaFormatter: format_text
                 # Another comment
                 3 => 4)
         """
-
         formatted_str1 = raw"""
         Dict{Int,Int}( # Comment
                       # Comment
@@ -762,7 +739,6 @@ using JuliaFormatter: format_text
                       # Another comment
                       3 => 4)
         """
-
         formatted_str2 = raw"""
         Dict{Int,Int}( # Comment
             # Comment
@@ -770,12 +746,10 @@ using JuliaFormatter: format_text
             # Another comment
             3 => 4)
         """
-
         # Test `variable_call_indent` with both an inline comment after the opening parenthesis
         # and a comment in a separate line.
-        @test format_text(str, YASStyle()) == formatted_str1
-        @test format_text(str, YASStyle(); variable_call_indent = ["Dict"]) ==
-              formatted_str2
+        test_format(str, formatted_str1, YASStyle())
+        test_format(str, formatted_str2, YASStyle(); variable_call_indent = ["Dict"])
 
         str = raw"""
         SVector( # Comment
@@ -784,7 +758,6 @@ using JuliaFormatter: format_text
                     # Another comment
                     2.0)
         """
-
         formatted_str1 = raw"""
         SVector( # Comment
                 # Comment
@@ -792,7 +765,6 @@ using JuliaFormatter: format_text
                 # Another comment
                 2.0)
         """
-
         formatted_str2 = raw"""
         SVector( # Comment
             # Comment
@@ -800,12 +772,9 @@ using JuliaFormatter: format_text
             # Another comment
             2.0)
         """
-
         # Test the same with different callers
-        @test format_text(str, YASStyle(); variable_call_indent = ["test"]) ==
-              formatted_str1
-        @test format_text(str, YASStyle(); variable_call_indent = ["SVector", "test"]) ==
-              formatted_str2
+        test_format(str, formatted_str1, YASStyle(); variable_call_indent = ["test"])
+        test_format(str, formatted_str2, YASStyle(); variable_call_indent = ["SVector", "test"])
     end
 end
 

--- a/test/yas_style.jl
+++ b/test/yas_style.jl
@@ -731,7 +731,8 @@ using JuliaFormatter: format_text
         """
 
         formatted_str1 = raw"""
-        Dict{Int,Int}(1 => 2,
+        Dict{Int,Int}(# Comment
+                      1 => 2,
                       3 => 4)
         """
 
@@ -742,8 +743,6 @@ using JuliaFormatter: format_text
         """
 
         # Test `variable_call_indent` with an inline comment after the opening parenthesis
-        # With `variable_call_indent = false`, the comment will be eaten,
-        # see https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/609
         @test format_text(str, YASStyle()) == formatted_str1
         @test format_text(str, YASStyle(); variable_call_indent = ["Dict"]) ==
               formatted_str2


### PR DESCRIPTION
Closes #1046

With this PR:

```julia
julia> s = """
           if (# opening inline
              a # another inline
              # stand-alone
              && c # closing inline
           )
              print("something")
           end
           """
"if (# opening inline\n   a # another inline\n   # stand-alone\n   && c # closing inline\n)\n   print(\"something\")\nend\n"

julia> s |> println
if (# opening inline
   a # another inline
   # stand-alone
   && c # closing inline
)
   print("something")
end


julia> ft(s, YASStyle()) |> println
if (# opening inline
    a # another inline
    # stand-alone
    &&
    c # closing inline
    )
    print("something")
end
```