### PR TITLE
fix unhelpful diff filenames

### DIFF
--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,6 +1,8 @@
 # v2.9.3
 
-Fixed a bug where even if Windows line endings were specified (either via `normalize_line_endings="windows"` or if the original file had Windows line endings), calling `format()` on the file would still append a final Unix trailing newline to the file. (#1155)
+Fixed a bug where even if Windows line endings were specified (either via `normalize_line_endings="windows"` or if the original file had Windows line endings), calling `format()` on the file would still append a final Unix trailing newline to the file. (#1156)
+
+Improved the output of `jlfmt --diff` to show the full name of the file being formatted, instead of just the base name. (#1152, #1157)
 
 # v2.9.2
 

--- a/src/app.jl
+++ b/src/app.jl
@@ -536,11 +536,12 @@ function process_file(args::ProcessFileArgs)
 
     if changed && args.diff
         mktempdir() do dir
-            a = mkdir(joinpath(dir, "a"))
-            b = mkdir(joinpath(dir, "b"))
-            file = basename(inputfile_pretty)
-            A = joinpath(a, file)
-            B = joinpath(b, file)
+            a = joinpath(dir, "original")
+            b = joinpath(dir, "formatted")
+            A = joinpath(a, inputfile_pretty)
+            B = joinpath(b, inputfile_pretty)
+            mkpath(dirname(A))
+            mkpath(dirname(B))
             write(A, sourcetext)
             write(B, formatted_str)
             color = supports_color(stderr) ? "always" : "never"


### PR DESCRIPTION
closes #1152

it now does something like

```diff
diff --git original/test/options/v2_stable_multiline_strings.jl formatted/test/options/v2_stable_multiline_strings.jl
index 2a223ba..d30af47 100644
--- original/test/options/v2_stable_multiline_strings.jl
+++ formatted/test/options/v2_stable_multiline_strings.jl
@@ -1,6 +1,7 @@
 module V2StableMultilineStringsTests

-using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyle, format_text, JuliaFormatter
+using JuliaFormatter:
+    DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyle, format_text, JuliaFormatter
 using JuliaFormatter.Internal: test_format, format_to_stage, ALL_STYLES
 using Test
```