### PR TITLE
Rewrite CLI argument parsing code

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -81,7 +81,7 @@ jobs:
             remove_config: true
             # that specific file defines 'expected output' for Documenter purposes,
             # which is not valid Julia
-            args: "--v2-stable-multiline-strings=true"
+            args: "--v2-stable-multiline-strings=true --ignore=test/book/cornerstones/polyhedral-geometry/g-vectors.jl"
             name_suffix: "default"
           - repo: oscar-system/Oscar.jl
             rev: v1.7.3

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -34,64 +34,64 @@ jobs:
           - repo: JuliaLang/julia
             rev: v1.12.6
             remove_config: true
-            args: "--v2_stable_multiline_strings"
+            args: "--v2-stable-multiline-strings=true"
             name_suffix: "default"
           - repo: JuliaLang/julia
             rev: v1.12.6
             remove_config: true
-            args: "--style=blue --v2_stable_multiline_strings --no-conditional_to_if"
+            args: "--style=blue --v2-stable-multiline-strings=true --conditional-to-if=false"
             name_suffix: "blue"
           - repo: SciML/OrdinaryDiffEq.jl
             rev: v7.0.0
             remove_config: true
-            args: "--v2_stable_multiline_strings"
+            args: "--v2-stable-multiline-strings=true"
             name_suffix: "default"
           - repo: SciML/OrdinaryDiffEq.jl
             rev: v7.0.0
             remove_config: true
-            args: "--style=blue --v2_stable_multiline_strings --no-conditional_to_if"
+            args: "--style=blue --v2-stable-multiline-strings=true --conditional-to-if=false"
             name_suffix: "blue"
           - repo: MakieOrg/Makie.jl
             rev: v0.24.11
             remove_config: true
-            args: "--v2_stable_multiline_strings"
+            args: "--v2-stable-multiline-strings=true"
             name_suffix: "default"
           - repo: MakieOrg/Makie.jl
             rev: v0.24.11
             remove_config: true
-            args: "--style=blue --v2_stable_multiline_strings --no-conditional_to_if"
+            args: "--style=blue --v2-stable-multiline-strings=true --conditional-to-if=false"
             name_suffix: "blue"
           - repo: jump-dev/JuMP.jl
             rev: v1.30.1
             remove_config: true
-            args: "--style=blue --v2_stable_multiline_strings --no-conditional_to_if"
+            args: "--style=blue --v2-stable-multiline-strings=true --conditional-to-if=false"
             name_suffix: "blue"
           - repo: EnzymeAD/Enzyme.jl
             rev: v0.13.157
             remove_config: true
-            args: "--style=blue --v2_stable_multiline_strings --no-conditional_to_if"
+            args: "--style=blue --v2-stable-multiline-strings=true --conditional-to-if=false"
             name_suffix: "blue"
           - repo: trixi-framework/Trixi.jl
             rev: v0.16.18
             remove_config: true
-            args: "--style=blue --v2_stable_multiline_strings --no-conditional_to_if"
+            args: "--style=blue --v2-stable-multiline-strings=true --conditional-to-if=false"
             name_suffix: "blue"
           - repo: oscar-system/Oscar.jl
             rev: v1.7.3
             remove_config: true
             # that specific file defines 'expected output' for Documenter purposes,
             # which is not valid Julia
-            args: "--v2_stable_multiline_strings"
+            args: "--v2-stable-multiline-strings=true"
             name_suffix: "default"
           - repo: oscar-system/Oscar.jl
             rev: v1.7.3
             remove_config: true
-            args: "--style=blue --v2_stable_multiline_strings --no-conditional_to_if --ignore=test/book/cornerstones/polyhedral-geometry/g-vectors.jl"
+            args: "--style=blue --v2-stable-multiline-strings=true --conditional-to-if=false --ignore=test/book/cornerstones/polyhedral-geometry/g-vectors.jl"
             name_suffix: "blue"
           - repo: SciML/ModelingToolkit.jl
             rev: v11.26.8
             remove_config: true
-            args: "--style=blue --v2_stable_multiline_strings --no-conditional_to_if"
+            args: "--style=blue --v2-stable-multiline-strings=true --conditional-to-if=false"
             name_suffix: "blue"
 
     steps:

