### PR TITLE
Fix overly aggressive un-nesting

### DIFF
--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -12,6 +12,8 @@ For macros, JuliaFormatter errs on the side of caution and does not apply syntax
 
 Fixed a bug where whitespace around binary operators was not being respected, leading to a change in the meaning of the code. (#788, #1188)
 
+Fixed a bug where Blue and YAS styles would over-aggressively un-nest contents, leading to comments being joined with source code. (#922, #1189)
+
 # v2.9.4
 
 Fixed several instances where JuliaFormatter would use `length()` instead of `textwidth()`, leading to incorrect or non-idempotent formatting when non-ASCII characters were present. (#1166, #1167)

--- a/src/styles/yas/nest.jl
+++ b/src/styles/yas/nest.jl
@@ -459,6 +459,13 @@ function n_binaryopcall!(
         return n_binaryopcall!(DefaultStyle(style), fst, s, lineage; indent = indent)
     end
 
-    walk(increment_line_offset!, nodes[1:(end-1)], s, fst.indent)
-    nest!(style, fst[end], s, lineage)
+    nested = false
+    for (i, n) in enumerate(nodes)
+        if i == length(nodes) || must_nest(n) || any_descendant(must_nest, n)
+            nested |= nest!(style, n, s, lineage)
+        else
+            walk(increment_line_offset!, n, s)
+        end
+    end
+    return nested
 end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -2425,6 +2425,15 @@ end
         test_format(s, s)
     end
 
+    @testset "922" begin
+        s = "x::T{\n    # com\n    F\n} = z()"
+        for style in ALL_STYLES
+            test_format(s, nothing, style; ast=true)
+            sout = format_text(s, style)
+            @test occursin("# com", sout)
+        end
+    end
+
     @testset "926" begin
         # Function calls with binary operators as arguments should preserve whitespace.
         # Previously `f(*, +, a, b)` was formatted as `f(*,+,a,b)`.


### PR DESCRIPTION
Closes #922

```julia
julia> s = """
       @kwdef struct S
           x::Vector{
                   # comment
                   Float64
           } = zeros(3)
       end"""
"@kwdef struct S\n    x::Vector{\n            # comment\n            Float64\n    } = zeros(3)\nend"

julia> format_text(s, BlueStyle()) |> println
@kwdef struct S
    x::Vector{
        # comment
        Float64,
    } = zeros(3)
end
```