### PR TITLE
Use textwidth() instead of length()

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -88,10 +88,11 @@ jobs:
             end
           end
 
-      - name: Count Julia lines
+      - name: Count Julia files and lines
         run: |
+          files=$(find target -name '*.jl' -type f | wc -l)
           lines=$(find target -name '*.jl' -type f -print0 | xargs -0 cat | wc -l)
-          echo "Formatting $lines lines of Julia"
+          echo "Formatting $files files, $lines lines of Julia"
 
       - name: Format (pass 1)
         working-directory: target

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Format (pass 1)
         working-directory: target
         run: |
-          julia --project=../formatter -m JuliaFormatter --inplace --verbose --style=${{ matrix.style }} ${{ env.FORMATTER_OPTS }} .
+          julia --project=../formatter -m JuliaFormatter --inplace --style=${{ matrix.style }} ${{ env.FORMATTER_OPTS }} .
 
       - name: Check idempotence (pass 2)
         working-directory: target

--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,3 +1,7 @@
+# v2.9.4
+
+Fixed several instances where JuliaFormatter would use `length()` instead of `textwidth()`, leading to incorrect or non-idempotent formatting when non-ASCII characters were present. (#1166, #1167)
+
 # v2.9.3
 
 Fixed a bug where even if Windows line endings were specified (either via `normalize_line_endings="windows"` or if the original file had Windows line endings), calling `format()` on the file would still append a final Unix trailing newline to the file. (#1156)

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.9.3"
+version = "2.9.4"
 authors = ["Dominique Luna <dluna132@gmail.com> and contributors"]
 
 [workspace]

--- a/src/align.jl
+++ b/src/align.jl
@@ -1,13 +1,9 @@
 """
-    align_fst!(fst::FST, doc::Document, opts::Options)
+    align_fst!(fst::FST, opts::Options)
 
 Walk `fst` and apply the alignment passes enabled by `opts`.
-
-`doc` is the original source document and is used to translate parser line offsets into
-display columns before padding is adjusted. This keeps alignment stable for source text
-containing combining and other zero-width characters.
 """
-function align_fst!(fst::FST, doc::Document, opts::Options)
+function align_fst!(fst::FST, opts::Options)
     if is_leaf(fst)
         return
     end
@@ -18,15 +14,15 @@ function align_fst!(fst::FST, doc::Document, opts::Options)
         if is_leaf(n)
             continue
         elseif opts.align_struct_field && (n.typ === Struct || n.typ === Mutable)
-            align_struct!(doc, n)
+            align_struct!(n)
         elseif opts.align_conditional && n.typ === Conditional
-            align_conditional!(doc, n)
+            align_conditional!(n)
         elseif opts.align_matrix && (
             n.typ === Vcat || n.typ === TypedVcat || n.typ === Ncat || n.typ === TypedNcat
         )
-            align_matrix!(doc, n)
+            align_matrix!(n)
         else
-            align_fst!(n, doc, opts)
+            align_fst!(n, opts)
         end
 
         if opts.align_assignment && (is_assignment(n) || n.typ === Kw)
@@ -38,8 +34,8 @@ function align_fst!(fst::FST, doc::Document, opts::Options)
         end
     end
 
-    align_binaryopcalls!(doc, fst, assignment_inds)
-    align_binaryopcalls!(doc, fst, pair_arrow_inds)
+    align_binaryopcalls!(fst, assignment_inds)
+    align_binaryopcalls!(fst, pair_arrow_inds)
 end
 
 """
@@ -66,27 +62,6 @@ struct AlignGroup
 end
 AlignGroup() = AlignGroup(FST[], Int[], Int[], Int[], Int[])
 
-"""
-    source_display_line_offset(doc::Document, line::Int, line_offset::Int) -> Int
-
-Convert a 1-based source line offset into a 1-based display column for `line` in `doc`.
-
-`line_offset` follows the offsets recorded in the parsed source and therefore advances
-through the original text representation. Alignment, however, needs display width semantics
-so that combining marks and other zero-width codepoints do not consume extra padding. This
-helper measures the source line prefix with `textwidth` and returns the corresponding
-display column.
-"""
-function source_display_line_offset(doc::Document, line::Int, line_offset::Int)
-    line_offset <= 1 && return 1
-
-    code = JuliaSyntax.sourcetext(doc.srcfile)
-    line_start = doc.srcfile.line_starts[line]
-    offset = line_start + line_offset - 1
-    prefix_end = prevind(code, offset)
-
-    return textwidth(code[line_start:prefix_end]) + 1
-end
 
 function Base.push!(g::AlignGroup, n::FST, ind::Int, line_offset::Int, len::Int, ws::Int)
     push!(g.nodes, n)
@@ -164,15 +139,14 @@ function node_align_length(nodes::Vector{FST})
 end
 
 """
-    align_binaryopcalls!(doc::Document, fst::FST, op_inds::Vector{Int})
+    align_binaryopcalls!(fst::FST, op_inds::Vector{Int})
 
 Aligns binary operator expressions.
 
 Additionally handles the case where a keyword such as `const` is used prior to the binary op
-call. `doc` is used to compare source locations in display columns rather than raw source
-offsets.
+call.
 """
-function align_binaryopcalls!(doc::Document, fst::FST, op_inds::Vector{Int})
+function align_binaryopcalls!(fst::FST, op_inds::Vector{Int})
     if !(length(op_inds) > 1)
         return
     end
@@ -189,11 +163,7 @@ function align_binaryopcalls!(doc::Document, fst::FST, op_inds::Vector{Int})
 
         binop, nlen, ws = if n.typ === Binary || n.typ === Kw
             nlen = node_align_length(n[1])
-            start_offset = source_display_line_offset(doc, n.startline, n.line_offset)
-            op_offset =
-                source_display_line_offset(doc, n[3].startline, n[3].line_offset)
-
-            n, nlen, op_offset - start_offset - nlen
+            n, nlen, n[3].line_offset - n.line_offset - nlen
         else
             binop::Union{FST,Nothing} = nothing
             sn = n
@@ -210,16 +180,7 @@ function align_binaryopcalls!(doc::Document, fst::FST, op_inds::Vector{Int})
                 else
                     binop = (sn.nodes::Vector{FST})[binop_ind]
                     nlen += node_align_length(binop[1])
-                    start_offset =
-                        source_display_line_offset(doc, n.startline, n.line_offset)
-
-                    op_offset = source_display_line_offset(
-                        doc,
-                        binop[3].startline,
-                        binop[3].line_offset,
-                    )
-
-                    ws = op_offset - start_offset - nlen
+                    ws = binop[3].line_offset - n.line_offset - nlen
                     break
                 end
             end
@@ -233,10 +194,7 @@ function align_binaryopcalls!(doc::Document, fst::FST, op_inds::Vector{Int})
 
         push!(g.nodes, binop)
         push!(g.node_inds, i)
-        push!(
-            g.line_offsets,
-            source_display_line_offset(doc, binop[3].startline, binop[3].line_offset),
-        )
+        push!(g.line_offsets, binop[3].line_offset)
         push!(g.lens, nlen)
         push!(g.whitespaces, ws)
 
@@ -261,14 +219,11 @@ function align_binaryopcalls!(doc::Document, fst::FST, op_inds::Vector{Int})
 end
 
 """
-    align_struct!(doc::Document, fst::FST)
+    align_struct!(fst::FST)
 
 Aligns struct fields.
-
-`doc` supplies the original source text so field and type operator columns can be measured
-using display width.
 """
-function align_struct!(doc::Document, fst::FST)
+function align_struct!(fst::FST)
     ind = findfirst(n -> n.typ === Block, fst.nodes)
     if isnothing(ind) || length(fst[ind]) == 0
         return
@@ -298,14 +253,11 @@ function align_struct!(doc::Document, fst::FST)
                 continue
             end
 
-            start_offset = source_display_line_offset(doc, n.startline, n.line_offset)
-            op_offset =
-                source_display_line_offset(doc, n[ind].startline, n[ind].line_offset)
-            ws = op_offset - start_offset - nlen
+            ws = n[ind].line_offset - n.line_offset - nlen
 
             push!(g.nodes, n)
             push!(g.node_inds, i)
-            push!(g.line_offsets, op_offset)
+            push!(g.line_offsets, n[ind].line_offset)
             push!(g.lens, nlen)
             push!(g.whitespaces, ws)
 
@@ -323,17 +275,11 @@ function align_struct!(doc::Document, fst::FST)
             if ind === nothing
                 continue
             end
-            start_offset = source_display_line_offset(doc, n.startline, n.line_offset)
-            op_offset = source_display_line_offset(
-                doc,
-                binop[ind].startline,
-                binop[ind].line_offset,
-            )
-            ws = op_offset - start_offset - nlen
+            ws = binop[ind].line_offset - n.line_offset - nlen
 
             push!(g.nodes, binop)
             push!(g.node_inds, i)
-            push!(g.line_offsets, op_offset)
+            push!(g.line_offsets, binop[ind].line_offset)
             push!(g.lens, nlen)
             push!(g.whitespaces, ws)
 
@@ -356,14 +302,11 @@ function align_struct!(doc::Document, fst::FST)
 end
 
 """
-    align_conditional!(doc::Document, fst::FST)
+    align_conditional!(fst::FST)
 
 Aligns a conditional expression.
-
-`doc` supplies the original source text so `?` and `:` alignment is computed using display
-columns.
 """
-function align_conditional!(doc::Document, fst::FST)
+function align_conditional!(fst::FST)
     nodes = flatten_conditionalopcall(fst)
 
     cond_group = AlignGroup()
@@ -376,17 +319,11 @@ function align_conditional!(doc::Document, fst::FST)
         if n.typ === OPERATOR && n.val == "?"
             if cond_prev_endline != n.endline
                 nlen = node_align_length(nodes[i-2])
-                start_offset = source_display_line_offset(
-                    doc,
-                    nodes[i-2].startline,
-                    nodes[i-2].line_offset,
-                )
-                op_offset = source_display_line_offset(doc, n.startline, n.line_offset)
-                ws = op_offset - start_offset - nlen
+                ws = n.line_offset - nodes[i-2].line_offset - nlen
 
                 push!(cond_group.nodes, n)
                 push!(cond_group.node_inds, i)
-                push!(cond_group.line_offsets, op_offset)
+                push!(cond_group.line_offsets, n.line_offset)
                 push!(cond_group.lens, nlen)
                 push!(cond_group.whitespaces, ws)
             end
@@ -394,17 +331,11 @@ function align_conditional!(doc::Document, fst::FST)
         elseif n.typ === OPERATOR && n.val == ":"
             if colon_prev_endline != n.endline
                 nlen = node_align_length(nodes[i-2])
-                start_offset = source_display_line_offset(
-                    doc,
-                    nodes[i-2].startline,
-                    nodes[i-2].line_offset,
-                )
-                op_offset = source_display_line_offset(doc, n.startline, n.line_offset)
-                ws = op_offset - start_offset - nlen
+                ws = n.line_offset - nodes[i-2].line_offset - nlen
 
                 push!(colon_group.nodes, n)
                 push!(colon_group.node_inds, i)
-                push!(colon_group.line_offsets, op_offset)
+                push!(colon_group.line_offsets, n.line_offset)
                 push!(colon_group.lens, nlen)
                 push!(colon_group.whitespaces, ws)
             end
@@ -450,28 +381,23 @@ function align_conditional!(doc::Document, fst::FST)
 end
 
 """
-    align_matrix!(doc::Document, fst::FST)
+    align_matrix!(fst::FST)
 
 Adjust whitespace between matrix elements so it matches the original source layout.
-
-`doc` is used to recover the source display columns for each element, which avoids
-overpadding when the source contains zero-width characters.
 """
-function align_matrix!(doc::Document, fst::FST)
+function align_matrix!(fst::FST)
     rows = filter(n -> n.typ === Row, fst.nodes::Vector{FST})
     if length(rows) == 0
         return
     end
 
-    min_offset = minimum(map(rows) do r
-        source_display_line_offset(doc, r[1].startline, r[1].line_offset)
-    end)
+    min_offset = minimum(r -> r[1].line_offset, rows)
 
     line = 0
     # add whitespace prior to initial element if elements are aligned to the right and
     # it's the first row on that line.
     for r in rows
-        row_offset = source_display_line_offset(doc, r[1].startline, r[1].line_offset)
+        row_offset = r[1].line_offset
         if row_offset > min_offset && line != r.startline
             diff = row_offset - min_offset
             if diff > 0
@@ -488,10 +414,7 @@ function align_matrix!(doc::Document, fst::FST)
                 n1 = r[i-1]
                 n2 = r[i+1]
 
-                diff =
-                    source_display_line_offset(doc, n2.startline, n2.line_offset) -
-                    source_display_line_offset(doc, n1.startline, n1.line_offset) -
-                    node_align_length(n1)
+                diff = n2.line_offset - n1.line_offset - node_align_length(n1)
 
                 # fix #694 and #713
                 if diff > 0

--- a/src/align.jl
+++ b/src/align.jl
@@ -62,7 +62,6 @@ struct AlignGroup
 end
 AlignGroup() = AlignGroup(FST[], Int[], Int[], Int[], Int[])
 
-
 function Base.push!(g::AlignGroup, n::FST, ind::Int, line_offset::Int, len::Int, ws::Int)
     push!(g.nodes, n)
     push!(g.node_inds, ind)

--- a/src/format.jl
+++ b/src/format.jl
@@ -118,7 +118,7 @@ function _format_text(
     end
 
     if needs_alignment(s.opts)
-        align_fst!(fst, s.doc, s.opts)
+        align_fst!(fst, s.opts)
     end
 
     nest!(style, fst, s)

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -133,8 +133,7 @@ mutable struct FST
     # comment rather than a true invariant right now.
     indent::Int
 
-    # TODO(penelopeysm) This uses length(op.val) which is character count
-    # It should really use textwidth.
+    # Display width of the node's content (measured in terminal columns via `textwidth`).
     len::Int
     val::String
     # Note that nodes = () indicates a leaf node, whereas nodes = [] indicates a tree node
@@ -231,7 +230,7 @@ function FST(
         startline,
         endline,
         0,
-        length(val),
+        textwidth(val),
         val,
         (),
         AllowNest,
@@ -904,13 +903,13 @@ function eq_to_in_normalization!(fst::FST, always_for_in::Bool, for_in_replaceme
         old_op_len = op.len
         if always_for_in
             op.val = for_in_replacement
-            op.len = length(op.val)
+            op.len = textwidth(op.val)
         elseif op.val == "=" && op_kind(fst[end]) !== K":"
             op.val = "in"
-            op.len = length(op.val)
+            op.len = textwidth(op.val)
         elseif op.val == "in" && op_kind(fst[end]) === K":"
             op.val = "="
-            op.len = length(op.val)
+            op.len = textwidth(op.val)
         end
         fst.len += op.len - old_op_len
         if !isnothing(fst.metadata)

--- a/src/internal/utils.jl
+++ b/src/internal/utils.jl
@@ -85,7 +85,7 @@ function format_to_stage(
         JF.short_circuit_to_if_pass!(fst, state)
     end
     if JF.needs_alignment(state.opts)
-        JF.align_fst!(fst, state.doc, state.opts)
+        JF.align_fst!(fst, state.opts)
     end
     JF.nest!(style, fst, state)
     if state.opts.join_lines_based_on_source

--- a/src/state.jl
+++ b/src/state.jl
@@ -22,7 +22,14 @@ hascomment(d::Document, line::Integer) = haskey(d.comments, line)
 function cursor_loc(s::State, offset::Integer)
     l = JuliaSyntax.source_line(s.doc.srcfile, offset)
     r = JuliaSyntax.source_line_range(s.doc.srcfile, offset)
-    return (l, offset - first(r) + 1, length(r))
+    code = JuliaSyntax.sourcetext(s.doc.srcfile)
+    line_start = first(r)
+    display_col = if offset <= line_start
+        1
+    else
+        textwidth(code[line_start:prevind(code, offset)]) + 1
+    end
+    return (l, display_col)
 end
 cursor_loc(s::State) = cursor_loc(s, s.offset)
 

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -899,7 +899,7 @@ function p_stringh(
     for (i, l) in enumerate(lines)
         ln = startline + i - 1
         l = i == 1 ? l : l[sidx:end]
-        n = FST(LITERAL, ln, ln, sidx - 1, length(l), l, (), AllowNest, 0, -1, nothing)
+        n = FST(LITERAL, ln, ln, sidx - 1, textwidth(l), l, (), AllowNest, 0, -1, nothing)
         add_node!(t, n, s)
     end
 

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -871,16 +871,15 @@ function p_stringh(
         return FST(LITERAL, loc[2], startline, startline, val)
     end
 
-    # The indent for the StringN FST should be the width of the first line prior to the
-    # opening quote. The quote is the loc[2]-th byte of line loc[1].
-    opening_quote_col = source_display_line_offset(s.doc, loc[1], loc[2])
-    t = FST(StringN, opening_quote_col - 1)
+    # The indent for the StringN FST should be the display width of the first line prior
+    # to the opening quote. loc[2] is already a display column (1-indexed).
+    t = FST(StringN, loc[2] - 1)
     t.line_offset = loc[2]
 
     lines = split(val, "\n")
     # Calculate the display column of the first non-whitespace character in the string
     # literal.
-    sidx = opening_quote_col  # Display column of the opening quote.
+    sidx = loc[2]  # Display column of the opening quote.
     for l in lines[2:end]
         # Note that `fc` is actually a byte index, not a display column. This works only
         # insofar as all whitespace characters (as defined by isspace(c)) have the same

--- a/test/internal_utils.jl
+++ b/test/internal_utils.jl
@@ -133,14 +133,17 @@ import JuliaSyntax as JS
     end
 
     @testset "display-width source offsets" begin
-        # Alignment uses display columns, not code-unit offsets; the combining mark
+        # cursor_loc returns display columns, not byte offsets; the combining mark
         # in s\u0304_b should not add a visible column.
         text = "s\u0304_b      = 1\n"
         doc = JF.Document(text)
-        eq_offset = findfirst(isequal('='), text)
+        eq_byte_offset = findfirst(isequal('='), text)
+        state = JF.State(doc, JF.Options())
+        state.offset = eq_byte_offset
+        loc = JF.cursor_loc(state)
 
-        @test eq_offset > 10
-        @test JF.source_display_line_offset(doc, 1, eq_offset) == 10
+        @test eq_byte_offset > 10
+        @test loc[2] == 10
         @test JF.node_align_length(JF.FST(JF.IDENTIFIER, 1, 1, 1, "s\u0304_b")) == 3
     end
 

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -3421,7 +3421,7 @@ end
         test_format(s, s)
     end
 
-    @testset "1164 emoji" begin
+    @testset "1166 emojis" begin
         s1 = raw"""
         @😬 \"foo
              foo\"
@@ -3435,6 +3435,30 @@ end
                 test_format(s, s, style)
             end
         end
+
+        # Multiline string with emojis in macro name: alignment must be idempotent.
+        s = raw"""
+        @😬 \"ssl_read ⬅️  $n $(n == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY ? foo :
+                               n == MBEDTLS_ERR_SSL_CONN_EOF          ? foo :
+                               n == MBEDTLS_ERR_NET_CONN_RESET        ? foo :
+                               n == MBEDTLS_ERR_SSL_WANT_READ         ? foo : boo)\"
+        """
+        test_format(s, s)
+
+        # Wide CJK characters should be measured by display width (textwidth), not
+        # character count (length). This line is 63 display columns wide but only
+        # 39 characters long, so it should nest at margin = 62 but not at margin = 63.
+        str = """
+        f("日本語は実はわかりません", "Claudeがこのテストを書きました")
+        """
+        str_nested = """
+        f(
+            "日本語は実はわかりません",
+            "Claudeがこのテストを書きました",
+        )
+        """
+        test_format(str, str_nested; margin = 62)
+        test_format(str, str; margin = 63)
     end
 end
 

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -2491,6 +2491,13 @@ end
         end
     end
 
+    @testset "991 emoji" begin
+        s = "e = 🙃 -> \"x\\\n   y\""
+        for style in ALL_STYLES
+            test_format(s, s, style)
+        end
+    end
+
     @testset "1025" begin
         # from julia@1.12.6 Compiler/src/typelimits.jl
         s = """
@@ -3412,6 +3419,22 @@ end
 
         s = raw":($(@__MODULE__).@macro foo)"
         test_format(s, s)
+    end
+
+    @testset "1164 emoji" begin
+        s1 = raw"""
+        @😬 \"foo
+             foo\"
+        """
+        s2 = raw"""
+        😬(\"foo
+            foo\")
+        """
+        for s in (s1, s2)
+            for style in ALL_STYLES
+                test_format(s, s, style)
+            end
+        end
     end
 end
 


### PR DESCRIPTION
JuliaFormatter used to use lots of length() everywhere instead of textwidth(). This was fine as long as you were using ASCII, but breaks for anything outside of that.

Closes #1166
Closes #991

Here's an example:

```julia
#=
         1         2         3         4         5         6
123456789012345678901234567890123456789012345678901234567890123
=#
f("日本語は実はわかりません", "Claudeがこのテストを書きました")
```

This is 63 columns wide. (Copy-paste the above into a terminal to see -- **note that GitHub's rendering is different**!!)

Previously, formatting this with margin=60 would not cause nesting, because the *length* of the string is 39. Now JuliaFormatter correctly recognises that it's over the margin and will rewrite it to

```julia
f(
    "日本語は実はわかりません",
    "Claudeがこのテストを書きました",
)
```

<sub>contrary to the test description, in a past life I did learn enough Japanese to be able to understand the meaning of those phrases, but I could not write it myself......</sub>