### PR TITLE
Declare docs and test as Pkg workspace projects

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 version = "2.6.15"
 authors = ["Dominique Luna <dluna132@gmail.com> and contributors"]
 
+[workspace]
+projects = ["docs", "test"]
+
 [deps]
 CommonMark = "a80b9123-70ca-4bc0-993e-6e3bcb318db6"
 Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"


### PR DESCRIPTION
Add a `[workspace]` section to the root `Project.toml` listing `docs` and `test` as sub-projects, so they resolve against a single shared manifest instead of separate environments.

This also helps language servers such as JETLS analyze JuliaFormatter: with a shared workspace manifest the server can resolve the package and its `docs`/`test` environments together, rather than treating them as disconnected projects.