### PR TITLE
Fix trailing newline handling

### DIFF
--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,3 +1,7 @@
+# v2.9.3
+
+Fixed a bug where even if Windows line endings were specified (either via `normalize_line_endings="windows"` or if the original file had Windows line endings), calling `format()` on the file would still append a final Unix trailing newline to the file. (#1155)
+
 # v2.9.2
 
 Fixed a bug where `pipe_to_function_call` would remove parentheses from the argument of a function call even if the argument was an assignment, changing the meaning of the code. (#1147, #1148)

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.9.2"
+version = "2.9.3"
 authors = ["Dominique Luna <dluna132@gmail.com> and contributors"]
 
 [workspace]

--- a/src/app.jl
+++ b/src/app.jl
@@ -458,16 +458,13 @@ function process_file(args::ProcessFileArgs)
     merged_options = get_formatting_options(config)
 
     formatted_str = try
-        _formatted_str = if is_markdown
+        if is_markdown
             _format_md(sourcetext, style, merged_options)
         elseif !isempty(args.line_ranges)
             _format_line_ranges(sourcetext, style, args.line_ranges, merged_options)
         else
-            _format_text(sourcetext, style, merged_options; check_output = true)
+            _format_text(sourcetext, style, merged_options; check_output = true, ensure_trailing_newline = true)
         end
-        # Since it's a file, presumably we only want one trailing newline, so
-        # we normalise it here.
-        replace(_formatted_str, r"\n*$" => "\n")
     catch err
         if err isa JuliaSyntax.ParseError
             report_status() do io

--- a/src/app.jl
+++ b/src/app.jl
@@ -463,7 +463,13 @@ function process_file(args::ProcessFileArgs)
         elseif !isempty(args.line_ranges)
             _format_line_ranges(sourcetext, style, args.line_ranges, merged_options)
         else
-            _format_text(sourcetext, style, merged_options; check_output = true, ensure_trailing_newline = true)
+            _format_text(
+                sourcetext,
+                style,
+                merged_options;
+                check_output = true,
+                ensure_trailing_newline = true,
+            )
         end
     catch err
         if err isa JuliaSyntax.ParseError

--- a/src/format.jl
+++ b/src/format.jl
@@ -54,7 +54,10 @@ _maxiters(::SciMLStyle) = 4
 """
     _format_text(
         text::AbstractString, style::AbstractStyle, opts::Options{Union{}};
-        check_output::Bool=true, maxiters::Int=1)
+        check_output::Bool=true,
+        maxiters::Int=1,
+        ensure_trailing_newline::Bool=false
+    )
 
 The lower-level entry point for text formatting.
 
@@ -67,6 +70,12 @@ The `maxiters` keyword argument is specified in order to allow the formatting al
 iterate to a fixed point. This is a hack and should really not be used, but currently
 SciMLStyle is not idempotent and requires multiple iterations to reach a fixed point. By
 default `maxiters` is set to 1, i.e., only one pass.
+
+If `ensure_trailing_newline` is set to `true`, the function will ensure that the formatted
+text ends with a single newline character. This might be either CRLF or LF depending on the
+line ending normalization settings. If set to `false`, the function will not modify the
+trailing newline character(s) in the formatted text. This option is useful when formatting
+files.
 """
 function _format_text(
     text::AbstractString,
@@ -74,9 +83,15 @@ function _format_text(
     opts::Options{Union{}};
     check_output::Bool = true,
     maxiters::Int = _maxiters(style),
+    ensure_trailing_newline::Bool = false,
 )
     maxiters <= 0 && return text
-    isempty(text) && return text
+    if isempty(text)
+        if ensure_trailing_newline
+            return opts.normalize_line_endings == "windows" ? "\r\n" : "\n"
+        end
+        return text
+    end
 
     node = JuliaSyntax.parseall(
         JuliaSyntax.GreenNode,
@@ -143,6 +158,16 @@ function _format_text(
         choose_line_ending_replacer(s.doc.srcfile.code)
     end
     output = normalize_line_ending(output, replacer)
+    
+    output = if ensure_trailing_newline
+        if replacer == WINDOWS_TO_UNIX
+            replace(output, r"\n*$" => "\n")
+        else
+            replace(output, r"(\r\n)*$" => "\r\n")
+        end
+    else
+        output
+    end
 
     if check_output
         try
@@ -182,15 +207,16 @@ function _format_file(filename::AbstractString, config::Configuration)::Bool
         config.format_markdown || return true
         config.verbose && println("Formatting $filename")
         str = String(read(filename))
+        # Already guarantees trailing newline, although newlines in Markdown are not
+        # normalised (that's a CommonMark thing, not JuliaFormatter).
         _format_md(str, config.style, merged_options)
     elseif ext == ".jl" || match(shebang_pattern, readline(filename)) !== nothing
         config.verbose && println("Formatting $filename")
         str = String(read(filename))
-        _format_text(str, config.style, merged_options)
+        _format_text(str, config.style, merged_options; ensure_trailing_newline = true)
     else
         throw(InvalidFileError(filename))
     end
-    formatted_str = replace(formatted_str, r"\n*$" => "\n")
 
     already_formatted = (formatted_str == str)
     if config.overwrite && !already_formatted

--- a/src/format.jl
+++ b/src/format.jl
@@ -158,7 +158,7 @@ function _format_text(
         choose_line_ending_replacer(s.doc.srcfile.code)
     end
     output = normalize_line_ending(output, replacer)
-    
+
     output = if ensure_trailing_newline
         if replacer == WINDOWS_TO_UNIX
             replace(output, r"\n*$" => "\n")

--- a/test/dispatch.jl
+++ b/test/dispatch.jl
@@ -169,6 +169,22 @@ end
         end
     end
 
+    @testset "newline handling" begin
+        for nls in ("", "\n", "\n\n")
+            with_tempfile(nls) do path
+                already = format(path)
+                @test read(path, String) == "\n"
+            end
+        end
+
+        for nls in ("\r\n", "\r\n\r\n")
+            with_tempfile(nls) do path
+                already = format(path)
+                @test read(path, String) == "\r\n"
+            end
+        end
+    end
+
     @testset "keyword style" begin
         with_tempfile(UNFORMATTED_KW) do path
             format(path; style = BlueStyle())


### PR DESCRIPTION
If `normalize_line_endings` is set to `windows`, or if it's set to `auto` and the file already has CRLFs, calling `JuliaFormatter.format()` or `jlfmt` on a file would append a final newline to it. Problem: it would be a LF, not CRLF.

This fixes it such that the trailing newline is correctly added as either LF or CRLF depending on the settings.