### PR TITLE
app: Clarify jlfmt check guidance for multiple inputs

### DIFF
--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,3 +1,7 @@
+# v2.7.0
+
+Improved usage messages for the `jlfmt` command-line tool. (#1098)
+
 # v2.6.15
 
 Fixed a bug where the combination of `always_use_return` and `short_circuit_to_if` would silently change the meaning of a programme. (#887, #1096)

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.6.15"
+version = "2.7.0"
 authors = ["Dominique Luna <dluna132@gmail.com> and contributors"]
 
 [deps]

--- a/src/app.jl
+++ b/src/app.jl
@@ -536,7 +536,9 @@ function main(argv::Vector{String})
         return panic("option `--output` can not be used together with multiple input files")
     end
     if multiple_inputs && !(inplace || check)
-        return panic("option `--inplace` or `--check` required with multiple input files")
+        return panic(
+            "multiple input files require either `--inplace` to write changes or `--check` to verify formatting",
+        )
     end
 
     if diff
@@ -622,7 +624,7 @@ function main(argv::Vector{String})
     if check && errno != 0
         printstyled(
             stderr,
-            "Some files are not formatted correctly. Run without --check to format them.\n";
+            "Some files are not formatted correctly. Run again with `--inplace` instead of `--check` to format them.\n";
             color = :red,
         )
     end

--- a/test/jlfmt_app.jl
+++ b/test/jlfmt_app.jl
@@ -7,14 +7,29 @@ using UUIDs: uuid4
 const PROJECT_DIR = dirname(abspath(Base.active_project()))
 const CONFIG_FILE_NAME = ".JuliaFormatter.toml"
 
-jlfmt_cmd(julia_flags::Cmd = ``) =
+function jlfmt_cmd(julia_flags::Cmd = ``)
     `$(Base.julia_cmd()) $julia_flags --project=$PROJECT_DIR -m JuliaFormatter`
+end
 
 function with_sandbox(f)
     mktempdir(; prefix = "jlfmt_test_$(uuid4())_") do dir
         cd(dir) do
             f(dir)
         end
+    end
+end
+
+function capture_stderr(f)
+    path = tempname()
+    try
+        return open(path, "w+") do io::IOStream
+            result = redirect_stderr(f, io)
+            flush(io)
+            seekstart(io)
+            return result, read(io, String)
+        end
+    finally
+        rm(path; force = true)
     end
 end
 
@@ -107,9 +122,32 @@ else
 
                 # --check should fail on unformatted file
                 write(fname, unformatted)
-                @test !success(`$(jlfmt_cmd()) --check $fname`)
+                errno, stderr = capture_stderr() do
+                    JuliaFormatter.main(["--check", fname])
+                end
+                @test errno == 1
+                @test occursin(
+                    "Some files are not formatted correctly. Run again with `--inplace` instead of `--check` to format them.",
+                    stderr,
+                )
                 # --check should not modify the file
                 @test readchomp(fname) == unformatted
+            end
+        end
+
+        @testset "multiple input diagnostics" begin
+            with_sandbox() do _
+                write("a.jl", "f( x,y )=x+y")
+                write("b.jl", "g( x,y )=x+y")
+
+                errno, stderr = capture_stderr() do
+                    JuliaFormatter.main(["."])
+                end
+                @test errno == 1
+                @test occursin(
+                    "multiple input files require either `--inplace` to write changes or `--check` to verify formatting",
+                    stderr,
+                )
             end
         end
 
@@ -156,7 +194,9 @@ else
                     @test readchomp(fname) == text
 
                     # With --prioritize-config-file, config wins over CLI
-                    run(`$(jlfmt_cmd()) --inplace --prioritize-config-file --style=default $fname`)
+                    run(
+                        `$(jlfmt_cmd()) --inplace --prioritize-config-file --style=default $fname`,
+                    )
                     @test readchomp(fname) == format_text(text, BlueStyle())
                 end
             end
@@ -173,8 +213,11 @@ else
                     @test readchomp(fname) == text
 
                     # With --prioritize-config-file, config wins over CLI
-                    run(`$(jlfmt_cmd()) --inplace --prioritize-config-file --whitespace_in_kwargs $fname`)
-                    @test readchomp(fname) == format_text(text; whitespace_in_kwargs = false)
+                    run(
+                        `$(jlfmt_cmd()) --inplace --prioritize-config-file --whitespace_in_kwargs $fname`,
+                    )
+                    @test readchomp(fname) ==
+                          format_text(text; whitespace_in_kwargs = false)
                 end
             end
         end


### PR DESCRIPTION
Before, the CLI suggested: `jlfmt --check src` -> "Some files are not formatted correctly. Run without `--check` to format them". Following that advice with a directory led to: `jlfmt src` -> "ERROR: option `--inplace` or `--check` required with multiple input files."

With this commit, `--check` failures now say: "Some files are not formatted correctly. Run again with `--inplace` instead of `--check` to format them". Running a directory without an action now says: "ERROR: multiple input files require either `--inplace` to write changes or `--check` to verify formatting".