### PR TITLE
Fix parenthesised caller bug

### DIFF
--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,3 +1,8 @@
+# v2.8.2
+
+Fixed a bug where JuliaFormatter would insert newlines around a parenthesised caller in a function definition, causing the function to be parsed differently on Julia 1.12.
+This is probably a Julia bug and not really JuliaFormatter's fault, but this patch works around it. (#1114, #1117)
+
 # v2.8.1
 
 Fixed a bug causing line comments inside array literals to be dropped or otherwise cause non-idempotent formatting. (#1113, #1115, #1116)

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.8.1"
+version = "2.8.2"
 authors = ["Dominique Luna <dluna132@gmail.com> and contributors"]
 
 [workspace]

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -21,6 +21,10 @@
     # indicates whether newlines at the end are semantically meaningful
     is_last_ncat_or_nrow_arg::Bool=false
 
+    # indicates whether the caller in a function definition has been parenthesised
+    # see p_call for explanation
+    is_parenthesised_caller::Bool=false
+
     ignore_single_line::Bool = false
     from_quote::Bool = false
     join_body::Bool = false
@@ -2911,36 +2915,47 @@ function p_call(
         childs = childs[1:(do_block_idx-1)]
     end
 
+    caller_idx = findfirst(n -> !JuliaSyntax.is_whitespace(n), childs)
     args = call_args(childs)
     nest = should_allow_nesting_call_args(args, s.opts.disallow_single_arg_nesting)
 
     for (i, a) in enumerate(childs)
         k = kind(a)
-        n = if k == K"=" && haschildren(a)
-            p_kw(style, a, s, ctx, lineage)
-        else
-            pretty(style, a, s, ctx, lineage)
-        end
-
         if k === K"("
+            n = pretty(style, a, s, ctx, lineage)
             add_node!(t, n, s; join_lines = true)
             if nest
                 add_node!(t, Placeholder(0), s)
             end
         elseif k === K")"
+            n = pretty(style, a, s, ctx, lineage)
             if nest
                 add_node!(t, TrailingComma(), s)
                 add_node!(t, Placeholder(0), s)
             end
             add_node!(t, n, s; join_lines = true)
         elseif k === K","
+            n = pretty(style, a, s, ctx, lineage)
             add_node!(t, n, s; join_lines = true)
 
             # figure out if we need to put a placeholder
             if has_more_args_to_come(childs, i + 1, K")")
                 add_node!(t, Placeholder(1), s)
             end
+        elseif k == K"=" && haschildren(a)
+            n = p_kw(style, a, s, ctx, lineage)
+            add_node!(t, n, s; join_lines = true)
         else
+            # If the caller is parenthesised (usually callable struct, but not necessarily),
+            # avoid inserting placeholders after ( and before ), because that causes
+            # JuliaSyntax@1.0.2 to parse it wrongly. Hopefully this will be fixed
+            # https://github.com/JuliaLang/julia/issues/62124
+            ctx2 = if i == caller_idx && k === K"parens" && haschildren(a)
+                newctx(ctx; is_parenthesised_caller = true)
+            else
+                ctx
+            end
+            n = pretty(style, a, s, ctx2, lineage)
             add_node!(t, n, s; join_lines = true)
         end
     end
@@ -2983,19 +2998,19 @@ function p_parens(
         false
     end
 
+    # turn off the is_parenthesised_caller flag so that it's not propagated to children
+    is_parenthesised_caller = ctx.is_parenthesised_caller
+    ctx = newctx(ctx; is_parenthesised_caller = false)
+
     for c in children(cst)
         if kind(c) === K"("
             add_node!(t, pretty(style, c, s, ctx, lineage), s; join_lines = true)
-            if nest
+            if nest && !is_parenthesised_caller
                 add_node!(t, Placeholder(0), s)
-            else
-                false
             end
         elseif kind(c) === K")"
-            if nest
+            if nest && !is_parenthesised_caller
                 add_node!(t, Placeholder(0), s)
-            else
-                false
             end
             add_node!(t, pretty(style, c, s, ctx, lineage), s; join_lines = true)
         elseif kind(c) === K"block"

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -2998,18 +2998,35 @@ function p_parens(
         false
     end
 
-    # turn off the is_parenthesised_caller flag so that it's not propagated to children
-    is_parenthesised_caller = ctx.is_parenthesised_caller
+    # This is a workaround for 
+    # https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/1114
+    # https://github.com/JuliaLang/julia/issues/62124
+    #
+    # For a construct like
+    #
+    #     function (expr)(args...)
+    #         body
+    #     end
+    #
+    # we can't put newlines around `expr` as that causes JuliaSyntax to
+    # parse the resulting code incorrectly.
+    disable_nesting = (ctx.is_parenthesised_caller
+        && length(lineage) >= 2
+        && lineage[end-1][1] === K"call"
+        && lineage[end-2][1] === K"function"
+    )
+    nest = nest && !disable_nesting
+    # turn off the is_parenthesised_caller flag so that it's not propagated to children.
     ctx = newctx(ctx; is_parenthesised_caller = false)
 
     for c in children(cst)
         if kind(c) === K"("
             add_node!(t, pretty(style, c, s, ctx, lineage), s; join_lines = true)
-            if nest && !is_parenthesised_caller
+            if nest
                 add_node!(t, Placeholder(0), s)
             end
         elseif kind(c) === K")"
-            if nest && !is_parenthesised_caller
+            if nest
                 add_node!(t, Placeholder(0), s)
             end
             add_node!(t, pretty(style, c, s, ctx, lineage), s; join_lines = true)

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -3010,10 +3010,11 @@ function p_parens(
     #
     # we can't put newlines around `expr` as that causes JuliaSyntax to
     # parse the resulting code incorrectly.
-    disable_nesting = (ctx.is_parenthesised_caller
-        && length(lineage) >= 2
-        && lineage[end-1][1] === K"call"
-        && lineage[end-2][1] === K"function"
+    disable_nesting = (
+        ctx.is_parenthesised_caller &&
+        length(lineage) >= 2 &&
+        lineage[end-1][1] === K"call" &&
+        lineage[end-2][1] === K"function"
     )
     nest = nest && !disable_nesting
     # turn off the is_parenthesised_caller flag so that it's not propagated to children.

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -2964,6 +2964,43 @@ end
             test_format(s, nothing, style; ast=true, always_use_return=false)
             test_format(s, nothing, style; ast=true, always_use_return=false, margin=10)
         end
+
+        s = """
+        @inline function (boundary_condition::BoundaryConditionNavierStokesWall{<:NoSlip,
+                                                                                <:Adiabatic})(flux_inner,
+                                                                                              u_inner,
+                                                                                              orientation::Integer,
+                                                                                              direction,
+                                                                                              x,
+                                                                                              t,
+                                                                                              operator_type::Gradient,
+                                                                                              equations::CompressibleNavierStokesDiffusion1D{GradientVariablesPrimitive})
+            v1 = boundary_condition.boundary_condition_velocity.boundary_value_function(x, t,
+                                                                                        equations)
+            return SVector(u_inner[1], v1, u_inner[3])
+        end"""
+        output = """
+        @inline function (boundary_condition::BoundaryConditionNavierStokesWall{
+            <:NoSlip,
+            <:Adiabatic,
+        })(
+            flux_inner,
+            u_inner,
+            orientation::Integer,
+            direction,
+            x,
+            t,
+            operator_type::Gradient,
+            equations::CompressibleNavierStokesDiffusion1D{GradientVariablesPrimitive},
+        )
+            v1 = boundary_condition.boundary_condition_velocity.boundary_value_function(
+                x,
+                t,
+                equations,
+            )
+            return SVector(u_inner[1], v1, u_inner[3])
+        end"""
+        test_format(s, output; ast=true)
     end
 end
 

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -3001,6 +3001,22 @@ end
             return SVector(u_inner[1], v1, u_inner[3])
         end"""
         test_format(s, output; ast=true)
+
+        # Check that parenthesised callers outside of function definitions aren't affected.
+        s = "(loooooong)(1, 2, 3)"
+        out = "(\n    loooooong\n)(\n    1,\n    2,\n    3,\n)"
+        test_format(s, out; ast=true, margin=10)
+        s = """
+        (function()
+            foo
+        end)()"""
+        out = """
+        (
+            function ()
+                foo
+            end
+        )()"""
+        test_format(s, out; ast=true, margin=10)
     end
 end
 

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -2954,6 +2954,17 @@ end
         end
     end
 
+    @testset "1114 parenthesised caller in function def" begin
+        s = """
+        function (foo::Foo)(a, b)
+           foo
+        end
+        """
+        for style in ALL_STYLES
+            test_format(s, nothing, style; ast=true, always_use_return=false)
+            test_format(s, nothing, style; ast=true, always_use_return=false, margin=10)
+        end
+    end
 end
 
 end


### PR DESCRIPTION
Closes #1114 by not inserting newlines around the caller. This guarantees that even on Julia 1.12, your code won't break. ref:

https://github.com/JuliaLang/julia/issues/62124

https://github.com/JuliaLang/julia/issues/60558