### PR TITLE
Fix blue chained ternary idempotence issue

### DIFF
--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,3 +1,7 @@
+# v2.8.5
+
+Fixed more bugs where BlueStyle's chained-ternary-to-if conversion would lead to loss of idempotence. (#1131, #1132)
+
 # v2.8.4
 
 Disabled `short_circuit_to_if` for `x && y` and `x || y` statements at the end of a block (since the value of the expression is in fact being used).

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.8.4"
+version = "2.8.5"
 authors = ["Dominique Luna <dluna132@gmail.com> and contributors"]
 
 [workspace]

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -560,6 +560,15 @@ function is_block(x::JuliaSyntax.GreenNode)
         (kind(x) == K"quote" && haschildren(x) && is_block(x[1]))
 end
 
+# A chained ternary `a ? b : c ? d : e` is a K"?" node whose "else" branch (the last
+# non-whitespace child) is itself a K"?" node.
+function is_chained_ternary(cst::JuliaSyntax.GreenNode)
+    kind(cst) !== K"?" && return false
+    haschildren(cst) || return false
+    rhs = findlast(c -> !JuliaSyntax.is_whitespace(c), children(cst))
+    return rhs !== nothing && kind(cst[rhs]) === K"?" && haschildren(cst[rhs])
+end
+
 function is_block(x::FST)
     x.typ in (Block, If, Do, Try, Begin, For, While, Let) ||
         (x.typ === Quote && x[1].val == "quote")
@@ -808,10 +817,18 @@ function is_binaryop_nestable(::AbstractStyle, cst::JuliaSyntax.GreenNode)
     true
 end
 
-function nest_rhs(cst::JuliaSyntax.GreenNode)::Bool
+function nest_rhs(cst::JuliaSyntax.GreenNode, style::AbstractStyle)::Bool
     if defines_function(cst) && haschildren(cst)
         for c in children(cst)
             if is_if(c) || kind(c) in KSet"do try for while let" && haschildren(c)
+                return true
+            end
+            # BlueStyle converts chained ternaries to if/elseif/else blocks at the CST
+            # stage, so we need to treat them as blocks here too. For example, without
+            # this, `f() = a ? b : c ? d : e` would first produce `f() = if a ... end`
+            # (AllowNest), but on the second pass the `if` block triggers AlwaysNest,
+            # producing `f() =\n    if a ... end` instead.
+            if style isa BlueStyle && is_chained_ternary(c)
                 return true
             end
         end

--- a/src/styles/blue/pretty.jl
+++ b/src/styles/blue/pretty.jl
@@ -272,10 +272,7 @@ function p_conditionalopcall(
         return FST(Conditional, nspaces(s))
     end
 
-    # identify rhs of ternary and if it is itself a ternary, generate an if/elseif/else
-    # block instead of a chained ternary
-    rhs = findlast(c -> !JuliaSyntax.is_whitespace(c), children(cst))
-    return if rhs !== nothing && kind(cst[rhs]) == K"?" && haschildren(cst[rhs])
+    return if is_chained_ternary(cst)
         output_fst = FST(If, nspaces(s))
         _ternary_to_ifelse!(output_fst, style, cst, s, ctx, lineage, true, FST[])
         output_fst

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -2544,7 +2544,7 @@ function p_binaryopcall(
 
     nonest = ctx.nonest || opkind === K":"
 
-    nrhs = nest_rhs(cst)
+    nrhs = nest_rhs(cst, style)
     if nrhs
         t.nest_behavior = AlwaysNest
     end


### PR DESCRIPTION
The problem is that chained ternaries `a ? b : c ? d : e` get expanded to blocks automatically in BlueStyle. However, the parent nodes need to know whether they have any block children. Prior to the expansion this is false, but after the expansion it is true.
For this case though we are lucky because as long as it is a chained ternary, we know it will unconditionally be expanded, and so we can just detect such cases in advance (before they are expanded).
This patches at least one case of non-idempotence. There could still be more......

Claude did this, after I told it pretty much exactly what to do. I'm actually quite pleased!

Still needs tests etc because this was caught via the blue style regression tests #1120 

Closes #1131