--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -11,6 +11,7 @@ For all formatting options that require a value (e.g. `--margin=80`), also allow
 
 Added missing formatting options to the CLI app (previously only a subset of these could be specified on the command line). (#1135)
 
+Added an `--ignore-config` option to the CLI app, which will ignore any `.JuliaFormatter.toml` files and use only the options specified on the command line. (#1135)
 
 # v2.8.5
 

--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,3 +1,7 @@
+# v2.9.0
+
+Rewrote CLI argument parsing code to avoid code duplication.
+
 # v2.8.5
 
 Fixed more bugs where BlueStyle's chained-ternary-to-if conversion would lead to loss of idempotence. (#1131, #1132)

--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,6 +1,6 @@
 # v2.9.0
 
-Rewrote CLI argument parsing code to avoid code duplication.
+Rewrote CLI argument parsing code to avoid code duplication. (#1031, #1135)
 
 # v2.8.5
 

--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -2,6 +2,16 @@
 
 Rewrote CLI argument parsing code to avoid code duplication. (#1031, #1135)
 
+For all old formatting options, added aliases that used hyphens instead of underscores, and expect the actual value on the right-hand side of the `=` sign.
+For example, what was previously `--always_use_return` and `--no-always_use_return` should now be specified as `--always-use-return=true` and `--always-use-return=false`.
+This is done to improve consistency with `.JuliaFormatter.toml` and also generalisability to other types of options.
+The underscore versions are still supported for backwards compatibility, but the hyphenated versions should be preferred going forwards. (#1135)
+
+For all formatting options that require a value (e.g. `--margin=80`), also allow the value to be space-separated (i.e. `--margin 80`). (#1135)
+
+Added missing formatting options to the CLI app (previously only a subset of these could be specified on the command line). (#1135)
+
+
 # v2.8.5
 
 Fixed more bugs where BlueStyle's chained-ternary-to-if conversion would lead to loss of idempotence. (#1131, #1132)

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.8.5"
+version = "2.9.0"
 authors = ["Dominique Luna <dluna132@gmail.com> and contributors"]
 
 [workspace]

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -53,12 +53,7 @@ In general the way that CLI options are specified are exactly the same as in `.J
 - To set an option to `nothing`, use `--option=nothing` (in the config file it would have to be `option = "nothing"`).
 - To pass a list of strings for `variable_call_indent`, specify the option multiple times on the CLI, e.g. `--variable-call-indent=foo --variable-call-indent=bar` (in the config file it would be `variable_call_indent = ["foo", "bar"]`).
 
-`jlfmt --help` provides a complete list:
-
-```@repl
-using JuliaFormatter # hide
-JuliaFormatter.main(["--help"]); # hide
-```
+You can run `jlfmt --help` for a full list of available options (the output of this is at the bottom of this page, to avoid clutter).
 
 !!! note "Deprecated options"
 
@@ -111,3 +106,11 @@ The formatter will search for `.JuliaFormatter.toml` in the specified directory 
 - Exit code 1 on formatting errors or when `--check` detects unformatted files
 - Formatted output to stdout (default) or in-place with `--inplace`
 - Error messages to stderr
+
+## Help text
+
+```@repl
+using JuliaFormatter # hide
+JuliaFormatter.main(["--help"]); # hide
+```
+

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -84,6 +84,13 @@ Use `--prioritize-config-file` to make configuration file settings take preceden
 jlfmt --prioritize-config-file --indent=2 src/file.jl
 ```
 
+If you want to ignore preexisting configuration files, use `--ignore-config` (this is mostly useful for JuliaFormatter's own testing pipelines):
+
+```bash
+# Ignore any config files and use only CLI args
+jlfmt --ignore-config --indent=2 src/file.jl
+```
+
 ### Configuration with stdin
 
 When formatting from stdin, no configuration file is used by default.

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -45,16 +45,36 @@ jlfmt --diff src/file.jl
 
 ## Options
 
-Run `jlfmt --help` for a complete list:
+All formatting options can be passed to `jlfmt` as command-line arguments, e.g. `--indent=2 --always-use-return=true`.
+
+In general the way that CLI options are specified are exactly the same as in `.JuliaFormatter.toml`, with some exceptions:
+
+- When specified on the CLI options are hyphenated (e.g. `--always-use-return`), while in the config file they are underscored (e.g. `always_use_return`).
+- To set an option to `nothing`, use `--option=nothing` (in the config file it would have to be `option = "nothing"`).
+- To pass a list of strings for `variable_call_indent`, specify the option multiple times on the CLI, e.g. `--variable-call-indent=foo --variable-call-indent=bar` (in the config file it would be `variable_call_indent = ["foo", "bar"]`).
+
+`jlfmt --help` provides a complete list:
 
 ```@repl
 using JuliaFormatter # hide
 JuliaFormatter.main(["--help"]); # hide
 ```
 
+!!! note "Deprecated options"
+
+    In previous versions of `jlfmt`, some (but not all) Boolean options could be specified using `--option_name` or `--no-option_name` flags (e.g. `--always-use-return` or `--no-always-use-return`).
+    This is now deprecated in favor of `--option-name=true` or `--option-name=false` (note hyphens instead of underscores, and the value must be explicitly supplied!), and will be removed in a future release.
+
 ## Configuration Files
 
 `jlfmt` searches for [`.JuliaFormatter.toml` configuration](@ref config) files starting from each input file's directory and walking up the directory tree.
+
+A specific directory containing a configuration file can be specified with `--config-dir`:
+
+```bash
+# Search upwards from home directory for a config file
+jlfmt --config-dir=~ src/file.jl
+```
 
 By default, command-line options override configuration file settings:
 

--- a/src/JuliaFormatter.jl
+++ b/src/JuliaFormatter.jl
@@ -592,6 +592,7 @@ function isignored(path, options)
     return any(x -> occursin(Glob.FilenameMatch("*$x"), path_posix), ignore)
 end
 
+include("argparse.jl")
 include("app.jl")
 
 include("internal/utils.jl")

--- a/src/app.jl
+++ b/src/app.jl
@@ -206,6 +206,7 @@ function main(argv::Vector{String})
                 true,
                 args.stdin_filename,
                 args.config_dir,
+                args.ignore_config,
                 format_options,
                 args.diff,
                 args.format_markdown,
@@ -226,6 +227,7 @@ function main(argv::Vector{String})
                 false,
                 args.stdin_filename,
                 args.config_dir,
+                args.ignore_config,
                 format_options,
                 args.diff,
                 args.format_markdown,
@@ -284,6 +286,7 @@ struct ProcessFileArgs
     input_is_stdin::Bool
     stdin_filename::String
     config_dir::String
+    ignore_config::Bool
     format_options::Dict{Symbol,Any} # options passed as CLI args
     diff::Bool
     format_markdown::Bool
@@ -403,7 +406,9 @@ function process_file(args::ProcessFileArgs)
 
     # Look up .JuliaFormatter.toml config. --config-dir overrides the default
     # (which walks up from the input file's directory, or does nothing for stdin).
-    config_nt = if args.config_dir != ""
+    config_nt = if args.ignore_config
+        (;)
+    elseif args.config_dir != ""
         config_path = joinpath(args.config_dir, CONFIG_FILE_NAME)
         if isfile(config_path)
             parse_config(config_path)

--- a/src/app.jl
+++ b/src/app.jl
@@ -1,5 +1,13 @@
-import .ArgParse: ParseArgsError, ParsedArgs, parse_args, parse_raw, PARSER,
-    StdoutMode, InplaceMode, CheckMode, print_help
+import .ArgParse:
+    ParseArgsError,
+    ParsedArgs,
+    parse_args,
+    parse_raw,
+    PARSER,
+    StdoutMode,
+    InplaceMode,
+    CheckMode,
+    print_help
 
 # For thread-safe printing
 const print_lock = ReentrantLock()
@@ -181,46 +189,49 @@ function main(argv::Vector{String})
     end
 
     # Disable verbose if piping from/to stdin/stdout
-    output_is_stdout =
-        !inplace && !check && (outputfile in ("", "-"))
+    output_is_stdout = !inplace && !check && (outputfile in ("", "-"))
     print_progress = args.verbose && !(input_is_stdin || output_is_stdout)
 
     fileargs_to_process = if input_is_stdin
         # Sentinel value representing stdin.
-        [ProcessFileArgs(
-            "",
-            1,
-            "1",
-            print_progress,
-            check,
-            inplace,
-            outputfile,
-            true,
-            args.stdin_filename,
-            args.config_dir,
-            format_options,
-            args.diff,
-            args.format_markdown,
-            args.config_priority,
-        )]
+        [
+            ProcessFileArgs(
+                "",
+                1,
+                "1",
+                print_progress,
+                check,
+                inplace,
+                outputfile,
+                true,
+                args.stdin_filename,
+                args.config_dir,
+                format_options,
+                args.diff,
+                args.format_markdown,
+                args.config_priority,
+            ),
+        ]
     else
         nfiles_str = string(length(inputfiles))
-        [ProcessFileArgs(
-            inputfile,
-            file_counter,
-            nfiles_str,
-            print_progress,
-            check,
-            inplace,
-            outputfile,
-            false,
-            args.stdin_filename,
-            args.config_dir,
-            format_options,
-            args.diff,
-            args.format_markdown,
-            args.config_priority,
-        ) for (file_counter, inputfile) in enumerate(inputfiles)]
+        [
+            ProcessFileArgs(
+                inputfile,
+                file_counter,
+                nfiles_str,
+                print_progress,
+                check,
+                inplace,
+                outputfile,
+                false,
+                args.stdin_filename,
+                args.config_dir,
+                format_options,
+                args.diff,
+                args.format_markdown,
+                args.config_priority,
+            ) for (file_counter, inputfile) in enumerate(inputfiles)
+        ]
     end
 
     # Use multithreading for multiple files (only if multiple threads available)

--- a/src/app.jl
+++ b/src/app.jl
@@ -404,7 +404,12 @@ function process_file(args::ProcessFileArgs)
     # Look up .JuliaFormatter.toml config. --config-dir overrides the default
     # (which walks up from the input file's directory, or does nothing for stdin).
     config_nt = if args.config_dir != ""
-        find_config_file(args.config_dir)
+        config_path = joinpath(args.config_dir, CONFIG_FILE_NAME)
+        if isfile(config_path)
+            parse_config(config_path)
+        else
+            find_config_file(args.config_dir)
+        end
     elseif !args.input_is_stdin
         find_config_file(args.inputfile)
     else

--- a/src/app.jl
+++ b/src/app.jl
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: MIT
+import .ArgParse: ParseArgsError, ParsedArgs, parse_args, parse_raw, PARSER,
+    StdoutMode, InplaceMode, CheckMode, print_help
 
 # For thread-safe printing
 const print_lock = ReentrantLock()
@@ -73,231 +74,6 @@ function errln(io::IO, msg::String = "✗")
     return
 end
 
-function print_help()
-    io = stdout
-    printstyled(io, "NAME"; bold = true)
-    println(io)
-    println(io, "       jlfmt - An opinionated code formatter for Julia.")
-    println(io)
-    printstyled(io, "SYNOPSIS"; bold = true)
-    println(io)
-    println(io, "       jlfmt [<options>] <path>...")
-    println(io, "       jlfmt [<options>] -")
-    println(io, "       ... | jlfmt [<options>]")
-    println(io)
-    printstyled(io, "DESCRIPTION"; bold = true)
-    println(io)
-    println(
-        io,
-        """
-               `jlfmt` formats Julia source code using JuliaFormatter.jl.
-               This tool can also be invoked as `julia -m JuliaFormatter`.
-        """,
-    )
-    printstyled(io, "OPTIONS"; bold = true)
-    println(io)
-    println(
-        io,
-        """
-               <path>...
-                   Input path(s) (files and/or directories) to process. For directories,
-                   all files (recursively) with the '*.jl' suffix are used as input files
-                   (also '*.md', '*.jmd', '*.qmd' if --format-markdown is specified).
-                   If no path is given, or if path is `-`, input is read from stdin.
-
-               -c, --check
-                   Do not write output and exit with a non-zero code if the input is not
-                   formatted correctly.
-
-               -d, --diff
-                   Print the diff between the input and formatted output to stderr.
-                   Requires `git` to be installed.
-
-               -h, --help
-                   Print this message.
-
-               -i, --inplace
-                   Format files in place.
-
-               -o <file>, --output=<file>
-                   File to write formatted output to. If no output is given, or if the file
-                   is `-`, output is written to stdout.
-
-               --stdin-filename=<filename>
-                   Assumed filename when formatting from stdin. Used for error messages.
-
-               --config-dir=<path>
-                   Directory path to use for .JuliaFormatter.toml config file lookup when
-                   formatting from stdin. By default, stdin input does not use config files.
-                   With this option, the formatter will search for .JuliaFormatter.toml in
-                   the specified directory and its parent directories.
-
-               -v, --verbose
-                   Enable verbose output.
-
-               --version
-                   Print JuliaFormatter and julia version information.
-
-               --prioritize-config-file
-                   Prioritize .JuliaFormatter.toml config file options over command-line options.
-                   By default, command-line options override config file options. This flag
-                   reverses that precedence, useful for language server integration where
-                   project configuration should take precedence over editor settings.
-
-               FORMATTING OPTIONS
-
-               --style=<style>
-                   Formatting style: "default", "yas", "blue", "sciml", or "minimal".
-                   Default: "default"
-
-               --indent=<n>
-                   Indentation width. Default: 4
-
-               --margin=<n>
-                   Maximum line width. Default: 92
-
-               --sciml_margin_overrun=<n>
-                   Additional columns SciMLStyle may use when a slightly
-                   over-margin line is more readable. Default: 20
-
-               --format_markdown
-                   Also format code blocks in Markdown files (.md, .jmd, .qmd).
-
-               --ignore=<pattern>
-                   Ignore files matching the given pattern. Can be specified multiple times.
-                   Patterns use glob-style matching (e.g., "*/test/*", "*.tmp").
-
-               --lines=<start>:<stop>
-                   Only format the given range of lines (1-based, inclusive); all other
-                   lines are emitted verbatim. Can be specified multiple times to format
-                   several ranges (e.g., --lines=1:10 --lines=42:47). Overlapping and
-                   adjacent ranges are merged. Requires a single input file (or stdin);
-                   it cannot be combined with multiple input files or directories, nor
-                   with Markdown input. A range that begins or ends in the middle of a
-                   multi-line expression is formatted on a best-effort basis.
-
-               --always_for_in / --no-always_for_in
-                   Always use 'for x in' instead of 'for x =' or 'for x '.
-                   Default: false
-
-               --whitespace_typedefs / --no-whitespace_typedefs
-                   Add whitespace around '::' in type definitions.
-                   Default: false
-
-               --remove_extra_newlines / --no-remove_extra_newlines
-                   Remove extra newlines.
-                   Default: false
-
-               --import_to_using / --no-import_to_using
-                   Convert 'import' to 'using'.
-                   Default: false
-
-               --pipe_to_function_call / --no-pipe_to_function_call
-                   Convert pipe operator to function calls.
-                   Default: false
-
-               --short_to_long_function_def / --no-short_to_long_function_def
-                   Convert short function definitions to long form.
-                   Default: false
-
-               --always_use_return / --no-always_use_return
-                   Always add explicit 'return' statements.
-                   Default: false
-
-               --whitespace_in_kwargs / --no-whitespace_in_kwargs
-                   Add whitespace in keyword arguments.
-                   Default: true
-
-               --format_docstrings / --no-format_docstrings
-                   Format docstrings.
-                   Default: false
-
-               --align_struct_field / --no-align_struct_field
-                   Align struct field type annotations.
-                   Default: false
-
-               --align_assignment / --no-align_assignment
-                   Align assignment operators.
-                   Default: false
-
-               --align_conditional / --no-align_conditional
-                   Align conditional operators.
-                   Default: false
-
-               --align_pair_arrow / --no-align_pair_arrow
-                   Align pair arrows (=>).
-                   Default: false
-
-               --trailing_comma / --no-trailing_comma
-                   Add trailing commas.
-                   Default: true
-
-               --trailing_zero / --no-trailing_zero
-                   Add trailing zeros to floats.
-                   Default: true
-
-               --v2_stable_multiline_strings / --no-v2_stable_multiline_strings
-                   Use stable multiline string length calculation for idempotent
-                   formatting.
-                   Default: false
-
-               --conditional_to_if / --no-conditional_to_if
-                   Convert ternary conditional expressions to if/else blocks
-                   when they exceed the line margin. Warning: enabling this
-                   option may lead to idempotence failures in some cases.
-                   Default: false
-
-               --normalize_line_endings=<mode>
-                   Normalize line endings: "auto", "unix", or "windows".
-                   Default: "auto"
-        """,
-    )
-    println(io)
-    printstyled(io, "EXAMPLES"; bold = true)
-    println(io)
-    println(
-        io,
-        """
-               Format a file and write to stdout:
-                   jlfmt src/file.jl
-
-               Format a file in place:
-                   jlfmt --inplace src/file.jl
-
-               Format all files in a directory with the verbose mode:
-                   jlfmt --inplace --verbose src/
-
-               Check if a file is formatted:
-                   jlfmt --check src/file.jl
-
-               Format only lines 1-10 and 42-47 of a file:
-                   jlfmt --lines=1:10 --lines=42:47 src/file.jl
-
-               Check if all files in a directory are formatted with multiple threads:
-                   jlfmt --threads=4 -- --check src/
-
-               Show diff for formatting wtih 2-space indentations:
-                    jlfmt --diff --indent=2 src/file.jl
-
-               Format from stdin (pipe):
-                   echo 'f(x,y)=x+y' | jlfmt
-
-               Format from stdin (explicit):
-                   jlfmt - < input.jl
-
-               Format from stdin using project config:
-                   echo 'f(x,y)=x+y' | jlfmt --config-dir=./src
-
-               Use specific style:
-                   jlfmt --style=blue src/file.jl
-
-               Combine options:
-                   echo 'for i=1:10; end' | jlfmt --always_for_in
-        """,
-    )
-    return
-end
-
 function print_version()
     print(stdout, "jlfmt (JuliaFormatter) version ")
     print(stdout, string(pkgversion(JuliaFormatter)))
@@ -327,235 +103,43 @@ function writeo(output::Output, content::String)
 end
 
 function main(argv::Vector{String})
+    args = try
+        parse_args(argv)
+    catch err
+        err isa ParseArgsError || rethrow()
+        return panic(err.message)
+    end
+
+    if args.help
+        print_help(PARSER)
+        return Cint(0)
+    end
+    if args.version
+        print_version()
+        return Cint(0)
+    end
+
+    inplace = args.mode == InplaceMode
+    check = args.mode == CheckMode
+    outputfile = something(args.outputfile, "")
+
     errno::Cint = 0
 
     inputfiles = String[]
-    outputfile = ""
-    stdin_filename = "stdin"
-    config_dir = ""
-    verbose = false
-    inplace = false
-    diff = false
-    check = false
     input_is_stdin = true
-    multiple_inputs = false
-    format_markdown = false
-    config_priority = false
-    style_name = nothing
-    format_options = Dict{Symbol,Any}()
-    ignore_patterns = String[]
-    line_ranges = Tuple{Int,Int}[]
+    # There might be multiple inputs if either more than one path is given, or if a single
+    # directory is given. This catches the first case
+    multiple_inputs = length(args.paths) > 1
 
-    paths = String[]
-    i = 1
-    while i <= length(argv)
-        x = argv[i]
-        if x == "-i" || x == "--inplace"
-            inplace = true
-            i += 1
-        elseif x == "-h" || x == "--help"
-            print_help()
-            return errno
-        elseif x == "--version"
-            print_version()
-            return errno
-        elseif x == "-v" || x == "--verbose"
-            verbose = true
-            i += 1
-        elseif x == "-d" || x == "--diff"
-            diff = true
-            i += 1
-        elseif x == "-c" || x == "--check"
-            check = true
-            i += 1
-        elseif x == "--prioritize-config-file"
-            config_priority = true
-            i += 1
-        elseif startswith(x, "--stdin-filename=")
-            m = match(r"^--stdin-filename=(.+)$", x)
-            stdin_filename = String(m.captures[1]::AbstractString)
-            i += 1
-        elseif startswith(x, "--config-dir=")
-            m = match(r"^--config-dir=(.+)$", x)
-            config_dir = String(m.captures[1]::AbstractString)
-            i += 1
-        elseif x == "-o"
-            if i >= length(argv)
-                return panic("expected output file argument after `-o`")
-            end
-            outputfile = argv[i+1]
-            i += 2
-        elseif startswith(x, "--output=")
-            m = match(r"^--output=(.+)$", x)
-            outputfile = String(m.captures[1]::AbstractString)
-            i += 1
-        elseif x == "--format_markdown"
-            format_markdown = true
-            i += 1
-        elseif startswith(x, "--ignore=")
-            m = match(r"^--ignore=(.+)$", x)
-            push!(ignore_patterns, String(m.captures[1]::AbstractString))
-            i += 1
-        elseif startswith(x, "--lines=")
-            # Repeatable: `--lines=1:10 --lines=42:47` restricts formatting to those line
-            # ranges (1-based, inclusive). Forwarded to the `lines` kwarg of `format_text`.
-            m = match(r"^--lines=(\d+):(\d+)$", x)
-            if m === nothing
-                return panic(
-                    "invalid `--lines` argument `$x`, expected `--lines=<start>:<stop>` with 1-based line numbers",
-                )
-            end
-            start_line = Base.parse(Int, m.captures[1]::AbstractString)
-            stop_line = Base.parse(Int, m.captures[2]::AbstractString)
-            # out-of-bounds line ranges are caught directly in `format_text`
-            if start_line > stop_line
-                return panic(
-                    "invalid `--lines` range `$start_line:$stop_line`: start is greater than stop",
-                )
-            end
-            push!(line_ranges, (start_line, stop_line))
-            i += 1
-        elseif startswith(x, "--style=")
-            m = match(r"^--style=(.+)$", x)
-            style_name = String(m.captures[1]::AbstractString)
-            i += 1
-        elseif startswith(x, "--indent=")
-            m = match(r"^--indent=(\d+)$", x)
-            format_options[:indent] = Base.parse(Int, m.captures[1]::AbstractString)
-            i += 1
-        elseif startswith(x, "--margin=")
-            m = match(r"^--margin=(\d+)$", x)
-            format_options[:margin] = Base.parse(Int, m.captures[1]::AbstractString)
-            i += 1
-        elseif startswith(x, "--sciml_margin_overrun=")
-            m = match(r"^--sciml_margin_overrun=(\d+)$", x)
-            format_options[:sciml_margin_overrun] =
-                Base.parse(Int, m.captures[1]::AbstractString)
-            i += 1
-        elseif startswith(x, "--normalize_line_endings=")
-            m = match(r"^--normalize_line_endings=(.+)$", x)
-            format_options[:normalize_line_endings] = String(m.captures[1]::AbstractString)
-            i += 1
-        elseif x == "--always_for_in"
-            format_options[:always_for_in] = true
-            i += 1
-        elseif x == "--no-always_for_in"
-            format_options[:always_for_in] = false
-            i += 1
-        elseif x == "--whitespace_typedefs"
-            format_options[:whitespace_typedefs] = true
-            i += 1
-        elseif x == "--no-whitespace_typedefs"
-            format_options[:whitespace_typedefs] = false
-            i += 1
-        elseif x == "--remove_extra_newlines"
-            format_options[:remove_extra_newlines] = true
-            i += 1
-        elseif x == "--no-remove_extra_newlines"
-            format_options[:remove_extra_newlines] = false
-            i += 1
-        elseif x == "--import_to_using"
-            format_options[:import_to_using] = true
-            i += 1
-        elseif x == "--no-import_to_using"
-            format_options[:import_to_using] = false
-            i += 1
-        elseif x == "--pipe_to_function_call"
-            format_options[:pipe_to_function_call] = true
-            i += 1
-        elseif x == "--no-pipe_to_function_call"
-            format_options[:pipe_to_function_call] = false
-            i += 1
-        elseif x == "--short_to_long_function_def"
-            format_options[:short_to_long_function_def] = true
-            i += 1
-        elseif x == "--no-short_to_long_function_def"
-            format_options[:short_to_long_function_def] = false
-            i += 1
-        elseif x == "--always_use_return"
-            format_options[:always_use_return] = true
-            i += 1
-        elseif x == "--no-always_use_return"
-            format_options[:always_use_return] = false
-            i += 1
-        elseif x == "--whitespace_in_kwargs"
-            format_options[:whitespace_in_kwargs] = true
-            i += 1
-        elseif x == "--no-whitespace_in_kwargs"
-            format_options[:whitespace_in_kwargs] = false
-            i += 1
-        elseif x == "--format_docstrings"
-            format_options[:format_docstrings] = true
-            i += 1
-        elseif x == "--no-format_docstrings"
-            format_options[:format_docstrings] = false
-            i += 1
-        elseif x == "--align_struct_field"
-            format_options[:align_struct_field] = true
-            i += 1
-        elseif x == "--no-align_struct_field"
-            format_options[:align_struct_field] = false
-            i += 1
-        elseif x == "--align_assignment"
-            format_options[:align_assignment] = true
-            i += 1
-        elseif x == "--no-align_assignment"
-            format_options[:align_assignment] = false
-            i += 1
-        elseif x == "--align_conditional"
-            format_options[:align_conditional] = true
-            i += 1
-        elseif x == "--no-align_conditional"
-            format_options[:align_conditional] = false
-            i += 1
-        elseif x == "--align_pair_arrow"
-            format_options[:align_pair_arrow] = true
-            i += 1
-        elseif x == "--no-align_pair_arrow"
-            format_options[:align_pair_arrow] = false
-            i += 1
-        elseif x == "--trailing_comma"
-            format_options[:trailing_comma] = true
-            i += 1
-        elseif x == "--no-trailing_comma"
-            format_options[:trailing_comma] = false
-            i += 1
-        elseif x == "--trailing_zero"
-            format_options[:trailing_zero] = true
-            i += 1
-        elseif x == "--no-trailing_zero"
-            format_options[:trailing_zero] = false
-            i += 1
-        elseif x == "--v2_stable_multiline_strings"
-            format_options[:v2_stable_multiline_strings] = true
-            i += 1
-        elseif x == "--no-v2_stable_multiline_strings"
-            format_options[:v2_stable_multiline_strings] = false
-            i += 1
-        elseif x == "--conditional_to_if"
-            format_options[:conditional_to_if] = true
-            i += 1
-        elseif x == "--no-conditional_to_if"
-            format_options[:conditional_to_if] = false
-            i += 1
-        else
-            # Not an option, must be a file or directory
-            push!(paths, x)
-            i += 1
-        end
-    end
-
-    for x in paths
+    for x in args.paths
         if x == "-"
-            # `-` is only allowed once and as the only input
-            if length(paths) > 1
+            if length(args.paths) > 1
                 return panic("input `-` cannot be combined with other input")
             end
-            push!(inputfiles, x)
-            input_is_stdin = true
         else
             input_is_stdin = false
             if isdir(x)
+                # This catches the second case (single-directory)
                 scandir!(inputfiles, x)
                 multiple_inputs = true
             else
@@ -564,26 +148,7 @@ function main(argv::Vector{String})
         end
     end
 
-    if length(paths) > 1 || (length(paths) == 1 && isdir(paths[1]))
-        multiple_inputs = true
-    end
-
-    # Insert `-` as the input if there were no input files/directories on the command line
-    if input_is_stdin && length(inputfiles) == 0
-        @assert !multiple_inputs
-        push!(inputfiles, "-")
-    end
-
     # Validate the arguments
-    if inplace && check
-        return panic("options `--inplace` and `--check` are mutually exclusive")
-    end
-    if inplace && outputfile != ""
-        return panic("options `--inplace` and `--output` are mutually exclusive")
-    end
-    if check && outputfile != ""
-        return panic("options `--check` and `--output` are mutually exclusive")
-    end
     if inplace && input_is_stdin
         return panic("option `--inplace` cannot be used together with stdin input")
     end
@@ -595,71 +160,67 @@ function main(argv::Vector{String})
             "multiple input files require either `--inplace` to write changes or `--check` to verify formatting",
         )
     end
-    if !isempty(line_ranges) && multiple_inputs
+    if !isempty(args.line_ranges) && multiple_inputs
         return panic(
             "option `--lines` cannot be used together with multiple input files or directories",
         )
     end
-
-    if diff
+    if args.diff
         if Sys.which("git") === nothing
             return panic("option `--diff` requires `git` to be installed")
         end
     end
 
-    # Set the style if it was specified as a CLI arg
-    if style_name !== nothing
-        format_options[:style] = if style_name == "default"
-            DefaultStyle()
-        elseif style_name == "yas"
-            YASStyle()
-        elseif style_name == "blue"
-            BlueStyle()
-        elseif style_name == "sciml"
-            SciMLStyle()
-        elseif style_name == "minimal"
-            MinimalStyle()
-        else
-            return panic("unknown style: \"$style_name\"")
-        end
+    # Add ignore patterns and line ranges from command line
+    format_options = copy(args.format_options)
+    if !isempty(args.ignore_patterns)
+        format_options[:ignore] = args.ignore_patterns
     end
-
-    # Add ignore patterns from command line
-    if !isempty(ignore_patterns)
-        format_options[:ignore] = ignore_patterns
-    end
-
-    # Add line ranges from command line
-    if !isempty(line_ranges)
-        format_options[:lines] = line_ranges
+    if !isempty(args.line_ranges)
+        format_options[:lines] = args.line_ranges
     end
 
     # Disable verbose if piping from/to stdin/stdout
-    output_is_stdout = !inplace && !check && (outputfile == "" || outputfile == "-")
-    print_progress = verbose && !(input_is_stdin || output_is_stdout)
+    output_is_stdout =
+        !inplace && !check && (outputfile in ("", "-"))
+    print_progress = args.verbose && !(input_is_stdin || output_is_stdout)
 
-    nfiles_str = string(length(inputfiles))
-    options_list = ProcessFileArgs[]
-    for (file_counter, inputfile) in enumerate(inputfiles)
-        push!(
-            options_list,
-            ProcessFileArgs(
-                inputfile,
-                file_counter,
-                nfiles_str,
-                print_progress,
-                check,
-                inplace,
-                outputfile,
-                input_is_stdin,
-                stdin_filename,
-                config_dir,
-                format_options,
-                diff,
-                format_markdown,
-                config_priority,
-            ),
-        )
+    fileargs_to_process = if input_is_stdin
+        # Sentinel value representing stdin.
+        [ProcessFileArgs(
+            "",
+            1,
+            "1",
+            print_progress,
+            check,
+            inplace,
+            outputfile,
+            true,
+            args.stdin_filename,
+            args.config_dir,
+            format_options,
+            args.diff,
+            args.format_markdown,
+            args.config_priority,
+        )]
+    else
+        nfiles_str = string(length(inputfiles))
+        [ProcessFileArgs(
+            inputfile,
+            file_counter,
+            nfiles_str,
+            print_progress,
+            check,
+            inplace,
+            outputfile,
+            false,
+            args.stdin_filename,
+            args.config_dir,
+            format_options,
+            args.diff,
+            args.format_markdown,
+            args.config_priority,
+        ) for (file_counter, inputfile) in enumerate(inputfiles)]
     end
 
     # Use multithreading for multiple files (only if multiple threads available)
@@ -670,8 +231,8 @@ function main(argv::Vector{String})
         # Parallel processing for multiple files
         # Use Threads.Atomic to track errors across threads
         has_error = Threads.Atomic{Bool}(false)
-        Threads.@threads for opts in options_list
-            err = process_file(opts)
+        Threads.@threads for fileargs in fileargs_to_process
+            err = process_file(fileargs)
             if err != 0
                 Threads.atomic_or!(has_error, true)
             end
@@ -681,7 +242,7 @@ function main(argv::Vector{String})
         end
     else
         # Sequential processing
-        for opts in options_list
+        for opts in fileargs_to_process
             err = process_file(opts)
             if err != 0
                 errno = err
@@ -723,7 +284,7 @@ function process_file(args::ProcessFileArgs)
 
     # Build progress message if needed
     progress_prefix = if args.print_progress
-        @assert args.inputfile != "-"
+        @assert !args.input_is_stdin
         input_pretty = relpath(args.inputfile)
         if Sys.iswindows()
             input_pretty = replace(input_pretty, "\\" => "/")
@@ -759,7 +320,7 @@ function process_file(args::ProcessFileArgs)
     end
 
     # Check if we should skip markdown files
-    inputfile_pretty = args.inputfile == "-" ? args.stdin_filename : args.inputfile
+    inputfile_pretty = args.input_is_stdin ? args.stdin_filename : args.inputfile
     _, ext = splitext(inputfile_pretty)
     is_markdown = ext in (".md", ".jmd", ".qmd")
     if is_markdown && haskey(args.format_options, :lines)
@@ -775,8 +336,7 @@ function process_file(args::ProcessFileArgs)
     end
 
     # Read the input
-    sourcetext = if args.inputfile == "-"
-        @assert args.input_is_stdin
+    sourcetext = if args.input_is_stdin
         try
             read(stdin, String)
         catch err
@@ -787,7 +347,6 @@ function process_file(args::ProcessFileArgs)
             return 1
         end
     elseif isfile(args.inputfile)
-        @assert !args.input_is_stdin
         try
             read(args.inputfile, String)
         catch err
@@ -823,7 +382,7 @@ function process_file(args::ProcessFileArgs)
                 errln(io, "✗ invalid output")
             end
             panic(
-                "cannot use same file for input and output, use `-i` to modify a file in place",
+                "cannot use same file for input and output, use `--inplace` to modify a file in place",
             )
             return 1
         else
@@ -831,40 +390,24 @@ function process_file(args::ProcessFileArgs)
         end
     end
 
-    # For files (not stdin), merge with .JuliaFormatter.toml config if it exists
-    # Also merge config if --config-dir is specified for stdin input
-    effective_options = if args.inputfile != "-"
-        # Find and load .JuliaFormatter.toml config
-        config_nt = find_config_file(args.inputfile)
-        config_dict = Dict{Symbol,Any}(Symbol(k) => v for (k, v) in pairs(config_nt))
-        # Merge: by default, command line options override config file
-        # If --prioritize-config-file is set, config file options override command line
-        if args.config_priority
-            merge(args.format_options, config_dict)
-        else
-            merge(config_dict, args.format_options)
-        end
-    elseif args.config_dir != ""
-        # For stdin input with --config-dir specified, use the directory for config lookup
-        config_path = joinpath(args.config_dir, ".JuliaFormatter.toml")
-        config_nt = if isfile(config_path)
-            parse_config(config_path)
-        else
-            # Try to find config file recursively from the directory
-            find_config_file(args.config_dir)
-        end
-        config_dict = Dict{Symbol,Any}(Symbol(k) => v for (k, v) in pairs(config_nt))
-        if args.config_priority
-            merge(args.format_options, config_dict)
-        else
-            merge(config_dict, args.format_options)
-        end
+    # Look up .JuliaFormatter.toml config. --config-dir overrides the default
+    # (which walks up from the input file's directory, or does nothing for stdin).
+    config_nt = if args.config_dir != ""
+        find_config_file(args.config_dir)
+    elseif !args.input_is_stdin
+        find_config_file(args.inputfile)
     else
-        args.format_options
+        (;)
+    end
+    config_dict = Dict{Symbol,Any}(Symbol(k) => v for (k, v) in pairs(config_nt))
+    effective_options = if args.config_priority
+        merge(args.format_options, config_dict)
+    else
+        merge(config_dict, args.format_options)
     end
 
     # Check if file should be ignored (based on .JuliaFormatter.toml ignore patterns)
-    if args.inputfile != "-"
+    if !args.input_is_stdin
         ignore_patterns = get(effective_options, :ignore, String[])
         # Glob.jl only matches paths that have '/' as the pathsep, so we need to normalise
         # to that before matching, otherwise ignore patterns won't work on Windows
@@ -882,12 +425,14 @@ function process_file(args::ProcessFileArgs)
     end
 
     formatted_str = try
-        local formatted_str = if is_markdown
+        _formatted_str = if is_markdown
             format_md(sourcetext; effective_options...)
         else
             format_text(sourcetext; effective_options...)
         end
-        replace(formatted_str, r"\n*$" => "\n")
+        # Since it's a file, presumably we only want one trailing newline, so
+        # we normalise it here.
+        replace(_formatted_str, r"\n*$" => "\n")
     catch err
         if err isa JuliaSyntax.ParseError
             report_status() do io
@@ -956,7 +501,7 @@ function process_file(args::ProcessFileArgs)
         mktempdir() do dir
             a = mkdir(joinpath(dir, "a"))
             b = mkdir(joinpath(dir, "b"))
-            file = basename(args.inputfile == "-" ? args.stdin_filename : args.inputfile)
+            file = basename(inputfile_pretty)
             A = joinpath(a, file)
             B = joinpath(b, file)
             write(A, sourcetext)
@@ -966,6 +511,7 @@ function process_file(args::ProcessFileArgs)
                 Sys.which("git"),
                 "--no-pager",
                 "diff",
+                "--diff-algorithm=patience",
                 "--color=$(color)",
                 "--no-index",
                 "--no-prefix",

--- a/src/argparse.jl
+++ b/src/argparse.jl
@@ -253,6 +253,7 @@ Base.@kwdef struct ParsedArgs
     verbose::Bool = false
     format_markdown::Bool = false
     config_priority::Bool = false
+    ignore_config::Bool = false
     outputfile::Union{String,Nothing} = nothing
     stdin_filename::String = "stdin"
     config_dir::String = ""
@@ -325,6 +326,11 @@ const PARSER = ArgParser(
         ["--prioritize-config-file"];
         dest = :config_priority,
         help = "Prioritize config file options over command-line options.",
+    ),
+    flag(
+        ["--ignore-config"];
+        dest = :ignore_config,
+        help = "Do not use .JuliaFormatter.toml config files.",
     ),
     option(
         "--stdin-filename";
@@ -796,6 +802,16 @@ function parse_args(argv::Vector{String})::ParsedArgs
         StdoutMode
     end
 
+    # --- ignore-config is mutually exclusive with config-related options ---
+    ignore_config = get(raw, :ignore_config, false)
+    config_priority = get(raw, :config_priority, false)
+    if ignore_config && config_priority
+        throw(ParseArgsError("options `--ignore-config` and `--prioritize-config-file` are mutually exclusive"))
+    end
+    if ignore_config && get(raw, :config_dir, "") != ""
+        throw(ParseArgsError("options `--ignore-config` and `--config-dir` are mutually exclusive"))
+    end
+
     # --- Collect format options ---
     format_options = Dict{Symbol,Any}()
     for key in FORMAT_OPTION_KEYS
@@ -811,7 +827,8 @@ function parse_args(argv::Vector{String})::ParsedArgs
         diff = get(raw, :diff, false),
         verbose = get(raw, :verbose, false),
         format_markdown = get(raw, :format_markdown, false),
-        config_priority = get(raw, :config_priority, false),
+        config_priority,
+        ignore_config,
         outputfile = get(raw, :outputfile, nothing),
         stdin_filename = get(raw, :stdin_filename, "stdin"),
         config_dir = get(raw, :config_dir, ""),

--- a/src/argparse.jl
+++ b/src/argparse.jl
@@ -317,34 +317,17 @@ const PARSER = ArgParser(
         help = "File to write formatted output to.",
     ),
     flag(["-v", "--verbose"]; dest = :verbose, help = "Enable verbose output."),
-    flag(
-        ["--format_markdown"];
-        dest = :format_markdown,
-        help = "Also format code blocks in Markdown files.",
-    ),
-    flag(
-        ["--prioritize-config-file"];
-        dest = :config_priority,
-        help = "Prioritize config file options over command-line options.",
-    ),
-    flag(
-        ["--ignore-config"];
-        dest = :ignore_config,
-        help = "Do not use .JuliaFormatter.toml config files.",
-    ),
-    option(
-        "--stdin-filename";
-        dest = :stdin_filename,
-        type = String,
-        metavar = "<name>",
-        help = "Assumed filename when formatting from stdin.",
-    ),
     option(
         "--config-dir";
         dest = :config_dir,
         type = String,
         metavar = "<dir>",
         help = "Directory path for .JuliaFormatter.toml config lookup.",
+    ),
+    flag(
+        ["--format_markdown"];
+        dest = :format_markdown,
+        help = "Also format code blocks in Markdown files.",
     ),
     option(
         "--ignore";
@@ -354,6 +337,11 @@ const PARSER = ArgParser(
         metavar = "<pattern>",
         help = "Ignore files matching the given pattern. Can be repeated.",
     ),
+    flag(
+        ["--ignore-config"];
+        dest = :ignore_config,
+        help = "Do not use .JuliaFormatter.toml config files.",
+    ),
     option(
         "--lines";
         dest = :lines,
@@ -361,6 +349,18 @@ const PARSER = ArgParser(
         multi = true,
         metavar = "<start:stop>",
         help = "Only format the given range of lines. Can be repeated.",
+    ),
+    flag(
+        ["--prioritize-config-file"];
+        dest = :config_priority,
+        help = "Prioritize config file options over command-line options.",
+    ),
+    option(
+        "--stdin-filename";
+        dest = :stdin_filename,
+        type = String,
+        metavar = "<name>",
+        help = "Assumed filename when formatting from stdin.",
     ),
     # --- Formatting options ---
     option(

--- a/src/argparse.jl
+++ b/src/argparse.jl
@@ -51,6 +51,13 @@ function parse_value(::Type{T}, raw::AbstractString, option_name::String) where 
     end
 end
 
+function parse_value(::Type{Union{Nothing,Bool}}, raw::AbstractString, option_name::String)
+    raw == "true" && return true
+    raw == "false" && return false
+    raw == "nothing" && return nothing
+    throw(ParseArgsError("invalid value `$raw` for option `$option_name` (expected `true`, `false`, or `nothing`)"))
+end
+
 # Parse (x, y) where x <= y. Used in --lines.
 function parse_value(::Type{Tuple{Int,Int}}, raw::AbstractString, option_name::String)
     m = match(r"^(\d+):(\d+)$", raw)
@@ -129,6 +136,7 @@ end
 # `names` is a vector of names, e.g. `["-o", "--output"]`.
 _metavar(::Type{Int}) = "<n>"
 _metavar(::Type{Bool}) = "true|false"
+_metavar(::Type{Union{Nothing,Bool}}) = "true|false|nothing"
 _metavar(::Type{String}) = "<value>"
 _metavar(::Type) = "<value>"
 
@@ -252,28 +260,42 @@ end
 
 # All format option keys — these are collected from the raw dict into format_options.
 const FORMAT_OPTION_KEYS = Set{Symbol}([
-    :style,
-    :indent,
-    :margin,
-    :sciml_margin_overrun,
-    :normalize_line_endings,
-    :always_for_in,
-    :whitespace_typedefs,
-    :remove_extra_newlines,
-    :import_to_using,
-    :pipe_to_function_call,
-    :short_to_long_function_def,
-    :always_use_return,
-    :whitespace_in_kwargs,
-    :format_docstrings,
-    :align_struct_field,
     :align_assignment,
     :align_conditional,
+    :align_matrix,
     :align_pair_arrow,
+    :align_struct_field,
+    :always_for_in,
+    :always_use_return,
+    :annotate_untyped_fields_with_any,
+    :conditional_to_if,
+    :disallow_single_arg_nesting,
+    :for_in_replacement,
+    :force_long_function_def,
+    :format_docstrings,
+    :import_to_using,
+    :indent,
+    :indent_submodule,
+    :join_lines_based_on_source,
+    :long_to_short_function_def,
+    :margin,
+    :normalize_line_endings,
+    :pipe_to_function_call,
+    :remove_extra_newlines,
+    :sciml_margin_overrun,
+    :separate_kwargs_with_semicolon,
+    :short_circuit_to_if,
+    :short_to_long_function_def,
+    :style,
+    :surround_whereop_typeparameters,
     :trailing_comma,
     :trailing_zero,
     :v2_stable_multiline_strings,
-    :conditional_to_if,
+    :variable_call_indent,
+    :whitespace_in_kwargs,
+    :whitespace_ops_in_indices,
+    :whitespace_typedefs,
+    :yas_style_nesting,
 ])
 
 const PARSER = ArgParser(
@@ -354,6 +376,13 @@ const PARSER = ArgParser(
         group = FormattingGroup,
     ),
     option(
+        "--align-matrix";
+        dest = :align_matrix,
+        type = Bool,
+        help = "Preserve whitespace alignment of matrix elements.",
+        group = FormattingGroup,
+    ),
+    option(
         "--align-pair-arrow";
         dest = :align_pair_arrow,
         type = Bool,
@@ -370,7 +399,7 @@ const PARSER = ArgParser(
     option(
         "--always-for-in";
         dest = :always_for_in,
-        type = Bool,
+        type = Union{Nothing,Bool},
         help = "Normalise `in` to/from `=` in for loops.",
         group = FormattingGroup,
     ),
@@ -382,10 +411,39 @@ const PARSER = ArgParser(
         group = FormattingGroup,
     ),
     option(
+        "--annotate-untyped-fields-with-any";
+        dest = :annotate_untyped_fields_with_any,
+        type = Bool,
+        help = "Annotate untyped struct fields with '::Any'.",
+        group = FormattingGroup,
+    ),
+    option(
         "--conditional-to-if";
         dest = :conditional_to_if,
         type = Bool,
         help = "Convert ternary expressions to if/else blocks when over margin.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--disallow-single-arg-nesting";
+        dest = :disallow_single_arg_nesting,
+        type = Bool,
+        help = "Prevent nesting of a single argument in parentheses.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--for-in-replacement";
+        dest = :for_in_replacement,
+        type = String,
+        metavar = "in|=|∈",
+        help = "Replacement for `=` in for loops when always_for_in is true.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--force-long-function-def";
+        dest = :force_long_function_def,
+        type = Bool,
+        help = "Force short-to-long function def transformation regardless of length.",
         group = FormattingGroup,
     ),
     option(
@@ -407,6 +465,27 @@ const PARSER = ArgParser(
         dest = :indent,
         type = Int,
         help = "Indentation width.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--indent-submodule";
+        dest = :indent_submodule,
+        type = Bool,
+        help = "Indent submodules appearing in the same file.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--join-lines-based-on-source";
+        dest = :join_lines_based_on_source,
+        type = Bool,
+        help = "Join lines as they appear in the original source file.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--long-to-short-function-def";
+        dest = :long_to_short_function_def,
+        type = Bool,
+        help = "Convert long function definitions to short form.",
         group = FormattingGroup,
     ),
     option(
@@ -446,6 +525,20 @@ const PARSER = ArgParser(
         group = FormattingGroup,
     ),
     option(
+        "--separate-kwargs-with-semicolon";
+        dest = :separate_kwargs_with_semicolon,
+        type = Bool,
+        help = "Separate keyword arguments with a semicolon.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--short-circuit-to-if";
+        dest = :short_circuit_to_if,
+        type = Bool,
+        help = "Convert short-circuit operators to if-expressions.",
+        group = FormattingGroup,
+    ),
+    option(
         "--short-to-long-function-def";
         dest = :short_to_long_function_def,
         type = Bool,
@@ -453,9 +546,16 @@ const PARSER = ArgParser(
         group = FormattingGroup,
     ),
     option(
+        "--surround-whereop-typeparameters";
+        dest = :surround_whereop_typeparameters,
+        type = Bool,
+        help = "Add curly braces around where type parameters.",
+        group = FormattingGroup,
+    ),
+    option(
         "--trailing-comma";
         dest = :trailing_comma,
-        type = Bool,
+        type = Union{Nothing,Bool},
         help = "Add trailing commas.",
         group = FormattingGroup,
     ),
@@ -474,6 +574,15 @@ const PARSER = ArgParser(
         group = FormattingGroup,
     ),
     option(
+        "--variable-call-indent";
+        dest = :variable_call_indent,
+        type = String,
+        multi = true,
+        metavar = "<name>",
+        help = "Allow variable indentation for calls to this function. Can be repeated.",
+        group = FormattingGroup,
+    ),
+    option(
         "--whitespace-in-kwargs";
         dest = :whitespace_in_kwargs,
         type = Bool,
@@ -481,10 +590,24 @@ const PARSER = ArgParser(
         group = FormattingGroup,
     ),
     option(
+        "--whitespace-ops-in-indices";
+        dest = :whitespace_ops_in_indices,
+        type = Bool,
+        help = "Add whitespace around binary operations in indices.",
+        group = FormattingGroup,
+    ),
+    option(
         "--whitespace-typedefs";
         dest = :whitespace_typedefs,
         type = Bool,
         help = "Add whitespace around '::' in type definitions.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--yas-style-nesting";
+        dest = :yas_style_nesting,
+        type = Bool,
+        help = "Use YASStyle nesting rules in SciMLStyle.",
         group = FormattingGroup,
     ),
     # Deprecated options (for backward compatibility)

--- a/src/argparse.jl
+++ b/src/argparse.jl
@@ -1,6 +1,7 @@
 module ArgParse
 
-import ..JuliaFormatter: AbstractStyle, DefaultStyle, BlueStyle, SciMLStyle, YASStyle, MinimalStyle
+import ..JuliaFormatter:
+    AbstractStyle, DefaultStyle, BlueStyle, SciMLStyle, YASStyle, MinimalStyle
 
 struct ParseArgsError <: Exception
     message::String
@@ -54,16 +55,20 @@ end
 function parse_value(::Type{Tuple{Int,Int}}, raw::AbstractString, option_name::String)
     m = match(r"^(\d+):(\d+)$", raw)
     if m === nothing
-        throw(ParseArgsError(
-            "invalid value `$raw` for option `$option_name` (expected `<start>:<stop>` with 1-based line numbers)",
-        ))
+        throw(
+            ParseArgsError(
+                "invalid value `$raw` for option `$option_name` (expected `<start>:<stop>` with 1-based line numbers)",
+            ),
+        )
     end
     start_line = Base.parse(Int, m.captures[1]::AbstractString)
     stop_line = Base.parse(Int, m.captures[2]::AbstractString)
     if start_line > stop_line
-        throw(ParseArgsError(
-            "invalid value `$raw` for option `$option_name`: start is greater than stop",
-        ))
+        throw(
+            ParseArgsError(
+                "invalid value `$raw` for option `$option_name`: start is greater than stop",
+            ),
+        )
     end
     return (start_line, stop_line)
 end
@@ -80,15 +85,27 @@ function parse_value(::Type{AbstractStyle}, raw::AbstractString, option_name::St
     style = get(STYLE_MAP, raw, nothing)
     if style === nothing
         valid = join(sort!(collect(keys(STYLE_MAP))), ", ")
-        throw(ParseArgsError("invalid value `$raw` for option `$option_name` (expected one of: $valid)"))
+        throw(
+            ParseArgsError(
+                "invalid value `$raw` for option `$option_name` (expected one of: $valid)",
+            ),
+        )
     end
     return style
 end
 
 # Flag: `--check` / `-c` sets dest to true.
 function flag(names; dest::Symbol, help::String, group::OptGroup = GeneralGroup)
-    OptSpec(names, help, dest, argv -> (true, @view argv[2:end]), false,
-        FlagKind, group, "")
+    OptSpec(
+        names,
+        help,
+        dest,
+        argv -> (true, @view argv[2:end]),
+        false,
+        FlagKind,
+        group,
+        "",
+    )
 end
 
 # Negatable flag (DEPRECATED): `--always_for_in` / `--no-always_for_in`.
@@ -96,9 +113,15 @@ end
 function negatable_flag(name::String; dest::Symbol)
     pos = "--$name"
     neg = "--no-$name"
-    OptSpec([pos, neg], "", dest,
+    OptSpec(
+        [pos, neg],
+        "",
+        dest,
         argv -> (argv[1] == pos, @view argv[2:end]),
-        false, NegatableFlagKind, DeprecatedGroup, "",
+        false,
+        NegatableFlagKind,
+        DeprecatedGroup,
+        "",
     )
 end
 
@@ -109,21 +132,34 @@ _metavar(::Type{Bool}) = "true|false"
 _metavar(::Type{String}) = "<value>"
 _metavar(::Type) = "<value>"
 
-function option(names; dest::Symbol, type::Type, help::String, multi::Bool = false,
-        group::OptGroup = GeneralGroup, metavar::String = _metavar(type))
-    OptSpec(names, help, dest,
+function option(
+    names;
+    dest::Symbol,
+    type::Type,
+    help::String,
+    multi::Bool = false,
+    group::OptGroup = GeneralGroup,
+    metavar::String = _metavar(type),
+)
+    OptSpec(
+        names,
+        help,
+        dest,
         argv -> begin
             x = argv[1]
             eq = findfirst('=', x)
             if eq !== nothing
-                raw = x[eq+1:end]
+                raw = x[(eq+1):end]
                 (parse_value(type, raw, x), @view argv[2:end])
             else
                 length(argv) < 2 && throw(ParseArgsError("expected value after `$x`"))
                 (parse_value(type, argv[2], x), @view argv[3:end])
             end
         end,
-        multi, OptionKind, group, metavar,
+        multi,
+        OptionKind,
+        group,
+        metavar,
     )
 end
 
@@ -216,91 +252,256 @@ end
 
 # All format option keys — these are collected from the raw dict into format_options.
 const FORMAT_OPTION_KEYS = Set{Symbol}([
-    :style, :indent, :margin, :sciml_margin_overrun, :normalize_line_endings,
-    :always_for_in, :whitespace_typedefs, :remove_extra_newlines,
-    :import_to_using, :pipe_to_function_call, :short_to_long_function_def,
-    :always_use_return, :whitespace_in_kwargs, :format_docstrings,
-    :align_struct_field, :align_assignment, :align_conditional, :align_pair_arrow,
-    :trailing_comma, :trailing_zero, :v2_stable_multiline_strings, :conditional_to_if,
+    :style,
+    :indent,
+    :margin,
+    :sciml_margin_overrun,
+    :normalize_line_endings,
+    :always_for_in,
+    :whitespace_typedefs,
+    :remove_extra_newlines,
+    :import_to_using,
+    :pipe_to_function_call,
+    :short_to_long_function_def,
+    :always_use_return,
+    :whitespace_in_kwargs,
+    :format_docstrings,
+    :align_struct_field,
+    :align_assignment,
+    :align_conditional,
+    :align_pair_arrow,
+    :trailing_comma,
+    :trailing_zero,
+    :v2_stable_multiline_strings,
+    :conditional_to_if,
 ])
 
 const PARSER = ArgParser(
-    flag(["-h", "--help"]; dest = :help,
-        help = "Print this message."),
-    flag(["--version"]; dest = :version,
-        help = "Print version information."),
-    flag(["-c", "--check"]; dest = :check,
-        help = "Check formatting without writing."),
-    flag(["-i", "--inplace"]; dest = :inplace,
-        help = "Format files in place."),
-    flag(["-d", "--diff"]; dest = :diff,
-        help = "Print diff to stderr."),
-    option(["-o", "--output"]; dest = :outputfile, type = String, metavar = "<file>",
-        help = "File to write formatted output to."),
-    flag(["-v", "--verbose"]; dest = :verbose,
-        help = "Enable verbose output."),
-    flag(["--format_markdown"]; dest = :format_markdown,
-        help = "Also format code blocks in Markdown files."),
-    flag(["--prioritize-config-file"]; dest = :config_priority,
-        help = "Prioritize config file options over command-line options."),
-    option("--stdin-filename"; dest = :stdin_filename, type = String, metavar = "<name>",
-        help = "Assumed filename when formatting from stdin."),
-    option("--config-dir"; dest = :config_dir, type = String, metavar = "<dir>",
-        help = "Directory path for .JuliaFormatter.toml config lookup."),
-    option("--ignore"; dest = :ignore, type = String, multi = true, metavar = "<pattern>",
-        help = "Ignore files matching the given pattern. Can be repeated."),
-    option("--lines"; dest = :lines, type = Tuple{Int,Int}, multi = true, metavar = "<start:stop>",
-        help = "Only format the given range of lines. Can be repeated."),
+    flag(["-h", "--help"]; dest = :help, help = "Print this message."),
+    flag(["--version"]; dest = :version, help = "Print version information."),
+    flag(["-c", "--check"]; dest = :check, help = "Check formatting without writing."),
+    flag(["-i", "--inplace"]; dest = :inplace, help = "Format files in place."),
+    flag(["-d", "--diff"]; dest = :diff, help = "Print diff to stderr."),
+    option(
+        ["-o", "--output"];
+        dest = :outputfile,
+        type = String,
+        metavar = "<file>",
+        help = "File to write formatted output to.",
+    ),
+    flag(["-v", "--verbose"]; dest = :verbose, help = "Enable verbose output."),
+    flag(
+        ["--format_markdown"];
+        dest = :format_markdown,
+        help = "Also format code blocks in Markdown files.",
+    ),
+    flag(
+        ["--prioritize-config-file"];
+        dest = :config_priority,
+        help = "Prioritize config file options over command-line options.",
+    ),
+    option(
+        "--stdin-filename";
+        dest = :stdin_filename,
+        type = String,
+        metavar = "<name>",
+        help = "Assumed filename when formatting from stdin.",
+    ),
+    option(
+        "--config-dir";
+        dest = :config_dir,
+        type = String,
+        metavar = "<dir>",
+        help = "Directory path for .JuliaFormatter.toml config lookup.",
+    ),
+    option(
+        "--ignore";
+        dest = :ignore,
+        type = String,
+        multi = true,
+        metavar = "<pattern>",
+        help = "Ignore files matching the given pattern. Can be repeated.",
+    ),
+    option(
+        "--lines";
+        dest = :lines,
+        type = Tuple{Int,Int},
+        multi = true,
+        metavar = "<start:stop>",
+        help = "Only format the given range of lines. Can be repeated.",
+    ),
     # --- Formatting options ---
-    option("--style"; dest = :style, type = AbstractStyle, metavar = "default|blue|sciml|yas|minimal",
-        help = "Formatting style.", group = FormattingGroup),
-    option("--align-assignment"; dest = :align_assignment, type = Bool,
-        help = "Align assignment operators.", group = FormattingGroup),
-    option("--align-conditional"; dest = :align_conditional, type = Bool,
-        help = "Align conditional operators.", group = FormattingGroup),
-    option("--align-pair-arrow"; dest = :align_pair_arrow, type = Bool,
-        help = "Align pair arrows (=>).", group = FormattingGroup),
-    option("--align-struct-field"; dest = :align_struct_field, type = Bool,
-        help = "Align struct field type annotations.", group = FormattingGroup),
-    option("--always-for-in"; dest = :always_for_in, type = Bool,
-        help = "Normalise `in` to/from `=` in for loops.", group = FormattingGroup),
-    option("--always-use-return"; dest = :always_use_return, type = Bool,
-        help = "Add explicit 'return' statements to function definitions.", group = FormattingGroup),
-    option("--conditional-to-if"; dest = :conditional_to_if, type = Bool,
-        help = "Convert ternary expressions to if/else blocks when over margin.", group = FormattingGroup),
-    option("--format-docstrings"; dest = :format_docstrings, type = Bool,
-        help = "Format docstrings.", group = FormattingGroup),
-    option("--import-to-using"; dest = :import_to_using, type = Bool,
-        help = "Convert 'import' to 'using'.", group = FormattingGroup),
-    option("--indent"; dest = :indent, type = Int,
-        help = "Indentation width.", group = FormattingGroup),
-    option("--margin"; dest = :margin, type = Int,
-        help = "Maximum line width.", group = FormattingGroup),
-    option("--normalize-line-endings"; dest = :normalize_line_endings, type = String, metavar = "auto|unix|windows",
-        help = "Normalize line endings.", group = FormattingGroup),
-    option("--pipe-to-function-call"; dest = :pipe_to_function_call, type = Bool,
-        help = "Convert pipe operator to function calls.", group = FormattingGroup),
-    option("--remove-extra-newlines"; dest = :remove_extra_newlines, type = Bool,
-        help = "Remove extra newlines.", group = FormattingGroup),
-    option("--sciml-margin-overrun"; dest = :sciml_margin_overrun, type = Int,
-        help = "Additional columns SciMLStyle may use.", group = FormattingGroup),
-    option("--short-to-long-function-def"; dest = :short_to_long_function_def, type = Bool,
-        help = "Convert short function definitions to long form.", group = FormattingGroup),
-    option("--trailing-comma"; dest = :trailing_comma, type = Bool,
-        help = "Add trailing commas.", group = FormattingGroup),
-    option("--trailing-zero"; dest = :trailing_zero, type = Bool,
-        help = "Add trailing zeros to floats.", group = FormattingGroup),
-    option("--v2-stable-multiline-strings"; dest = :v2_stable_multiline_strings, type = Bool,
-        help = "Use stable multiline string length calculation.", group = FormattingGroup),
-    option("--whitespace-in-kwargs"; dest = :whitespace_in_kwargs, type = Bool,
-        help = "Add whitespace in keyword arguments.", group = FormattingGroup),
-    option("--whitespace-typedefs"; dest = :whitespace_typedefs, type = Bool,
-        help = "Add whitespace around '::' in type definitions.", group = FormattingGroup),
+    option(
+        "--style";
+        dest = :style,
+        type = AbstractStyle,
+        metavar = "default|blue|sciml|yas|minimal",
+        help = "Formatting style.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--align-assignment";
+        dest = :align_assignment,
+        type = Bool,
+        help = "Align assignment operators.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--align-conditional";
+        dest = :align_conditional,
+        type = Bool,
+        help = "Align conditional operators.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--align-pair-arrow";
+        dest = :align_pair_arrow,
+        type = Bool,
+        help = "Align pair arrows (=>).",
+        group = FormattingGroup,
+    ),
+    option(
+        "--align-struct-field";
+        dest = :align_struct_field,
+        type = Bool,
+        help = "Align struct field type annotations.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--always-for-in";
+        dest = :always_for_in,
+        type = Bool,
+        help = "Normalise `in` to/from `=` in for loops.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--always-use-return";
+        dest = :always_use_return,
+        type = Bool,
+        help = "Add explicit 'return' statements to function definitions.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--conditional-to-if";
+        dest = :conditional_to_if,
+        type = Bool,
+        help = "Convert ternary expressions to if/else blocks when over margin.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--format-docstrings";
+        dest = :format_docstrings,
+        type = Bool,
+        help = "Format docstrings.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--import-to-using";
+        dest = :import_to_using,
+        type = Bool,
+        help = "Convert 'import' to 'using'.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--indent";
+        dest = :indent,
+        type = Int,
+        help = "Indentation width.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--margin";
+        dest = :margin,
+        type = Int,
+        help = "Maximum line width.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--normalize-line-endings";
+        dest = :normalize_line_endings,
+        type = String,
+        metavar = "auto|unix|windows",
+        help = "Normalize line endings.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--pipe-to-function-call";
+        dest = :pipe_to_function_call,
+        type = Bool,
+        help = "Convert pipe operator to function calls.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--remove-extra-newlines";
+        dest = :remove_extra_newlines,
+        type = Bool,
+        help = "Remove extra newlines.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--sciml-margin-overrun";
+        dest = :sciml_margin_overrun,
+        type = Int,
+        help = "Additional columns SciMLStyle may use.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--short-to-long-function-def";
+        dest = :short_to_long_function_def,
+        type = Bool,
+        help = "Convert short function definitions to long form.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--trailing-comma";
+        dest = :trailing_comma,
+        type = Bool,
+        help = "Add trailing commas.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--trailing-zero";
+        dest = :trailing_zero,
+        type = Bool,
+        help = "Add trailing zeros to floats.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--v2-stable-multiline-strings";
+        dest = :v2_stable_multiline_strings,
+        type = Bool,
+        help = "Use stable multiline string length calculation.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--whitespace-in-kwargs";
+        dest = :whitespace_in_kwargs,
+        type = Bool,
+        help = "Add whitespace in keyword arguments.",
+        group = FormattingGroup,
+    ),
+    option(
+        "--whitespace-typedefs";
+        dest = :whitespace_typedefs,
+        type = Bool,
+        help = "Add whitespace around '::' in type definitions.",
+        group = FormattingGroup,
+    ),
     # Deprecated options (for backward compatibility)
-    option("--sciml_margin_overrun"; dest = :sciml_margin_overrun, type = Int,
-        help = "", group = DeprecatedGroup),
-    option("--normalize_line_endings"; dest = :normalize_line_endings, type = String,
-        help = "", group = DeprecatedGroup),
+    option(
+        "--sciml_margin_overrun";
+        dest = :sciml_margin_overrun,
+        type = Int,
+        help = "",
+        group = DeprecatedGroup,
+    ),
+    option(
+        "--normalize_line_endings";
+        dest = :normalize_line_endings,
+        type = String,
+        help = "",
+        group = DeprecatedGroup,
+    ),
     negatable_flag("always_for_in"; dest = :always_for_in),
     negatable_flag("whitespace_typedefs"; dest = :whitespace_typedefs),
     negatable_flag("remove_extra_newlines"; dest = :remove_extra_newlines),
@@ -330,48 +531,60 @@ function print_help(parser::ArgParser; io::IO = stdout)
     println(io, "       jlfmt - An opinionated code formatter for Julia\n")
 
     section("SYNOPSIS")
-    println(io, """
-               jlfmt [<julia_options> --] [<options>] <path>...
-               jlfmt [<julia_options> --] [<options>] -
-               ... | jlfmt [<julia_options> --] [<options>]
+    println(
+        io,
+        """
+       jlfmt [<julia_options> --] [<options>] <path>...
+       jlfmt [<julia_options> --] [<options>] -
+       ... | jlfmt [<julia_options> --] [<options>]
 
-               where <julia_options> are options passed to the Julia
-               interpreter (e.g. --threads=auto), and <options> are
-               options for JuliaFormatter.
-        """)
+       where <julia_options> are options passed to the Julia
+       interpreter (e.g. --threads=auto), and <options> are
+       options for JuliaFormatter.
+""",
+    )
 
     section("DESCRIPTION")
-    println(io, """
-               `jlfmt` formats Julia source code using JuliaFormatter.jl.
-               This tool can also be invoked as `julia -m JuliaFormatter`.
-        """)
+    println(
+        io,
+        """
+       `jlfmt` formats Julia source code using JuliaFormatter.jl.
+       This tool can also be invoked as `julia -m JuliaFormatter`.
+""",
+    )
 
     section("OPTIONS")
-    println(io, """
-               <path>...
-                   Input path(s) (files and/or directories) to process. For directories,
-                   all files (recursively) with the '*.jl' suffix are used as input files
-                   (also '*.md', '*.jmd', '*.qmd' if --format-markdown is specified).
-                   If no path is given, or if path is `-`, input is read from stdin.
-        """)
+    println(
+        io,
+        """
+       <path>...
+           Input path(s) (files and/or directories) to process. For directories,
+           all files (recursively) with the '*.jl' suffix are used as input files
+           (also '*.md', '*.jmd', '*.qmd' if --format-markdown is specified).
+           If no path is given, or if path is `-`, input is read from stdin.
+""",
+    )
 
     for group in instances(OptGroup)
         group == DeprecatedGroup && continue
         if group == FormattingGroup
             section("FORMATTING OPTIONS")
-            println(io, """
-                   These options control the formatting style. They can also be set in
-                   a `.JuliaFormatter.toml` config file.
+            println(
+                io,
+                """
+           These options control the formatting style. They can also be set in
+           a `.JuliaFormatter.toml` config file.
 
-                   Note that options are merged from the config file and command-line
-                   arguments. If the same option is specified both a config file and
-                   command-line options are specified, the CLI arguments take priority
-                   by default. With `--prioritize-config-file`, the config file takes
-                   priority instead.
+           Note that options are merged from the config file and command-line
+           arguments. If the same option is specified both a config file and
+           command-line options are specified, the CLI arguments take priority
+           by default. With `--prioritize-config-file`, the config file takes
+           priority instead.
 
-                   If the same option is specified multiple times on the command line,
-                   the last value is used.
-            """)
+           If the same option is specified multiple times on the command line,
+           the last value is used.
+    """,
+            )
         end
         for spec in parser.specs
             spec.group != group && continue
@@ -389,43 +602,46 @@ function print_help(parser::ArgParser; io::IO = stdout)
     end
 
     section("EXAMPLES")
-    println(io, """
-               Format a file and write to stdout:
-                   jlfmt src/file.jl
+    println(
+        io,
+        """
+       Format a file and write to stdout:
+           jlfmt src/file.jl
 
-               Format a file in place:
-                   jlfmt --inplace src/file.jl
+       Format a file in place:
+           jlfmt --inplace src/file.jl
 
-               Format all files in a directory with the verbose mode:
-                   jlfmt --inplace --verbose src/
+       Format all files in a directory with the verbose mode:
+           jlfmt --inplace --verbose src/
 
-               Check if a file is formatted:
-                   jlfmt --check src/file.jl
+       Check if a file is formatted:
+           jlfmt --check src/file.jl
 
-               Format only lines 1-10 and 42-47 of a file:
-                   jlfmt --lines=1:10 --lines=42:47 src/file.jl
+       Format only lines 1-10 and 42-47 of a file:
+           jlfmt --lines=1:10 --lines=42:47 src/file.jl
 
-               Check if all files in a directory are formatted with multiple threads:
-                   jlfmt --threads=4 -- --check src/
+       Check if all files in a directory are formatted with multiple threads:
+           jlfmt --threads=4 -- --check src/
 
-               Show diff for formatting with 2-space indentations:
-                   jlfmt --diff --indent=2 src/file.jl
+       Show diff for formatting with 2-space indentations:
+           jlfmt --diff --indent=2 src/file.jl
 
-               Format from stdin (pipe):
-                   echo 'f(x,y)=x+y' | jlfmt
+       Format from stdin (pipe):
+           echo 'f(x,y)=x+y' | jlfmt
 
-               Format from stdin (explicit):
-                   jlfmt - < input.jl
+       Format from stdin (explicit):
+           jlfmt - < input.jl
 
-               Format from stdin using project config:
-                   echo 'f(x,y)=x+y' | jlfmt --config-dir=./src
+       Format from stdin using project config:
+           echo 'f(x,y)=x+y' | jlfmt --config-dir=./src
 
-               Use specific style:
-                   jlfmt --style=blue src/file.jl
+       Use specific style:
+           jlfmt --style=blue src/file.jl
 
-               Combine options:
-                   echo 'for i=1:10; end' | jlfmt --always-for-in=true
-        """)
+       Combine options:
+           echo 'for i=1:10; end' | jlfmt --always-for-in=true
+""",
+    )
     return
 end
 

--- a/src/argparse.jl
+++ b/src/argparse.jl
@@ -55,7 +55,11 @@ function parse_value(::Type{Union{Nothing,Bool}}, raw::AbstractString, option_na
     raw == "true" && return true
     raw == "false" && return false
     raw == "nothing" && return nothing
-    throw(ParseArgsError("invalid value `$raw` for option `$option_name` (expected `true`, `false`, or `nothing`)"))
+    throw(
+        ParseArgsError(
+            "invalid value `$raw` for option `$option_name` (expected `true`, `false`, or `nothing`)",
+        ),
+    )
 end
 
 # Parse (x, y) where x <= y. Used in --lines.

--- a/src/argparse.jl
+++ b/src/argparse.jl
@@ -8,7 +8,7 @@ end
 
 # Enums that are attached to OptSpec that are used purely for help text rendering.
 @enum OptKind FlagKind OptionKind NegatableFlagKind
-@enum OptGroup GeneralGroup FormattingGroup
+@enum OptGroup GeneralGroup FormattingGroup DeprecatedGroup
 
 """
     OptionSpec
@@ -91,21 +91,26 @@ function flag(names; dest::Symbol, help::String, group::OptGroup = GeneralGroup)
         FlagKind, group, "")
 end
 
-# Negatable flag: `--always_for_in` sets dest to true, `--no-always_for_in` sets it to
-# false. The `name` argument is the bare name without `--` prefix, e.g. `"always_for_in"`.
-function negatable_flag(name::String; dest::Symbol, help::String, group::OptGroup = GeneralGroup)
+# Negatable flag (DEPRECATED): `--always_for_in` / `--no-always_for_in`.
+# Deprecated in favour of `--always-for-in=true` / `--always-for-in=false`.
+function negatable_flag(name::String; dest::Symbol)
     pos = "--$name"
     neg = "--no-$name"
-    OptSpec([pos, neg], help, dest,
+    OptSpec([pos, neg], "", dest,
         argv -> (argv[1] == pos, @view argv[2:end]),
-        false, NegatableFlagKind, group, "",
+        false, NegatableFlagKind, DeprecatedGroup, "",
     )
 end
 
 # Option with a value: `--margin=92` or `--margin 92` or `-o file`.
 # `names` is a vector of names, e.g. `["-o", "--output"]`.
+_metavar(::Type{Int}) = "<n>"
+_metavar(::Type{Bool}) = "true|false"
+_metavar(::Type{String}) = "<value>"
+_metavar(::Type) = "<value>"
+
 function option(names; dest::Symbol, type::Type, help::String, multi::Bool = false,
-        group::OptGroup = GeneralGroup, metavar::String = "<value>")
+        group::OptGroup = GeneralGroup, metavar::String = _metavar(type))
     OptSpec(names, help, dest,
         argv -> begin
             x = argv[1]
@@ -162,6 +167,11 @@ function parse_raw(parser::ArgParser, argv::Vector{String})
         token = first(remaining)
         spec = maybe_get_spec(parser, token)
         if spec !== nothing
+            if spec.group == DeprecatedGroup
+                @warn """Options with underscores (e.g. `--always_for_in`) are deprecated \
+                    and will be removed in a future version. \
+                    Use hyphens instead (e.g. `--always-for-in=true`).""" maxlog = 1
+            end
             value, remaining = spec.consume(remaining)
             if spec.multi
                 # append
@@ -244,48 +254,70 @@ const PARSER = ArgParser(
     # --- Formatting options ---
     option("--style"; dest = :style, type = AbstractStyle, metavar = "default|blue|sciml|yas|minimal",
         help = "Formatting style.", group = FormattingGroup),
-    option("--indent"; dest = :indent, type = Int, metavar = "<n>",
-        help = "Indentation width.", group = FormattingGroup),
-    option("--margin"; dest = :margin, type = Int, metavar = "<n>",
-        help = "Maximum line width.", group = FormattingGroup),
-    option("--sciml_margin_overrun"; dest = :sciml_margin_overrun, type = Int, metavar = "<n>",
-        help = "Additional columns SciMLStyle may use.", group = FormattingGroup),
-    option("--normalize_line_endings"; dest = :normalize_line_endings, type = String, metavar = "auto|unix|windows",
-        help = "Normalize line endings.", group = FormattingGroup),
-    negatable_flag("always_for_in"; dest = :always_for_in,
-        help = "Always use 'for x in' instead of 'for x ='.", group = FormattingGroup),
-    negatable_flag("whitespace_typedefs"; dest = :whitespace_typedefs,
-        help = "Add whitespace around '::' in type definitions.", group = FormattingGroup),
-    negatable_flag("remove_extra_newlines"; dest = :remove_extra_newlines,
-        help = "Remove extra newlines.", group = FormattingGroup),
-    negatable_flag("import_to_using"; dest = :import_to_using,
-        help = "Convert 'import' to 'using'.", group = FormattingGroup),
-    negatable_flag("pipe_to_function_call"; dest = :pipe_to_function_call,
-        help = "Convert pipe operator to function calls.", group = FormattingGroup),
-    negatable_flag("short_to_long_function_def"; dest = :short_to_long_function_def,
-        help = "Convert short function definitions to long form.", group = FormattingGroup),
-    negatable_flag("always_use_return"; dest = :always_use_return,
-        help = "Always add explicit 'return' statements.", group = FormattingGroup),
-    negatable_flag("whitespace_in_kwargs"; dest = :whitespace_in_kwargs,
-        help = "Add whitespace in keyword arguments.", group = FormattingGroup),
-    negatable_flag("format_docstrings"; dest = :format_docstrings,
-        help = "Format docstrings.", group = FormattingGroup),
-    negatable_flag("align_struct_field"; dest = :align_struct_field,
-        help = "Align struct field type annotations.", group = FormattingGroup),
-    negatable_flag("align_assignment"; dest = :align_assignment,
+    option("--align-assignment"; dest = :align_assignment, type = Bool,
         help = "Align assignment operators.", group = FormattingGroup),
-    negatable_flag("align_conditional"; dest = :align_conditional,
+    option("--align-conditional"; dest = :align_conditional, type = Bool,
         help = "Align conditional operators.", group = FormattingGroup),
-    negatable_flag("align_pair_arrow"; dest = :align_pair_arrow,
+    option("--align-pair-arrow"; dest = :align_pair_arrow, type = Bool,
         help = "Align pair arrows (=>).", group = FormattingGroup),
-    negatable_flag("trailing_comma"; dest = :trailing_comma,
+    option("--align-struct-field"; dest = :align_struct_field, type = Bool,
+        help = "Align struct field type annotations.", group = FormattingGroup),
+    option("--always-for-in"; dest = :always_for_in, type = Bool,
+        help = "Normalise `in` to/from `=` in for loops.", group = FormattingGroup),
+    option("--always-use-return"; dest = :always_use_return, type = Bool,
+        help = "Add explicit 'return' statements to function definitions.", group = FormattingGroup),
+    option("--conditional-to-if"; dest = :conditional_to_if, type = Bool,
+        help = "Convert ternary expressions to if/else blocks when over margin.", group = FormattingGroup),
+    option("--format-docstrings"; dest = :format_docstrings, type = Bool,
+        help = "Format docstrings.", group = FormattingGroup),
+    option("--import-to-using"; dest = :import_to_using, type = Bool,
+        help = "Convert 'import' to 'using'.", group = FormattingGroup),
+    option("--indent"; dest = :indent, type = Int,
+        help = "Indentation width.", group = FormattingGroup),
+    option("--margin"; dest = :margin, type = Int,
+        help = "Maximum line width.", group = FormattingGroup),
+    option("--normalize-line-endings"; dest = :normalize_line_endings, type = String, metavar = "auto|unix|windows",
+        help = "Normalize line endings.", group = FormattingGroup),
+    option("--pipe-to-function-call"; dest = :pipe_to_function_call, type = Bool,
+        help = "Convert pipe operator to function calls.", group = FormattingGroup),
+    option("--remove-extra-newlines"; dest = :remove_extra_newlines, type = Bool,
+        help = "Remove extra newlines.", group = FormattingGroup),
+    option("--sciml-margin-overrun"; dest = :sciml_margin_overrun, type = Int,
+        help = "Additional columns SciMLStyle may use.", group = FormattingGroup),
+    option("--short-to-long-function-def"; dest = :short_to_long_function_def, type = Bool,
+        help = "Convert short function definitions to long form.", group = FormattingGroup),
+    option("--trailing-comma"; dest = :trailing_comma, type = Bool,
         help = "Add trailing commas.", group = FormattingGroup),
-    negatable_flag("trailing_zero"; dest = :trailing_zero,
+    option("--trailing-zero"; dest = :trailing_zero, type = Bool,
         help = "Add trailing zeros to floats.", group = FormattingGroup),
-    negatable_flag("v2_stable_multiline_strings"; dest = :v2_stable_multiline_strings,
+    option("--v2-stable-multiline-strings"; dest = :v2_stable_multiline_strings, type = Bool,
         help = "Use stable multiline string length calculation.", group = FormattingGroup),
-    negatable_flag("conditional_to_if"; dest = :conditional_to_if,
-        help = "Convert ternary conditional expressions to if/else blocks.", group = FormattingGroup),
+    option("--whitespace-in-kwargs"; dest = :whitespace_in_kwargs, type = Bool,
+        help = "Add whitespace in keyword arguments.", group = FormattingGroup),
+    option("--whitespace-typedefs"; dest = :whitespace_typedefs, type = Bool,
+        help = "Add whitespace around '::' in type definitions.", group = FormattingGroup),
+    # Deprecated options (for backward compatibility)
+    option("--sciml_margin_overrun"; dest = :sciml_margin_overrun, type = Int,
+        help = "", group = DeprecatedGroup),
+    option("--normalize_line_endings"; dest = :normalize_line_endings, type = String,
+        help = "", group = DeprecatedGroup),
+    negatable_flag("always_for_in"; dest = :always_for_in),
+    negatable_flag("whitespace_typedefs"; dest = :whitespace_typedefs),
+    negatable_flag("remove_extra_newlines"; dest = :remove_extra_newlines),
+    negatable_flag("import_to_using"; dest = :import_to_using),
+    negatable_flag("pipe_to_function_call"; dest = :pipe_to_function_call),
+    negatable_flag("short_to_long_function_def"; dest = :short_to_long_function_def),
+    negatable_flag("always_use_return"; dest = :always_use_return),
+    negatable_flag("whitespace_in_kwargs"; dest = :whitespace_in_kwargs),
+    negatable_flag("format_docstrings"; dest = :format_docstrings),
+    negatable_flag("align_struct_field"; dest = :align_struct_field),
+    negatable_flag("align_assignment"; dest = :align_assignment),
+    negatable_flag("align_conditional"; dest = :align_conditional),
+    negatable_flag("align_pair_arrow"; dest = :align_pair_arrow),
+    negatable_flag("trailing_comma"; dest = :trailing_comma),
+    negatable_flag("trailing_zero"; dest = :trailing_zero),
+    negatable_flag("v2_stable_multiline_strings"; dest = :v2_stable_multiline_strings),
+    negatable_flag("conditional_to_if"; dest = :conditional_to_if),
 )
 
 function print_help(parser::ArgParser; io::IO = stdout)
@@ -324,6 +356,7 @@ function print_help(parser::ArgParser; io::IO = stdout)
         """)
 
     for group in instances(OptGroup)
+        group == DeprecatedGroup && continue
         if group == FormattingGroup
             section("FORMATTING OPTIONS")
             println(io, """
@@ -391,7 +424,7 @@ function print_help(parser::ArgParser; io::IO = stdout)
                    jlfmt --style=blue src/file.jl
 
                Combine options:
-                   echo 'for i=1:10; end' | jlfmt --always_for_in
+                   echo 'for i=1:10; end' | jlfmt --always-for-in=true
         """)
     return
 end

--- a/src/argparse.jl
+++ b/src/argparse.jl
@@ -806,10 +806,18 @@ function parse_args(argv::Vector{String})::ParsedArgs
     ignore_config = get(raw, :ignore_config, false)
     config_priority = get(raw, :config_priority, false)
     if ignore_config && config_priority
-        throw(ParseArgsError("options `--ignore-config` and `--prioritize-config-file` are mutually exclusive"))
+        throw(
+            ParseArgsError(
+                "options `--ignore-config` and `--prioritize-config-file` are mutually exclusive",
+            ),
+        )
     end
     if ignore_config && get(raw, :config_dir, "") != ""
-        throw(ParseArgsError("options `--ignore-config` and `--config-dir` are mutually exclusive"))
+        throw(
+            ParseArgsError(
+                "options `--ignore-config` and `--config-dir` are mutually exclusive",
+            ),
+        )
     end
 
     # --- Collect format options ---

--- a/src/argparse.jl
+++ b/src/argparse.jl
@@ -1,0 +1,449 @@
+module ArgParse
+
+import ..JuliaFormatter: AbstractStyle, DefaultStyle, BlueStyle, SciMLStyle, YASStyle, MinimalStyle
+
+struct ParseArgsError <: Exception
+    message::String
+end
+
+# Enums that are attached to OptSpec that are used purely for help text rendering.
+@enum OptKind FlagKind OptionKind NegatableFlagKind
+@enum OptGroup GeneralGroup FormattingGroup
+
+"""
+    OptionSpec
+
+A declarative (ish) specification of a command-line option, designed to mimic
+Haskell's `optparse-applicative`.
+
+These, combined with the actual arguments, are parsed into a `Dict{Symbol,Any}`.
+"""
+struct OptSpec
+    "The prefixes that trigger this option, e.g. `-c` or `--check`."
+    names::Vector{String}
+    "Help text"
+    help::String
+    "The key in the result dictionary where the parsed value will be stored."
+    dest::Symbol
+    "A function that consumes the option from the argument list. Takes the remaining
+    arguments (starting with the matched token) and returns `(value, rest)`."
+    consume::Function
+    "If true, values are collected into a vector instead of overwriting."
+    multi::Bool
+    "What kind of option this is, for help text rendering."
+    kind::OptKind
+    "Group for help text output. Options with the same group are displayed together."
+    group::OptGroup
+    "Placeholder for the value in help text, e.g. `<n>` or `<file>`."
+    metavar::String
+end
+
+# --- Combinators for building specs ---
+
+# Generic value parser.
+function parse_value(::Type{T}, raw::AbstractString, option_name::String) where {T}
+    T <: AbstractString && return raw
+    try
+        return Base.parse(T, raw)
+    catch
+        throw(ParseArgsError("invalid value `$raw` for option `$option_name`"))
+    end
+end
+
+# Parse (x, y) where x <= y. Used in --lines.
+function parse_value(::Type{Tuple{Int,Int}}, raw::AbstractString, option_name::String)
+    m = match(r"^(\d+):(\d+)$", raw)
+    if m === nothing
+        throw(ParseArgsError(
+            "invalid value `$raw` for option `$option_name` (expected `<start>:<stop>` with 1-based line numbers)",
+        ))
+    end
+    start_line = Base.parse(Int, m.captures[1]::AbstractString)
+    stop_line = Base.parse(Int, m.captures[2]::AbstractString)
+    if start_line > stop_line
+        throw(ParseArgsError(
+            "invalid value `$raw` for option `$option_name`: start is greater than stop",
+        ))
+    end
+    return (start_line, stop_line)
+end
+
+# Parse styles.
+const STYLE_MAP = Dict{String,AbstractStyle}(
+    "default" => DefaultStyle(),
+    "yas" => YASStyle(),
+    "blue" => BlueStyle(),
+    "sciml" => SciMLStyle(),
+    "minimal" => MinimalStyle(),
+)
+function parse_value(::Type{AbstractStyle}, raw::AbstractString, option_name::String)
+    style = get(STYLE_MAP, raw, nothing)
+    if style === nothing
+        valid = join(sort!(collect(keys(STYLE_MAP))), ", ")
+        throw(ParseArgsError("invalid value `$raw` for option `$option_name` (expected one of: $valid)"))
+    end
+    return style
+end
+
+# Flag: `--check` / `-c` sets dest to true.
+function flag(names; dest::Symbol, help::String, group::OptGroup = GeneralGroup)
+    OptSpec(names, help, dest, argv -> (true, @view argv[2:end]), false,
+        FlagKind, group, "")
+end
+
+# Negatable flag: `--always_for_in` sets dest to true, `--no-always_for_in` sets it to
+# false. The `name` argument is the bare name without `--` prefix, e.g. `"always_for_in"`.
+function negatable_flag(name::String; dest::Symbol, help::String, group::OptGroup = GeneralGroup)
+    pos = "--$name"
+    neg = "--no-$name"
+    OptSpec([pos, neg], help, dest,
+        argv -> (argv[1] == pos, @view argv[2:end]),
+        false, NegatableFlagKind, group, "",
+    )
+end
+
+# Option with a value: `--margin=92` or `--margin 92` or `-o file`.
+# `names` is a vector of names, e.g. `["-o", "--output"]`.
+function option(names; dest::Symbol, type::Type, help::String, multi::Bool = false,
+        group::OptGroup = GeneralGroup, metavar::String = "<value>")
+    OptSpec(names, help, dest,
+        argv -> begin
+            x = argv[1]
+            eq = findfirst('=', x)
+            if eq !== nothing
+                raw = x[eq+1:end]
+                (parse_value(type, raw, x), @view argv[2:end])
+            else
+                length(argv) < 2 && throw(ParseArgsError("expected value after `$x`"))
+                (parse_value(type, argv[2], x), @view argv[3:end])
+            end
+        end,
+        multi, OptionKind, group, metavar,
+    )
+end
+
+option(name::String; kw...) = option([name]; kw...)
+
+# --- The parser: a list of specs ---
+
+struct ArgParser
+    specs::Vector{OptSpec}
+    # Map from option name to index in `specs` for fast lookup.
+    index::Dict{String,Int}
+
+    function ArgParser(specs::OptSpec...)
+        index = Dict{String,Int}()
+        for (i, spec) in enumerate(specs)
+            for name in spec.names
+                haskey(index, name) && throw(ArgumentError("duplicate option name `$name`"))
+                index[name] = i
+            end
+        end
+        new(collect(specs), index)
+    end
+end
+
+function maybe_get_spec(parser::ArgParser, token::String)::Union{OptSpec,Nothing}
+    name = first(split(token, '='; limit = 2))
+    i = get(parser.index, name, nothing)
+    return if i === nothing
+        nothing
+    else
+        parser.specs[i]
+    end
+end
+
+function parse_raw(parser::ArgParser, argv::Vector{String})
+    positional_args = String[]
+    options = Dict{Symbol,Any}()
+
+    remaining = @view argv[:]
+    while !isempty(remaining)
+        token = first(remaining)
+        spec = maybe_get_spec(parser, token)
+        if spec !== nothing
+            value, remaining = spec.consume(remaining)
+            if spec.multi
+                # append
+                if !haskey(options, spec.dest)
+                    options[spec.dest] = []
+                end
+                push!(options[spec.dest], value)
+            else
+                # overwrite
+                options[spec.dest] = value
+            end
+        else
+            push!(positional_args, token)
+            remaining = @view remaining[2:end]
+        end
+    end
+
+    options[:paths] = positional_args
+    return options
+end
+
+# --- Typed result ---
+
+@enum OutputMode StdoutMode InplaceMode CheckMode
+
+Base.@kwdef struct ParsedArgs
+    help::Bool = false
+    version::Bool = false
+    mode::OutputMode = StdoutMode
+    diff::Bool = false
+    verbose::Bool = false
+    format_markdown::Bool = false
+    config_priority::Bool = false
+    outputfile::Union{String,Nothing} = nothing
+    stdin_filename::String = "stdin"
+    config_dir::String = ""
+    ignore_patterns::Vector{String} = String[]
+    line_ranges::Vector{Tuple{Int,Int}} = Tuple{Int,Int}[]
+    format_options::Dict{Symbol,Any} = Dict{Symbol,Any}()
+    paths::Vector{String} = String[]
+end
+
+# All format option keys — these are collected from the raw dict into format_options.
+const FORMAT_OPTION_KEYS = Set{Symbol}([
+    :style, :indent, :margin, :sciml_margin_overrun, :normalize_line_endings,
+    :always_for_in, :whitespace_typedefs, :remove_extra_newlines,
+    :import_to_using, :pipe_to_function_call, :short_to_long_function_def,
+    :always_use_return, :whitespace_in_kwargs, :format_docstrings,
+    :align_struct_field, :align_assignment, :align_conditional, :align_pair_arrow,
+    :trailing_comma, :trailing_zero, :v2_stable_multiline_strings, :conditional_to_if,
+])
+
+const PARSER = ArgParser(
+    flag(["-h", "--help"]; dest = :help,
+        help = "Print this message."),
+    flag(["--version"]; dest = :version,
+        help = "Print version information."),
+    flag(["-c", "--check"]; dest = :check,
+        help = "Check formatting without writing."),
+    flag(["-i", "--inplace"]; dest = :inplace,
+        help = "Format files in place."),
+    flag(["-d", "--diff"]; dest = :diff,
+        help = "Print diff to stderr."),
+    option(["-o", "--output"]; dest = :outputfile, type = String, metavar = "<file>",
+        help = "File to write formatted output to."),
+    flag(["-v", "--verbose"]; dest = :verbose,
+        help = "Enable verbose output."),
+    flag(["--format_markdown"]; dest = :format_markdown,
+        help = "Also format code blocks in Markdown files."),
+    flag(["--prioritize-config-file"]; dest = :config_priority,
+        help = "Prioritize config file options over command-line options."),
+    option("--stdin-filename"; dest = :stdin_filename, type = String, metavar = "<name>",
+        help = "Assumed filename when formatting from stdin."),
+    option("--config-dir"; dest = :config_dir, type = String, metavar = "<dir>",
+        help = "Directory path for .JuliaFormatter.toml config lookup."),
+    option("--ignore"; dest = :ignore, type = String, multi = true, metavar = "<pattern>",
+        help = "Ignore files matching the given pattern. Can be repeated."),
+    option("--lines"; dest = :lines, type = Tuple{Int,Int}, multi = true, metavar = "<start:stop>",
+        help = "Only format the given range of lines. Can be repeated."),
+    # --- Formatting options ---
+    option("--style"; dest = :style, type = AbstractStyle, metavar = "default|blue|sciml|yas|minimal",
+        help = "Formatting style.", group = FormattingGroup),
+    option("--indent"; dest = :indent, type = Int, metavar = "<n>",
+        help = "Indentation width.", group = FormattingGroup),
+    option("--margin"; dest = :margin, type = Int, metavar = "<n>",
+        help = "Maximum line width.", group = FormattingGroup),
+    option("--sciml_margin_overrun"; dest = :sciml_margin_overrun, type = Int, metavar = "<n>",
+        help = "Additional columns SciMLStyle may use.", group = FormattingGroup),
+    option("--normalize_line_endings"; dest = :normalize_line_endings, type = String, metavar = "auto|unix|windows",
+        help = "Normalize line endings.", group = FormattingGroup),
+    negatable_flag("always_for_in"; dest = :always_for_in,
+        help = "Always use 'for x in' instead of 'for x ='.", group = FormattingGroup),
+    negatable_flag("whitespace_typedefs"; dest = :whitespace_typedefs,
+        help = "Add whitespace around '::' in type definitions.", group = FormattingGroup),
+    negatable_flag("remove_extra_newlines"; dest = :remove_extra_newlines,
+        help = "Remove extra newlines.", group = FormattingGroup),
+    negatable_flag("import_to_using"; dest = :import_to_using,
+        help = "Convert 'import' to 'using'.", group = FormattingGroup),
+    negatable_flag("pipe_to_function_call"; dest = :pipe_to_function_call,
+        help = "Convert pipe operator to function calls.", group = FormattingGroup),
+    negatable_flag("short_to_long_function_def"; dest = :short_to_long_function_def,
+        help = "Convert short function definitions to long form.", group = FormattingGroup),
+    negatable_flag("always_use_return"; dest = :always_use_return,
+        help = "Always add explicit 'return' statements.", group = FormattingGroup),
+    negatable_flag("whitespace_in_kwargs"; dest = :whitespace_in_kwargs,
+        help = "Add whitespace in keyword arguments.", group = FormattingGroup),
+    negatable_flag("format_docstrings"; dest = :format_docstrings,
+        help = "Format docstrings.", group = FormattingGroup),
+    negatable_flag("align_struct_field"; dest = :align_struct_field,
+        help = "Align struct field type annotations.", group = FormattingGroup),
+    negatable_flag("align_assignment"; dest = :align_assignment,
+        help = "Align assignment operators.", group = FormattingGroup),
+    negatable_flag("align_conditional"; dest = :align_conditional,
+        help = "Align conditional operators.", group = FormattingGroup),
+    negatable_flag("align_pair_arrow"; dest = :align_pair_arrow,
+        help = "Align pair arrows (=>).", group = FormattingGroup),
+    negatable_flag("trailing_comma"; dest = :trailing_comma,
+        help = "Add trailing commas.", group = FormattingGroup),
+    negatable_flag("trailing_zero"; dest = :trailing_zero,
+        help = "Add trailing zeros to floats.", group = FormattingGroup),
+    negatable_flag("v2_stable_multiline_strings"; dest = :v2_stable_multiline_strings,
+        help = "Use stable multiline string length calculation.", group = FormattingGroup),
+    negatable_flag("conditional_to_if"; dest = :conditional_to_if,
+        help = "Convert ternary conditional expressions to if/else blocks.", group = FormattingGroup),
+)
+
+function print_help(parser::ArgParser; io::IO = stdout)
+    function section(title)
+        printstyled(io, title; bold = true)
+        println(io)
+    end
+
+    section("NAME")
+    println(io, "       jlfmt - An opinionated code formatter for Julia\n")
+
+    section("SYNOPSIS")
+    println(io, """
+               jlfmt [<julia_options> --] [<options>] <path>...
+               jlfmt [<julia_options> --] [<options>] -
+               ... | jlfmt [<julia_options> --] [<options>]
+
+               where <julia_options> are options passed to the Julia
+               interpreter (e.g. --threads=auto), and <options> are
+               options for JuliaFormatter.
+        """)
+
+    section("DESCRIPTION")
+    println(io, """
+               `jlfmt` formats Julia source code using JuliaFormatter.jl.
+               This tool can also be invoked as `julia -m JuliaFormatter`.
+        """)
+
+    section("OPTIONS")
+    println(io, """
+               <path>...
+                   Input path(s) (files and/or directories) to process. For directories,
+                   all files (recursively) with the '*.jl' suffix are used as input files
+                   (also '*.md', '*.jmd', '*.qmd' if --format-markdown is specified).
+                   If no path is given, or if path is `-`, input is read from stdin.
+        """)
+
+    for group in instances(OptGroup)
+        if group == FormattingGroup
+            section("FORMATTING OPTIONS")
+            println(io, """
+                   These options control the formatting style. They can also be set in
+                   a `.JuliaFormatter.toml` config file.
+
+                   Note that options are merged from the config file and command-line
+                   arguments. If the same option is specified both a config file and
+                   command-line options are specified, the CLI arguments take priority
+                   by default. With `--prioritize-config-file`, the config file takes
+                   priority instead.
+
+                   If the same option is specified multiple times on the command line,
+                   the last value is used.
+            """)
+        end
+        for spec in parser.specs
+            spec.group != group && continue
+            label = if spec.kind == FlagKind
+                join(spec.names, ", ")
+            elseif spec.kind == OptionKind
+                m = spec.metavar
+                join([startswith(n, "--") ? "$n=$m" : "$n $m" for n in spec.names], ", ")
+            else
+                join(spec.names, " / ")
+            end
+            println(io, "       ", label)
+            println(io, "           ", spec.help, "\n")
+        end
+    end
+
+    section("EXAMPLES")
+    println(io, """
+               Format a file and write to stdout:
+                   jlfmt src/file.jl
+
+               Format a file in place:
+                   jlfmt --inplace src/file.jl
+
+               Format all files in a directory with the verbose mode:
+                   jlfmt --inplace --verbose src/
+
+               Check if a file is formatted:
+                   jlfmt --check src/file.jl
+
+               Format only lines 1-10 and 42-47 of a file:
+                   jlfmt --lines=1:10 --lines=42:47 src/file.jl
+
+               Check if all files in a directory are formatted with multiple threads:
+                   jlfmt --threads=4 -- --check src/
+
+               Show diff for formatting with 2-space indentations:
+                   jlfmt --diff --indent=2 src/file.jl
+
+               Format from stdin (pipe):
+                   echo 'f(x,y)=x+y' | jlfmt
+
+               Format from stdin (explicit):
+                   jlfmt - < input.jl
+
+               Format from stdin using project config:
+                   echo 'f(x,y)=x+y' | jlfmt --config-dir=./src
+
+               Use specific style:
+                   jlfmt --style=blue src/file.jl
+
+               Combine options:
+                   echo 'for i=1:10; end' | jlfmt --always_for_in
+        """)
+    return
+end
+
+function parse_args(argv::Vector{String})::ParsedArgs
+    raw = parse_raw(PARSER, argv)
+
+    # --- Output mode (mutually exclusive) ---
+    has_check = get(raw, :check, false)
+    has_inplace = get(raw, :inplace, false)
+    has_output = haskey(raw, :outputfile)
+    if has_check && has_inplace
+        throw(ParseArgsError("options `--check` and `--inplace` are mutually exclusive"))
+    end
+    if has_inplace && has_output
+        throw(ParseArgsError("options `--inplace` and `--output` are mutually exclusive"))
+    end
+    if has_check && has_output
+        throw(ParseArgsError("options `--check` and `--output` are mutually exclusive"))
+    end
+    mode = if has_check
+        CheckMode
+    elseif has_inplace
+        InplaceMode
+    else
+        StdoutMode
+    end
+
+    # --- Collect format options ---
+    format_options = Dict{Symbol,Any}()
+    for key in FORMAT_OPTION_KEYS
+        if haskey(raw, key)
+            format_options[key] = raw[key]
+        end
+    end
+
+    return ParsedArgs(;
+        help = get(raw, :help, false),
+        version = get(raw, :version, false),
+        mode,
+        diff = get(raw, :diff, false),
+        verbose = get(raw, :verbose, false),
+        format_markdown = get(raw, :format_markdown, false),
+        config_priority = get(raw, :config_priority, false),
+        outputfile = get(raw, :outputfile, nothing),
+        stdin_filename = get(raw, :stdin_filename, "stdin"),
+        config_dir = get(raw, :config_dir, ""),
+        ignore_patterns = get(raw, :ignore, String[]),
+        line_ranges = get(raw, :lines, Tuple{Int,Int}[]),
+        format_options,
+        paths = raw[:paths],
+    )
+end
+
+end # module

--- a/test/argparse.jl
+++ b/test/argparse.jl
@@ -198,49 +198,82 @@ using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyl
         end
 
         @testset "all formatting options (new-style)" begin
+            # style
             @test parse_args(["--style=default"]).format_options[:style] == DefaultStyle()
             @test parse_args(["--style=yas"]).format_options[:style] == YASStyle()
             @test parse_args(["--style=blue"]).format_options[:style] == BlueStyle()
             @test parse_args(["--style=sciml"]).format_options[:style] == SciMLStyle()
             @test parse_args(["--style=minimal"]).format_options[:style] == MinimalStyle()
+            # int options
             @test parse_args(["--indent=2"]).format_options[:indent] == 2
             @test parse_args(["--margin=80"]).format_options[:margin] == 80
             @test parse_args(["--sciml-margin-overrun=10"]).format_options[:sciml_margin_overrun] == 10
+            # string options
+            @test parse_args(["--for-in-replacement=∈"]).format_options[:for_in_replacement] == "∈"
             @test parse_args(["--normalize-line-endings=unix"]).format_options[:normalize_line_endings] == "unix"
-            @test parse_args(["--always-for-in=true"]).format_options[:always_for_in] == true
-            @test parse_args(["--always-for-in=false"]).format_options[:always_for_in] == false
-            @test parse_args(["--whitespace-typedefs=true"]).format_options[:whitespace_typedefs] == true
-            @test parse_args(["--whitespace-typedefs=false"]).format_options[:whitespace_typedefs] == false
-            @test parse_args(["--remove-extra-newlines=true"]).format_options[:remove_extra_newlines] == true
-            @test parse_args(["--remove-extra-newlines=false"]).format_options[:remove_extra_newlines] == false
-            @test parse_args(["--import-to-using=true"]).format_options[:import_to_using] == true
-            @test parse_args(["--import-to-using=false"]).format_options[:import_to_using] == false
-            @test parse_args(["--pipe-to-function-call=true"]).format_options[:pipe_to_function_call] == true
-            @test parse_args(["--pipe-to-function-call=false"]).format_options[:pipe_to_function_call] == false
-            @test parse_args(["--short-to-long-function-def=true"]).format_options[:short_to_long_function_def] == true
-            @test parse_args(["--short-to-long-function-def=false"]).format_options[:short_to_long_function_def] == false
-            @test parse_args(["--always-use-return=true"]).format_options[:always_use_return] == true
-            @test parse_args(["--always-use-return=false"]).format_options[:always_use_return] == false
-            @test parse_args(["--whitespace-in-kwargs=true"]).format_options[:whitespace_in_kwargs] == true
-            @test parse_args(["--whitespace-in-kwargs=false"]).format_options[:whitespace_in_kwargs] == false
-            @test parse_args(["--format-docstrings=true"]).format_options[:format_docstrings] == true
-            @test parse_args(["--format-docstrings=false"]).format_options[:format_docstrings] == false
-            @test parse_args(["--align-struct-field=true"]).format_options[:align_struct_field] == true
-            @test parse_args(["--align-struct-field=false"]).format_options[:align_struct_field] == false
+            # bool options (alphabetical)
             @test parse_args(["--align-assignment=true"]).format_options[:align_assignment] == true
             @test parse_args(["--align-assignment=false"]).format_options[:align_assignment] == false
             @test parse_args(["--align-conditional=true"]).format_options[:align_conditional] == true
             @test parse_args(["--align-conditional=false"]).format_options[:align_conditional] == false
+            @test parse_args(["--align-matrix=true"]).format_options[:align_matrix] == true
+            @test parse_args(["--align-matrix=false"]).format_options[:align_matrix] == false
             @test parse_args(["--align-pair-arrow=true"]).format_options[:align_pair_arrow] == true
             @test parse_args(["--align-pair-arrow=false"]).format_options[:align_pair_arrow] == false
+            @test parse_args(["--align-struct-field=true"]).format_options[:align_struct_field] == true
+            @test parse_args(["--align-struct-field=false"]).format_options[:align_struct_field] == false
+            @test parse_args(["--always-for-in=true"]).format_options[:always_for_in] == true
+            @test parse_args(["--always-for-in=false"]).format_options[:always_for_in] == false
+            @test parse_args(["--always-for-in=nothing"]).format_options[:always_for_in] === nothing
+            @test parse_args(["--always-use-return=true"]).format_options[:always_use_return] == true
+            @test parse_args(["--always-use-return=false"]).format_options[:always_use_return] == false
+            @test parse_args(["--annotate-untyped-fields-with-any=true"]).format_options[:annotate_untyped_fields_with_any] == true
+            @test parse_args(["--annotate-untyped-fields-with-any=false"]).format_options[:annotate_untyped_fields_with_any] == false
+            @test parse_args(["--conditional-to-if=true"]).format_options[:conditional_to_if] == true
+            @test parse_args(["--conditional-to-if=false"]).format_options[:conditional_to_if] == false
+            @test parse_args(["--disallow-single-arg-nesting=true"]).format_options[:disallow_single_arg_nesting] == true
+            @test parse_args(["--disallow-single-arg-nesting=false"]).format_options[:disallow_single_arg_nesting] == false
+            @test parse_args(["--force-long-function-def=true"]).format_options[:force_long_function_def] == true
+            @test parse_args(["--force-long-function-def=false"]).format_options[:force_long_function_def] == false
+            @test parse_args(["--format-docstrings=true"]).format_options[:format_docstrings] == true
+            @test parse_args(["--format-docstrings=false"]).format_options[:format_docstrings] == false
+            @test parse_args(["--import-to-using=true"]).format_options[:import_to_using] == true
+            @test parse_args(["--import-to-using=false"]).format_options[:import_to_using] == false
+            @test parse_args(["--indent-submodule=true"]).format_options[:indent_submodule] == true
+            @test parse_args(["--indent-submodule=false"]).format_options[:indent_submodule] == false
+            @test parse_args(["--join-lines-based-on-source=true"]).format_options[:join_lines_based_on_source] == true
+            @test parse_args(["--join-lines-based-on-source=false"]).format_options[:join_lines_based_on_source] == false
+            @test parse_args(["--long-to-short-function-def=true"]).format_options[:long_to_short_function_def] == true
+            @test parse_args(["--long-to-short-function-def=false"]).format_options[:long_to_short_function_def] == false
+            @test parse_args(["--pipe-to-function-call=true"]).format_options[:pipe_to_function_call] == true
+            @test parse_args(["--pipe-to-function-call=false"]).format_options[:pipe_to_function_call] == false
+            @test parse_args(["--remove-extra-newlines=true"]).format_options[:remove_extra_newlines] == true
+            @test parse_args(["--remove-extra-newlines=false"]).format_options[:remove_extra_newlines] == false
+            @test parse_args(["--separate-kwargs-with-semicolon=true"]).format_options[:separate_kwargs_with_semicolon] == true
+            @test parse_args(["--separate-kwargs-with-semicolon=false"]).format_options[:separate_kwargs_with_semicolon] == false
+            @test parse_args(["--short-circuit-to-if=true"]).format_options[:short_circuit_to_if] == true
+            @test parse_args(["--short-circuit-to-if=false"]).format_options[:short_circuit_to_if] == false
+            @test parse_args(["--short-to-long-function-def=true"]).format_options[:short_to_long_function_def] == true
+            @test parse_args(["--short-to-long-function-def=false"]).format_options[:short_to_long_function_def] == false
+            @test parse_args(["--surround-whereop-typeparameters=true"]).format_options[:surround_whereop_typeparameters] == true
+            @test parse_args(["--surround-whereop-typeparameters=false"]).format_options[:surround_whereop_typeparameters] == false
             @test parse_args(["--trailing-comma=true"]).format_options[:trailing_comma] == true
             @test parse_args(["--trailing-comma=false"]).format_options[:trailing_comma] == false
+            @test parse_args(["--trailing-comma=nothing"]).format_options[:trailing_comma] === nothing
             @test parse_args(["--trailing-zero=true"]).format_options[:trailing_zero] == true
             @test parse_args(["--trailing-zero=false"]).format_options[:trailing_zero] == false
             @test parse_args(["--v2-stable-multiline-strings=true"]).format_options[:v2_stable_multiline_strings] == true
             @test parse_args(["--v2-stable-multiline-strings=false"]).format_options[:v2_stable_multiline_strings] == false
-            @test parse_args(["--conditional-to-if=true"]).format_options[:conditional_to_if] == true
-            @test parse_args(["--conditional-to-if=false"]).format_options[:conditional_to_if] == false
+            @test parse_args(["--variable-call-indent=Dict"]).format_options[:variable_call_indent] == ["Dict"]
+            @test parse_args(["--variable-call-indent=Dict", "--variable-call-indent=Foo"]).format_options[:variable_call_indent] == ["Dict", "Foo"]
+            @test parse_args(["--whitespace-in-kwargs=true"]).format_options[:whitespace_in_kwargs] == true
+            @test parse_args(["--whitespace-in-kwargs=false"]).format_options[:whitespace_in_kwargs] == false
+            @test parse_args(["--whitespace-ops-in-indices=true"]).format_options[:whitespace_ops_in_indices] == true
+            @test parse_args(["--whitespace-ops-in-indices=false"]).format_options[:whitespace_ops_in_indices] == false
+            @test parse_args(["--whitespace-typedefs=true"]).format_options[:whitespace_typedefs] == true
+            @test parse_args(["--whitespace-typedefs=false"]).format_options[:whitespace_typedefs] == false
+            @test parse_args(["--yas-style-nesting=true"]).format_options[:yas_style_nesting] == true
+            @test parse_args(["--yas-style-nesting=false"]).format_options[:yas_style_nesting] == false
         end
 
         @testset "deprecated underscored options still work" begin

--- a/test/argparse.jl
+++ b/test/argparse.jl
@@ -1,6 +1,6 @@
 module ArgparseTests
 
-using Test: @test, @testset, @test_throws
+using Test: @test, @testset, @test_throws, @test_logs
 using JuliaFormatter.ArgParse: ParseArgsError, ParsedArgs, parse_args, parse_raw, PARSER,
     StdoutMode, InplaceMode, CheckMode
 using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyle
@@ -35,10 +35,17 @@ using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyl
             @test raw[:outputfile] == "out.jl"
         end
 
-        @testset "negatable flag" begin
+        @testset "negatable flag (deprecated)" begin
             raw = parse_raw(PARSER, ["--always_for_in"])
             @test raw[:always_for_in] == true
             raw = parse_raw(PARSER, ["--no-always_for_in"])
+            @test raw[:always_for_in] == false
+        end
+
+        @testset "boolean option with = syntax" begin
+            raw = parse_raw(PARSER, ["--always-for-in=true"])
+            @test raw[:always_for_in] == true
+            raw = parse_raw(PARSER, ["--always-for-in=false"])
             @test raw[:always_for_in] == false
         end
 
@@ -190,7 +197,7 @@ using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyl
             @test a.format_options[:margin] == b.format_options[:margin] == 80
         end
 
-        @testset "all formatting options" begin
+        @testset "all formatting options (new-style)" begin
             @test parse_args(["--style=default"]).format_options[:style] == DefaultStyle()
             @test parse_args(["--style=yas"]).format_options[:style] == YASStyle()
             @test parse_args(["--style=blue"]).format_options[:style] == BlueStyle()
@@ -198,8 +205,50 @@ using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyl
             @test parse_args(["--style=minimal"]).format_options[:style] == MinimalStyle()
             @test parse_args(["--indent=2"]).format_options[:indent] == 2
             @test parse_args(["--margin=80"]).format_options[:margin] == 80
+            @test parse_args(["--sciml-margin-overrun=10"]).format_options[:sciml_margin_overrun] == 10
+            @test parse_args(["--normalize-line-endings=unix"]).format_options[:normalize_line_endings] == "unix"
+            @test parse_args(["--always-for-in=true"]).format_options[:always_for_in] == true
+            @test parse_args(["--always-for-in=false"]).format_options[:always_for_in] == false
+            @test parse_args(["--whitespace-typedefs=true"]).format_options[:whitespace_typedefs] == true
+            @test parse_args(["--whitespace-typedefs=false"]).format_options[:whitespace_typedefs] == false
+            @test parse_args(["--remove-extra-newlines=true"]).format_options[:remove_extra_newlines] == true
+            @test parse_args(["--remove-extra-newlines=false"]).format_options[:remove_extra_newlines] == false
+            @test parse_args(["--import-to-using=true"]).format_options[:import_to_using] == true
+            @test parse_args(["--import-to-using=false"]).format_options[:import_to_using] == false
+            @test parse_args(["--pipe-to-function-call=true"]).format_options[:pipe_to_function_call] == true
+            @test parse_args(["--pipe-to-function-call=false"]).format_options[:pipe_to_function_call] == false
+            @test parse_args(["--short-to-long-function-def=true"]).format_options[:short_to_long_function_def] == true
+            @test parse_args(["--short-to-long-function-def=false"]).format_options[:short_to_long_function_def] == false
+            @test parse_args(["--always-use-return=true"]).format_options[:always_use_return] == true
+            @test parse_args(["--always-use-return=false"]).format_options[:always_use_return] == false
+            @test parse_args(["--whitespace-in-kwargs=true"]).format_options[:whitespace_in_kwargs] == true
+            @test parse_args(["--whitespace-in-kwargs=false"]).format_options[:whitespace_in_kwargs] == false
+            @test parse_args(["--format-docstrings=true"]).format_options[:format_docstrings] == true
+            @test parse_args(["--format-docstrings=false"]).format_options[:format_docstrings] == false
+            @test parse_args(["--align-struct-field=true"]).format_options[:align_struct_field] == true
+            @test parse_args(["--align-struct-field=false"]).format_options[:align_struct_field] == false
+            @test parse_args(["--align-assignment=true"]).format_options[:align_assignment] == true
+            @test parse_args(["--align-assignment=false"]).format_options[:align_assignment] == false
+            @test parse_args(["--align-conditional=true"]).format_options[:align_conditional] == true
+            @test parse_args(["--align-conditional=false"]).format_options[:align_conditional] == false
+            @test parse_args(["--align-pair-arrow=true"]).format_options[:align_pair_arrow] == true
+            @test parse_args(["--align-pair-arrow=false"]).format_options[:align_pair_arrow] == false
+            @test parse_args(["--trailing-comma=true"]).format_options[:trailing_comma] == true
+            @test parse_args(["--trailing-comma=false"]).format_options[:trailing_comma] == false
+            @test parse_args(["--trailing-zero=true"]).format_options[:trailing_zero] == true
+            @test parse_args(["--trailing-zero=false"]).format_options[:trailing_zero] == false
+            @test parse_args(["--v2-stable-multiline-strings=true"]).format_options[:v2_stable_multiline_strings] == true
+            @test parse_args(["--v2-stable-multiline-strings=false"]).format_options[:v2_stable_multiline_strings] == false
+            @test parse_args(["--conditional-to-if=true"]).format_options[:conditional_to_if] == true
+            @test parse_args(["--conditional-to-if=false"]).format_options[:conditional_to_if] == false
+        end
+
+        @testset "deprecated underscored options still work" begin
             @test parse_args(["--sciml_margin_overrun=10"]).format_options[:sciml_margin_overrun] == 10
             @test parse_args(["--normalize_line_endings=unix"]).format_options[:normalize_line_endings] == "unix"
+        end
+
+        @testset "all formatting options (deprecated negatable flags still work)" begin
             @test parse_args(["--always_for_in"]).format_options[:always_for_in] == true
             @test parse_args(["--no-always_for_in"]).format_options[:always_for_in] == false
             @test parse_args(["--whitespace_typedefs"]).format_options[:whitespace_typedefs] == true
@@ -234,6 +283,13 @@ using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyl
             @test parse_args(["--no-v2_stable_multiline_strings"]).format_options[:v2_stable_multiline_strings] == false
             @test parse_args(["--conditional_to_if"]).format_options[:conditional_to_if] == true
             @test parse_args(["--no-conditional_to_if"]).format_options[:conditional_to_if] == false
+        end
+
+        @testset "new-style option overrides deprecated flag (last wins)" begin
+            args = parse_args(["--always_for_in", "--always-for-in=false"])
+            @test args.format_options[:always_for_in] == false
+            args = parse_args(["--always-for-in=false", "--always_for_in"])
+            @test args.format_options[:always_for_in] == true
         end
     end
 end

--- a/test/argparse.jl
+++ b/test/argparse.jl
@@ -1,0 +1,241 @@
+module ArgparseTests
+
+using Test: @test, @testset, @test_throws
+using JuliaFormatter.ArgParse: ParseArgsError, ParsedArgs, parse_args, parse_raw, PARSER,
+    StdoutMode, InplaceMode, CheckMode
+using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyle
+
+@testset "argparse" begin
+    @testset "parse_raw" begin
+        @testset "empty args" begin
+            raw = parse_raw(PARSER, String[])
+            @test raw[:paths] == []
+        end
+
+        @testset "flag short and long forms" begin
+            raw = parse_raw(PARSER, ["-c", "foo.jl"])
+            @test raw[:check] == true
+            raw = parse_raw(PARSER, ["--check", "foo.jl"])
+            @test raw[:check] == true
+        end
+
+        @testset "option with = and space" begin
+            raw = parse_raw(PARSER, ["--margin=80"])
+            @test raw[:margin] == 80
+            raw = parse_raw(PARSER, ["--margin", "80"])
+            @test raw[:margin] == 80
+        end
+
+        @testset "option with multiple names" begin
+            raw = parse_raw(PARSER, ["-o", "out.jl"])
+            @test raw[:outputfile] == "out.jl"
+            raw = parse_raw(PARSER, ["--output=out.jl"])
+            @test raw[:outputfile] == "out.jl"
+            raw = parse_raw(PARSER, ["--output", "out.jl"])
+            @test raw[:outputfile] == "out.jl"
+        end
+
+        @testset "negatable flag" begin
+            raw = parse_raw(PARSER, ["--always_for_in"])
+            @test raw[:always_for_in] == true
+            raw = parse_raw(PARSER, ["--no-always_for_in"])
+            @test raw[:always_for_in] == false
+        end
+
+        @testset "multi option collects values" begin
+            raw = parse_raw(PARSER, ["--ignore=*.tmp", "--ignore=*/test/*"])
+            @test raw[:ignore] == ["*.tmp", "*/test/*"]
+        end
+
+        @testset "last value wins for non-multi" begin
+            raw = parse_raw(PARSER, ["--margin=10", "--margin=20"])
+            @test raw[:margin] == 20
+        end
+
+        @testset "positional args preserved in order" begin
+            raw = parse_raw(PARSER, ["a.jl", "-c", "b.jl", "--margin=1", "c.jl"])
+            @test raw[:paths] == ["a.jl", "b.jl", "c.jl"]
+        end
+
+        @testset "unknown flags treated as positional" begin
+            raw = parse_raw(PARSER, ["--unknown", "foo.jl"])
+            @test raw[:paths] == ["--unknown", "foo.jl"]
+        end
+
+        @testset "missing value for option" begin
+            @test_throws ParseArgsError parse_raw(PARSER, ["--margin"])
+        end
+
+        @testset "invalid value for option" begin
+            @test_throws ParseArgsError parse_raw(PARSER, ["--margin=abc"])
+        end
+
+        @testset "line ranges" begin
+            raw = parse_raw(PARSER, ["--lines=1:10", "--lines=42:47"])
+            @test raw[:lines] == [(1, 10), (42, 47)]
+        end
+
+        @testset "line range errors" begin
+            @test_throws ParseArgsError parse_raw(PARSER, ["--lines=abc"])
+            @test_throws ParseArgsError parse_raw(PARSER, ["--lines=5:2"])
+        end
+    end
+
+    @testset "parse_args" begin
+        @testset "defaults" begin
+            args = parse_args(String[])
+            @test args.help == false
+            @test args.version == false
+            @test args.mode == StdoutMode
+            @test args.diff == false
+            @test args.verbose == false
+            @test args.format_markdown == false
+            @test args.config_priority == false
+            @test args.outputfile === nothing
+            @test args.stdin_filename == "stdin"
+            @test args.config_dir == ""
+            @test args.ignore_patterns == []
+            @test args.line_ranges == []
+            @test args.format_options == Dict{Symbol,Any}()
+            @test args.paths == []
+        end
+
+        @testset "help and version" begin
+            @test parse_args(["-h"]).help == true
+            @test parse_args(["--help"]).help == true
+            @test parse_args(["--version"]).version == true
+        end
+
+        @testset "output mode" begin
+            @test parse_args(["-c"]).mode == CheckMode
+            @test parse_args(["--check"]).mode == CheckMode
+            @test parse_args(["-i"]).mode == InplaceMode
+            @test parse_args(["--inplace"]).mode == InplaceMode
+            @test parse_args(["f.jl"]).mode == StdoutMode
+        end
+
+        @testset "output mode mutual exclusion" begin
+            @test_throws ParseArgsError parse_args(["--check", "--inplace"])
+            @test_throws ParseArgsError parse_args(["--check", "-o", "out.jl"])
+            @test_throws ParseArgsError parse_args(["--inplace", "--output=out.jl"])
+        end
+
+        @testset "outputfile" begin
+            args = parse_args(["-o", "out.jl"])
+            @test args.outputfile == "out.jl"
+            args = parse_args(["--output=out.jl"])
+            @test args.outputfile == "out.jl"
+            @test parse_args(["f.jl"]).outputfile === nothing
+        end
+
+        @testset "simple flags" begin
+            @test parse_args(["-d"]).diff == true
+            @test parse_args(["-v"]).verbose == true
+            @test parse_args(["--format_markdown"]).format_markdown == true
+            @test parse_args(["--prioritize-config-file"]).config_priority == true
+        end
+
+        @testset "string options" begin
+            @test parse_args(["--stdin-filename=foo.jl"]).stdin_filename == "foo.jl"
+            @test parse_args(["--config-dir=/some/path"]).config_dir == "/some/path"
+        end
+
+        @testset "ignore patterns" begin
+            args = parse_args(["--ignore=*.tmp", "--ignore=*/test/*"])
+            @test args.ignore_patterns == ["*.tmp", "*/test/*"]
+            @test parse_args(["f.jl"]).ignore_patterns == []
+        end
+
+        @testset "line ranges" begin
+            args = parse_args(["--lines=1:10", "--lines=42:47"])
+            @test args.line_ranges == [(1, 10), (42, 47)]
+            @test parse_args(["f.jl"]).line_ranges == []
+        end
+
+        @testset "format options from value options" begin
+            args = parse_args(["--indent=2", "--margin=80"])
+            @test args.format_options[:indent] == 2
+            @test args.format_options[:margin] == 80
+        end
+
+        @testset "format options from negatable flags" begin
+            args = parse_args(["--always_for_in"])
+            @test args.format_options[:always_for_in] == true
+
+            args = parse_args(["--no-always_for_in"])
+            @test args.format_options[:always_for_in] == false
+        end
+
+        @testset "unset format options are absent" begin
+            args = parse_args(["--always_for_in"])
+            @test haskey(args.format_options, :always_for_in)
+            @test !haskey(args.format_options, :trailing_comma)
+        end
+
+        @testset "mixed flags and paths" begin
+            args = parse_args(["-i", "--margin=80", "-d", "-v", "--style=blue", "src/", "lib/"])
+            @test args.mode == InplaceMode
+            @test args.diff == true
+            @test args.verbose == true
+            @test args.format_options[:style] == BlueStyle()
+            @test args.format_options[:margin] == 80
+            @test args.paths == ["src/", "lib/"]
+        end
+
+        @testset "flags can appear in any order" begin
+            a = parse_args(["-c", "-d", "--margin=80"])
+            b = parse_args(["--margin=80", "-d", "-c"])
+            @test a.mode == b.mode == CheckMode
+            @test a.diff == b.diff == true
+            @test a.format_options[:margin] == b.format_options[:margin] == 80
+        end
+
+        @testset "all formatting options" begin
+            @test parse_args(["--style=default"]).format_options[:style] == DefaultStyle()
+            @test parse_args(["--style=yas"]).format_options[:style] == YASStyle()
+            @test parse_args(["--style=blue"]).format_options[:style] == BlueStyle()
+            @test parse_args(["--style=sciml"]).format_options[:style] == SciMLStyle()
+            @test parse_args(["--style=minimal"]).format_options[:style] == MinimalStyle()
+            @test parse_args(["--indent=2"]).format_options[:indent] == 2
+            @test parse_args(["--margin=80"]).format_options[:margin] == 80
+            @test parse_args(["--sciml_margin_overrun=10"]).format_options[:sciml_margin_overrun] == 10
+            @test parse_args(["--normalize_line_endings=unix"]).format_options[:normalize_line_endings] == "unix"
+            @test parse_args(["--always_for_in"]).format_options[:always_for_in] == true
+            @test parse_args(["--no-always_for_in"]).format_options[:always_for_in] == false
+            @test parse_args(["--whitespace_typedefs"]).format_options[:whitespace_typedefs] == true
+            @test parse_args(["--no-whitespace_typedefs"]).format_options[:whitespace_typedefs] == false
+            @test parse_args(["--remove_extra_newlines"]).format_options[:remove_extra_newlines] == true
+            @test parse_args(["--no-remove_extra_newlines"]).format_options[:remove_extra_newlines] == false
+            @test parse_args(["--import_to_using"]).format_options[:import_to_using] == true
+            @test parse_args(["--no-import_to_using"]).format_options[:import_to_using] == false
+            @test parse_args(["--pipe_to_function_call"]).format_options[:pipe_to_function_call] == true
+            @test parse_args(["--no-pipe_to_function_call"]).format_options[:pipe_to_function_call] == false
+            @test parse_args(["--short_to_long_function_def"]).format_options[:short_to_long_function_def] == true
+            @test parse_args(["--no-short_to_long_function_def"]).format_options[:short_to_long_function_def] == false
+            @test parse_args(["--always_use_return"]).format_options[:always_use_return] == true
+            @test parse_args(["--no-always_use_return"]).format_options[:always_use_return] == false
+            @test parse_args(["--whitespace_in_kwargs"]).format_options[:whitespace_in_kwargs] == true
+            @test parse_args(["--no-whitespace_in_kwargs"]).format_options[:whitespace_in_kwargs] == false
+            @test parse_args(["--format_docstrings"]).format_options[:format_docstrings] == true
+            @test parse_args(["--no-format_docstrings"]).format_options[:format_docstrings] == false
+            @test parse_args(["--align_struct_field"]).format_options[:align_struct_field] == true
+            @test parse_args(["--no-align_struct_field"]).format_options[:align_struct_field] == false
+            @test parse_args(["--align_assignment"]).format_options[:align_assignment] == true
+            @test parse_args(["--no-align_assignment"]).format_options[:align_assignment] == false
+            @test parse_args(["--align_conditional"]).format_options[:align_conditional] == true
+            @test parse_args(["--no-align_conditional"]).format_options[:align_conditional] == false
+            @test parse_args(["--align_pair_arrow"]).format_options[:align_pair_arrow] == true
+            @test parse_args(["--no-align_pair_arrow"]).format_options[:align_pair_arrow] == false
+            @test parse_args(["--trailing_comma"]).format_options[:trailing_comma] == true
+            @test parse_args(["--no-trailing_comma"]).format_options[:trailing_comma] == false
+            @test parse_args(["--trailing_zero"]).format_options[:trailing_zero] == true
+            @test parse_args(["--no-trailing_zero"]).format_options[:trailing_zero] == false
+            @test parse_args(["--v2_stable_multiline_strings"]).format_options[:v2_stable_multiline_strings] == true
+            @test parse_args(["--no-v2_stable_multiline_strings"]).format_options[:v2_stable_multiline_strings] == false
+            @test parse_args(["--conditional_to_if"]).format_options[:conditional_to_if] == true
+            @test parse_args(["--no-conditional_to_if"]).format_options[:conditional_to_if] == false
+        end
+    end
+end
+
+end # module

--- a/test/argparse.jl
+++ b/test/argparse.jl
@@ -98,6 +98,7 @@ using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyl
             @test args.verbose == false
             @test args.format_markdown == false
             @test args.config_priority == false
+            @test args.ignore_config == false
             @test args.outputfile === nothing
             @test args.stdin_filename == "stdin"
             @test args.config_dir == ""
@@ -140,6 +141,12 @@ using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyl
             @test parse_args(["-v"]).verbose == true
             @test parse_args(["--format_markdown"]).format_markdown == true
             @test parse_args(["--prioritize-config-file"]).config_priority == true
+            @test parse_args(["--ignore-config"]).ignore_config == true
+        end
+
+        @testset "config file options mutual exclusion" begin
+            @test_throws ParseArgsError parse_args(["--prioritize-config-file", "--ignore-config"])
+            @test_throws ParseArgsError parse_args(["--ignore-config", "--config-dir", "foo"])
         end
 
         @testset "string options" begin

--- a/test/jlfmt_app.jl
+++ b/test/jlfmt_app.jl
@@ -419,7 +419,7 @@ else
                         `$(jlfmt_cmd()) --inplace --whitespace-in-kwargs=true $fname`,
                     )
                     output = readchomp(fname)
-                    @test output = rstrip(
+                    @test output == rstrip(
                         format_text(text, BlueStyle(); whitespace_in_kwargs = true),
                     )
                     @test output != strip(format_text(text, BlueStyle()))

--- a/test/jlfmt_app.jl
+++ b/test/jlfmt_app.jl
@@ -422,7 +422,7 @@ else
                     @test output = rstrip(
                         format_text(text, BlueStyle(); whitespace_in_kwargs = true),
                     )
-                    @test output != strip(format_text(text, BlueStyle())
+                    @test output != strip(format_text(text, BlueStyle()))
                 end
             end
 

--- a/test/jlfmt_app.jl
+++ b/test/jlfmt_app.jl
@@ -408,21 +408,21 @@ else
             @testset "config style with CLI option override" begin
                 with_sandbox() do _
                     fname = "a.jl"
-                    # BlueStyle changes formatting of named tuples: (; a = 1) -> (;a = 1)
-                    # But we also want to test that a CLI option can override a style default
+                    # BlueStyle sets f(a = 1) -> f(; a=1)
                     text = "f(a = 1)\n"
                     write(fname, text)
-                    # Config sets style=blue (which sets whitespace_in_kwargs=false by default)
+                    # But we also want to test that a CLI option can override a style default
                     # CLI overrides whitespace_in_kwargs=true
                     write(CONFIG_FILE_NAME, "style = \"blue\"")
 
                     run(
                         `$(jlfmt_cmd()) --inplace --whitespace-in-kwargs=true $fname`,
                     )
-                    @test readchomp(fname) ==
-                          rstrip(
+                    output = readchomp(fname)
+                    @test output = rstrip(
                         format_text(text, BlueStyle(); whitespace_in_kwargs = true),
                     )
+                    @test output != strip(format_text(text, BlueStyle())
                 end
             end
 

--- a/test/jlfmt_app.jl
+++ b/test/jlfmt_app.jl
@@ -306,7 +306,7 @@ else
                         JuliaFormatter.main(["--lines=abc", "a.jl"])
                     end
                     @test errno == 1
-                    @test occursin("invalid `--lines` argument", stderr)
+                    @test occursin("invalid value `abc` for option `--lines=abc`", stderr)
 
                     # start greater than stop
                     errno, stderr = capture_stderr() do

--- a/test/jlfmt_app.jl
+++ b/test/jlfmt_app.jl
@@ -335,6 +335,145 @@ else
                 end
             end
         end
+
+        @testset "config file vs CLI argument interaction" begin
+            @testset "CLI overrides config file by default" begin
+                with_sandbox() do _
+                    fname = "a.jl"
+                    text = "if true\nx = 1\nend\n"
+                    write(fname, text)
+                    write(CONFIG_FILE_NAME, "indent = 8")
+
+                    # CLI --indent=2 should win over config indent=8
+                    run(`$(jlfmt_cmd()) --inplace --indent=2 $fname`)
+                    @test readchomp(fname) == rstrip(format_text(text; indent = 2))
+                    # Sanity check: the config value (8) would give different output
+                    @test format_text(text; indent = 2) != format_text(text; indent = 8)
+                end
+            end
+
+            @testset "config provides defaults for options not on CLI" begin
+                with_sandbox() do _
+                    fname = "a.jl"
+                    text = "if true\nx = 1\nend\n"
+                    write(fname, text)
+                    # Config sets indent=8; CLI does not specify --indent
+                    write(CONFIG_FILE_NAME, "indent = 8")
+
+                    run(`$(jlfmt_cmd()) --inplace $fname`)
+                    @test readchomp(fname) == rstrip(format_text(text; indent = 8))
+                end
+            end
+
+            @testset "config and CLI options merge (different keys)" begin
+                with_sandbox() do _
+                    fname = "a.jl"
+                    text = "f(a = 1)\n"
+                    write(fname, text)
+                    # Config sets whitespace_in_kwargs=false; CLI sets indent=2
+                    # Both should take effect since they control different things
+                    write(CONFIG_FILE_NAME, "whitespace_in_kwargs = false")
+
+                    run(`$(jlfmt_cmd()) --inplace --indent=2 $fname`)
+                    @test readchomp(fname) ==
+                          rstrip(format_text(text; whitespace_in_kwargs = false, indent = 2))
+                end
+            end
+
+            @testset "--config-dir loads config from specified directory" begin
+                with_sandbox() do dir
+                    fname = "a.jl"
+                    text = "if true\nx = 1\nend\n"
+                    write(fname, text)
+
+                    # Put the config in a subdirectory, not the file's own directory
+                    config_subdir = joinpath(dir, "config")
+                    mkdir(config_subdir)
+                    write(joinpath(config_subdir, CONFIG_FILE_NAME), "indent = 8")
+
+                    # Without --config-dir, no config is found (file is in sandbox root)
+                    run(`$(jlfmt_cmd()) --inplace $fname`)
+                    default_result = readchomp(fname)
+
+                    # Reset the file
+                    write(fname, text)
+
+                    # With --config-dir, config from subdirectory is used
+                    run(`$(jlfmt_cmd()) --inplace --config-dir=$config_subdir $fname`)
+                    @test readchomp(fname) == rstrip(format_text(text; indent = 8))
+                    @test readchomp(fname) != default_result
+                end
+            end
+
+            @testset "config style with CLI option override" begin
+                with_sandbox() do _
+                    fname = "a.jl"
+                    # BlueStyle changes formatting of named tuples: (; a = 1) -> (;a = 1)
+                    # But we also want to test that a CLI option can override a style default
+                    text = "f(a = 1)\n"
+                    write(fname, text)
+                    # Config sets style=blue (which sets whitespace_in_kwargs=false by default)
+                    # CLI overrides whitespace_in_kwargs=true
+                    write(CONFIG_FILE_NAME, "style = \"blue\"")
+
+                    run(
+                        `$(jlfmt_cmd()) --inplace --whitespace-in-kwargs=true $fname`,
+                    )
+                    @test readchomp(fname) ==
+                          rstrip(
+                        format_text(text, BlueStyle(); whitespace_in_kwargs = true),
+                    )
+                end
+            end
+
+            @testset "no config file uses only CLI args" begin
+                with_sandbox() do _
+                    fname = "a.jl"
+                    text = "if true\nx = 1\nend\n"
+                    write(fname, text)
+                    # No config file written in sandbox
+
+                    run(`$(jlfmt_cmd()) --inplace --indent=8 $fname`)
+                    @test readchomp(fname) == rstrip(format_text(text; indent = 8))
+                end
+            end
+
+            @testset "CLI --ignore replaces config ignore" begin
+                text = "a+ b"
+                formatted = format_text(text)
+                @assert text != formatted
+
+                with_sandbox() do _
+                    write("keep.jl", text)
+                    write("skip.jl", text)
+                    # Config ignores "keep.jl", but CLI ignores "skip.jl" instead.
+                    # Since merge replaces the :ignore key, only CLI's pattern applies.
+                    write(CONFIG_FILE_NAME, """ignore = ["keep.jl"]\n""")
+
+                    run(`$(jlfmt_cmd()) --inplace --ignore=skip.jl .`)
+                    @test readchomp("keep.jl") == formatted
+                    @test readchomp("skip.jl") == text
+                end
+            end
+
+            @testset "--prioritize-config-file with --config-dir" begin
+                with_sandbox() do dir
+                    fname = "a.jl"
+                    text = "if true\nx = 1\nend\n"
+                    write(fname, text)
+
+                    config_subdir = joinpath(dir, "config")
+                    mkdir(config_subdir)
+                    write(joinpath(config_subdir, CONFIG_FILE_NAME), "indent = 8")
+
+                    # CLI says indent=2, but --prioritize-config-file makes config win
+                    run(
+                        `$(jlfmt_cmd()) --inplace --prioritize-config-file --config-dir=$config_subdir --indent=2 $fname`,
+                    )
+                    @test readchomp(fname) == rstrip(format_text(text; indent = 8))
+                end
+            end
+        end
     end
 end
 

--- a/test/parse_args.jl
+++ b/test/parse_args.jl
@@ -1,8 +1,8 @@
 module ParseArgsTests
 
 using Test: @test, @testset, @test_throws
-using JuliaFormatter: ParsedArgs, ParseArgsError, parse_args, OutputMode, StdoutMode, InplaceMode, CheckMode,
-    DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyle
+using JuliaFormatter.ArgParse: ParsedArgs, ParseArgsError, parse_args, OutputMode, StdoutMode, InplaceMode, CheckMode
+using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyle
 
 @testset "parse_args" begin
     @testset "empty args" begin

--- a/test/parse_args.jl
+++ b/test/parse_args.jl
@@ -196,25 +196,45 @@ using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyl
         end
     end
 
+    @testset "for-in-replacement" begin
+        for val in ["in", "=", "∈"]
+            args = parse_args(["--for-in-replacement=$val", "foo.jl"])
+            @test args.format_options[:for_in_replacement] == val
+        end
+    end
+
     @testset "boolean format options (new-style)" begin
         boolean_options = Dict(
-            "always-for-in" => :always_for_in,
-            "whitespace-typedefs" => :whitespace_typedefs,
-            "remove-extra-newlines" => :remove_extra_newlines,
-            "import-to-using" => :import_to_using,
-            "pipe-to-function-call" => :pipe_to_function_call,
-            "short-to-long-function-def" => :short_to_long_function_def,
-            "always-use-return" => :always_use_return,
-            "whitespace-in-kwargs" => :whitespace_in_kwargs,
-            "format-docstrings" => :format_docstrings,
-            "align-struct-field" => :align_struct_field,
             "align-assignment" => :align_assignment,
             "align-conditional" => :align_conditional,
+            "align-matrix" => :align_matrix,
             "align-pair-arrow" => :align_pair_arrow,
+            "align-struct-field" => :align_struct_field,
+            "always-for-in" => :always_for_in,
+            "always-use-return" => :always_use_return,
+            "annotate-untyped-fields-with-any" => :annotate_untyped_fields_with_any,
+            "conditional-to-if" => :conditional_to_if,
+            "disallow-single-arg-nesting" => :disallow_single_arg_nesting,
+            "force-long-function-def" => :force_long_function_def,
+            "format-docstrings" => :format_docstrings,
+            "import-to-using" => :import_to_using,
+            "indent-submodule" => :indent_submodule,
+            "join-lines-based-on-source" => :join_lines_based_on_source,
+            "long-to-short-function-def" => :long_to_short_function_def,
+            "pipe-to-function-call" => :pipe_to_function_call,
+            "remove-extra-newlines" => :remove_extra_newlines,
+            "separate-kwargs-with-semicolon" => :separate_kwargs_with_semicolon,
+            "short-circuit-to-if" => :short_circuit_to_if,
+            "short-to-long-function-def" => :short_to_long_function_def,
+            "surround-whereop-typeparameters" => :surround_whereop_typeparameters,
             "trailing-comma" => :trailing_comma,
             "trailing-zero" => :trailing_zero,
             "v2-stable-multiline-strings" => :v2_stable_multiline_strings,
-            "conditional-to-if" => :conditional_to_if,
+            # Note: variable-call-indent is multi/String, tested separately
+            "whitespace-in-kwargs" => :whitespace_in_kwargs,
+            "whitespace-ops-in-indices" => :whitespace_ops_in_indices,
+            "whitespace-typedefs" => :whitespace_typedefs,
+            "yas-style-nesting" => :yas_style_nesting,
         )
 
         @testset "$cli_name" for (cli_name, dest) in sort(collect(boolean_options))
@@ -229,6 +249,24 @@ using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyl
             args = parse_args(["--always-for-in=true", "foo.jl"])
             @test haskey(args.format_options, :always_for_in)
             @test !haskey(args.format_options, :trailing_comma)
+        end
+
+        @testset "variable-call-indent (multi)" begin
+            args = parse_args(["--variable-call-indent=Dict", "foo.jl"])
+            @test args.format_options[:variable_call_indent] == ["Dict"]
+
+            args = parse_args(["--variable-call-indent=Dict", "--variable-call-indent=Foo", "foo.jl"])
+            @test args.format_options[:variable_call_indent] == ["Dict", "Foo"]
+
+            args = parse_args(["foo.jl"])
+            @test !haskey(args.format_options, :variable_call_indent)
+        end
+
+        @testset "nothing values for always-for-in and trailing-comma" begin
+            args = parse_args(["--always-for-in=nothing", "foo.jl"])
+            @test args.format_options[:always_for_in] === nothing
+            args = parse_args(["--trailing-comma=nothing", "foo.jl"])
+            @test args.format_options[:trailing_comma] === nothing
         end
     end
 

--- a/test/parse_args.jl
+++ b/test/parse_args.jl
@@ -169,14 +169,26 @@ using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyl
             @test args.format_options[:margin] == 80
         end
 
-        @testset "sciml_margin_overrun" begin
+        @testset "sciml-margin-overrun" begin
+            args = parse_args(["--sciml-margin-overrun=10", "foo.jl"])
+            @test args.format_options[:sciml_margin_overrun] == 10
+        end
+
+        @testset "sciml_margin_overrun (deprecated)" begin
             args = parse_args(["--sciml_margin_overrun=10", "foo.jl"])
             @test args.format_options[:sciml_margin_overrun] == 10
         end
     end
 
     @testset "string format options" begin
-        @testset "normalize_line_endings" begin
+        @testset "normalize-line-endings" begin
+            for mode in ["auto", "unix", "windows"]
+                args = parse_args(["--normalize-line-endings=$mode", "foo.jl"])
+                @test args.format_options[:normalize_line_endings] == mode
+            end
+        end
+
+        @testset "normalize_line_endings (deprecated)" begin
             for mode in ["auto", "unix", "windows"]
                 args = parse_args(["--normalize_line_endings=$mode", "foo.jl"])
                 @test args.format_options[:normalize_line_endings] == mode
@@ -184,8 +196,44 @@ using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyl
         end
     end
 
-    @testset "boolean format options" begin
-        boolean_options = [
+    @testset "boolean format options (new-style)" begin
+        boolean_options = Dict(
+            "always-for-in" => :always_for_in,
+            "whitespace-typedefs" => :whitespace_typedefs,
+            "remove-extra-newlines" => :remove_extra_newlines,
+            "import-to-using" => :import_to_using,
+            "pipe-to-function-call" => :pipe_to_function_call,
+            "short-to-long-function-def" => :short_to_long_function_def,
+            "always-use-return" => :always_use_return,
+            "whitespace-in-kwargs" => :whitespace_in_kwargs,
+            "format-docstrings" => :format_docstrings,
+            "align-struct-field" => :align_struct_field,
+            "align-assignment" => :align_assignment,
+            "align-conditional" => :align_conditional,
+            "align-pair-arrow" => :align_pair_arrow,
+            "trailing-comma" => :trailing_comma,
+            "trailing-zero" => :trailing_zero,
+            "v2-stable-multiline-strings" => :v2_stable_multiline_strings,
+            "conditional-to-if" => :conditional_to_if,
+        )
+
+        @testset "$cli_name" for (cli_name, dest) in sort(collect(boolean_options))
+            args = parse_args(["--$cli_name=true", "foo.jl"])
+            @test args.format_options[dest] == true
+
+            args = parse_args(["--$cli_name=false", "foo.jl"])
+            @test args.format_options[dest] == false
+        end
+
+        @testset "only set options appear in format_options" begin
+            args = parse_args(["--always-for-in=true", "foo.jl"])
+            @test haskey(args.format_options, :always_for_in)
+            @test !haskey(args.format_options, :trailing_comma)
+        end
+    end
+
+    @testset "boolean format options (deprecated negatable flags)" begin
+        deprecated_options = [
             :always_for_in,
             :whitespace_typedefs,
             :remove_extra_newlines,
@@ -205,20 +253,12 @@ using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyl
             :conditional_to_if,
         ]
 
-        @testset "$opt" for opt in boolean_options
-            # --flag sets to true
+        @testset "$opt" for opt in deprecated_options
             args = parse_args(["--$opt", "foo.jl"])
             @test args.format_options[opt] == true
 
-            # --no-flag sets to false
             args = parse_args(["--no-$opt", "foo.jl"])
             @test args.format_options[opt] == false
-        end
-
-        @testset "only set options appear in format_options" begin
-            args = parse_args(["--always_for_in", "foo.jl"])
-            @test haskey(args.format_options, :always_for_in)
-            @test !haskey(args.format_options, :trailing_comma)
         end
     end
 
@@ -245,8 +285,14 @@ using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyl
         args = parse_args(["--indent=2", "--indent=4", "foo.jl"])
         @test args.format_options[:indent] == 4
 
-        args = parse_args(["--always_for_in", "--no-always_for_in", "foo.jl"])
+        args = parse_args(["--always-for-in=true", "--always-for-in=false", "foo.jl"])
         @test args.format_options[:always_for_in] == false
+
+        # deprecated and new-style can be mixed, last wins
+        args = parse_args(["--always_for_in", "--always-for-in=false", "foo.jl"])
+        @test args.format_options[:always_for_in] == false
+        args = parse_args(["--always-for-in=false", "--always_for_in", "foo.jl"])
+        @test args.format_options[:always_for_in] == true
     end
 
     @testset "stdin marker" begin

--- a/test/parse_args.jl
+++ b/test/parse_args.jl
@@ -1,0 +1,258 @@
+module ParseArgsTests
+
+using Test: @test, @testset, @test_throws
+using JuliaFormatter: ParsedArgs, ParseArgsError, parse_args, OutputMode, StdoutMode, InplaceMode, CheckMode,
+    DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyle
+
+@testset "parse_args" begin
+    @testset "empty args" begin
+        args = parse_args(String[])
+        @test args.paths == []
+        @test args.mode == StdoutMode
+        @test args.diff == false
+        @test args.verbose == false
+        @test args.format_markdown == false
+        @test args.config_priority == false
+        @test args.outputfile === nothing
+        @test args.stdin_filename == "stdin"
+        @test args.config_dir == ""
+        @test args.ignore_patterns == []
+        @test args.line_ranges == []
+        @test args.format_options == Dict{Symbol,Any}()
+        @test args.help == false
+        @test args.version == false
+    end
+
+    @testset "help" begin
+        for flag in ["-h", "--help"]
+            args = parse_args([flag])
+            @test args.help == true
+        end
+    end
+
+    @testset "version" begin
+        args = parse_args(["--version"])
+        @test args.version == true
+    end
+
+    @testset "output mode" begin
+        @testset "inplace" begin
+            for flag in ["-i", "--inplace"]
+                args = parse_args([flag, "foo.jl"])
+                @test args.mode == InplaceMode
+            end
+        end
+
+        @testset "check" begin
+            for flag in ["-c", "--check"]
+                args = parse_args([flag, "foo.jl"])
+                @test args.mode == CheckMode
+            end
+        end
+
+        @testset "stdout (default)" begin
+            args = parse_args(["foo.jl"])
+            @test args.mode == StdoutMode
+        end
+
+        @testset "mutual exclusion" begin
+            @test_throws ParseArgsError parse_args(["--check", "--inplace", "foo.jl"])
+            @test_throws ParseArgsError parse_args(["--check", "-o", "out.jl", "foo.jl"])
+            @test_throws ParseArgsError parse_args(["--inplace", "--output=out.jl", "foo.jl"])
+        end
+    end
+
+    @testset "boolean flags" begin
+        @testset "diff" begin
+            for flag in ["-d", "--diff"]
+                args = parse_args([flag, "foo.jl"])
+                @test args.diff == true
+            end
+        end
+
+        @testset "verbose" begin
+            for flag in ["-v", "--verbose"]
+                args = parse_args([flag, "foo.jl"])
+                @test args.verbose == true
+            end
+        end
+
+        @testset "format_markdown" begin
+            args = parse_args(["--format_markdown", "foo.jl"])
+            @test args.format_markdown == true
+        end
+
+        @testset "prioritize-config-file" begin
+            args = parse_args(["--prioritize-config-file", "foo.jl"])
+            @test args.config_priority == true
+        end
+    end
+
+    @testset "output" begin
+        @testset "-o flag" begin
+            args = parse_args(["-o", "out.jl", "foo.jl"])
+            @test args.outputfile == "out.jl"
+        end
+
+        @testset "--output= flag" begin
+            args = parse_args(["--output=out.jl", "foo.jl"])
+            @test args.outputfile == "out.jl"
+        end
+
+        @testset "-o without argument" begin
+            @test_throws ParseArgsError parse_args(["-o"])
+        end
+    end
+
+    @testset "stdin-filename" begin
+        args = parse_args(["--stdin-filename=myfile.jl"])
+        @test args.stdin_filename == "myfile.jl"
+    end
+
+    @testset "config-dir" begin
+        args = parse_args(["--config-dir=/some/path"])
+        @test args.config_dir == "/some/path"
+    end
+
+    @testset "style" begin
+        expected = Dict(
+            "default" => DefaultStyle(), "yas" => YASStyle(), "blue" => BlueStyle(),
+            "sciml" => SciMLStyle(), "minimal" => MinimalStyle(),
+        )
+        for (name, style) in expected
+            args = parse_args(["--style=$name", "foo.jl"])
+            @test args.format_options[:style] == style
+        end
+        @test_throws ParseArgsError parse_args(["--style=nonexistent", "foo.jl"])
+    end
+
+    @testset "ignore patterns" begin
+        @testset "single pattern" begin
+            args = parse_args(["--ignore=*.tmp", "foo.jl"])
+            @test args.ignore_patterns == ["*.tmp"]
+        end
+
+        @testset "multiple patterns" begin
+            args = parse_args(["--ignore=*.tmp", "--ignore=*/test/*", "foo.jl"])
+            @test args.ignore_patterns == ["*.tmp", "*/test/*"]
+        end
+    end
+
+    @testset "line ranges" begin
+        @testset "single range" begin
+            args = parse_args(["--lines=1:10", "foo.jl"])
+            @test args.line_ranges == [(1, 10)]
+        end
+
+        @testset "multiple ranges" begin
+            args = parse_args(["--lines=1:10", "--lines=42:47", "foo.jl"])
+            @test args.line_ranges == [(1, 10), (42, 47)]
+        end
+
+        @testset "malformed range" begin
+            @test_throws ParseArgsError parse_args(["--lines=abc", "foo.jl"])
+        end
+
+        @testset "start greater than stop" begin
+            @test_throws ParseArgsError parse_args(["--lines=5:2", "foo.jl"])
+        end
+    end
+
+    @testset "integer format options" begin
+        @testset "indent" begin
+            args = parse_args(["--indent=2", "foo.jl"])
+            @test args.format_options[:indent] == 2
+        end
+
+        @testset "margin" begin
+            args = parse_args(["--margin=80", "foo.jl"])
+            @test args.format_options[:margin] == 80
+        end
+
+        @testset "sciml_margin_overrun" begin
+            args = parse_args(["--sciml_margin_overrun=10", "foo.jl"])
+            @test args.format_options[:sciml_margin_overrun] == 10
+        end
+    end
+
+    @testset "string format options" begin
+        @testset "normalize_line_endings" begin
+            for mode in ["auto", "unix", "windows"]
+                args = parse_args(["--normalize_line_endings=$mode", "foo.jl"])
+                @test args.format_options[:normalize_line_endings] == mode
+            end
+        end
+    end
+
+    @testset "boolean format options" begin
+        boolean_options = [
+            :always_for_in,
+            :whitespace_typedefs,
+            :remove_extra_newlines,
+            :import_to_using,
+            :pipe_to_function_call,
+            :short_to_long_function_def,
+            :always_use_return,
+            :whitespace_in_kwargs,
+            :format_docstrings,
+            :align_struct_field,
+            :align_assignment,
+            :align_conditional,
+            :align_pair_arrow,
+            :trailing_comma,
+            :trailing_zero,
+            :v2_stable_multiline_strings,
+            :conditional_to_if,
+        ]
+
+        @testset "$opt" for opt in boolean_options
+            # --flag sets to true
+            args = parse_args(["--$opt", "foo.jl"])
+            @test args.format_options[opt] == true
+
+            # --no-flag sets to false
+            args = parse_args(["--no-$opt", "foo.jl"])
+            @test args.format_options[opt] == false
+        end
+
+        @testset "only set options appear in format_options" begin
+            args = parse_args(["--always_for_in", "foo.jl"])
+            @test haskey(args.format_options, :always_for_in)
+            @test !haskey(args.format_options, :trailing_comma)
+        end
+    end
+
+    @testset "positional paths" begin
+        args = parse_args(["foo.jl"])
+        @test args.paths == ["foo.jl"]
+
+        args = parse_args(["foo.jl", "bar.jl", "src/"])
+        @test args.paths == ["foo.jl", "bar.jl", "src/"]
+    end
+
+    @testset "mixed flags and paths" begin
+        args = parse_args(["--inplace", "--style=blue", "--indent=2", "src/", "lib/"])
+        @test args.mode == InplaceMode
+        @test args.format_options[:style] == BlueStyle()
+        @test args.format_options[:indent] == 2
+        @test args.paths == ["src/", "lib/"]
+    end
+
+    @testset "last value wins for repeated options" begin
+        args = parse_args(["--style=blue", "--style=yas", "foo.jl"])
+        @test args.format_options[:style] == YASStyle()
+
+        args = parse_args(["--indent=2", "--indent=4", "foo.jl"])
+        @test args.format_options[:indent] == 4
+
+        args = parse_args(["--always_for_in", "--no-always_for_in", "foo.jl"])
+        @test args.format_options[:always_for_in] == false
+    end
+
+    @testset "stdin marker" begin
+        args = parse_args(["-"])
+        @test args.paths == ["-"]
+    end
+end
+
+end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,5 +23,7 @@ Pkg.develop(; path = dirname(@__DIR__))
     include("interface.jl")
     include("config.jl")
     include("format_repo.jl")
+    include("argparse.jl")
+    include("parse_args.jl")
     include("jlfmt_app.jl")
 end


### PR DESCRIPTION
Closes #1031.

I thought that was low priority, but I wanted to add the remaining unimplemented options to the CLI, and I **really** didn't want to have to repeat myself over and over again. So this PR completely rewrites the argument parsing.

I find myself missing Haskell's `optparse-applicative` whenever I write any language that isn't Haskell, so I made this quite similar in style. Basically, it's declarative in nature: you define what your options are, and then lump them together into a single struct, and that struct knows how to both parse the options and also generate the help text.

Because there's some custom logic inside here (see e.g. the deprecated flag section), I didn't bother reaching for an external library.

On the plus side, the argument parsing is also much more testable now which will help avoid regressions. I will happily admit that most of this was Claude-generated, but I personally designed & reviewed all of it, and if you're a user, you should probably be relieved that the argument parsing is actually tested now as there used to be bugs with it (see e.g. #1021).