### PR TITLE
Update is_binaryop_nestable to retain the same meaning on JuliaSyntax@1

### DIFF
--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,3 +1,7 @@
+# v2.10.1
+
+Fixed a formatting regression for BlueStyle introduced in 2.5.0. (#1013, #1193)
+
 # v2.10.0
 
 Added a new formatting option, `max_iterations`, which controls the number of rounds of formatting that JuliaFormatter will apply.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.10.0"
+version = "2.10.1"
 authors = ["Dominique Luna <dluna132@gmail.com> and contributors"]
 
 [workspace]

--- a/src/styles/blue/pretty.jl
+++ b/src/styles/blue/pretty.jl
@@ -38,7 +38,9 @@ function is_binaryop_nestable(::BlueStyle, cst::JuliaSyntax.GreenNode)
     # don't, there are idempotence issues because on the second pass this will return true.
     # This is a massive pain to do though.
     # See https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues/1175
-    if is_assignment(cst) && haschildren(cst) && is_iterable(cst[end])
+    if (is_assignment(cst) || defines_function(cst)) &&
+       haschildren(cst) &&
+       is_iterable(cst[end])
         return false
     end
     return is_binaryop_nestable(DefaultStyle(), cst)

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -2520,6 +2520,15 @@ end
         end
     end
 
+    @testset "1013" begin
+        s = "check_constraints(ex::Union{AbstractExpression,AbstractExpressionNode}, options::AbstractOptions)::Bool = check_constraints(ex, options, options.maxsize)"
+        out = """
+        check_constraints(ex::Union{AbstractExpression,AbstractExpressionNode}, options::AbstractOptions)::Bool = check_constraints(
+            ex, options, options.maxsize
+        )"""
+        test_format(s, out, BlueStyle())
+    end
+
     @testset "1025" begin
         # from julia@1.12.6 Compiler/src/typelimits.jl
         s = """


### PR DESCRIPTION
Closes #1013

`f() = ...` used to return `true` for `is_assignment(cst)` with JuliaSyntax@0.4

```julia
 julia> parseall(GreenNode, s)
       1:153    │[toplevel]
       1:153    │  [=]
       1:103    │    [::]
       1:97     │      [call]
       1:17     │        Identifier       ✔
      18:18     │        (
      19:70     │        [::]
      19:20     │          Identifier     ✔
      21:22     │          ::
      23:70     │          [curly]
      23:27     │            Identifier   ✔
      28:28     │            {
      29:46     │            Identifier   ✔
      47:47     │            ,
      48:69     │            Identifier   ✔
      70:70     │            }
      71:71     │        ,
      72:72     │        Whitespace
      73:96     │        [::]
      73:79     │          Identifier     ✔
      80:81     │          ::
      82:96     │          Identifier     ✔
      97:97     │        )
      98:99     │      ::
     100:103    │      Identifier         ✔
     104:104    │    Whitespace
     105:105    │    =
     106:106    │    Whitespace
     107:153    │    [call]
     107:123    │      Identifier         ✔
     124:124    │      (
     125:126    │      Identifier         ✔
     127:127    │      ,
     128:128    │      Whitespace
     129:135    │      Identifier         ✔
     136:136    │      ,
     137:137    │      Whitespace
     138:152    │      [.]
     138:144    │        Identifier       ✔
     145:145    │        .
     146:152    │        [quote]
     146:152    │          Identifier
     153:153    │      )
```

But it's different in JuliaSyntax v1

```julia
     1:154    │[toplevel]
     1:153    │  [function]
     1:103    │    [::]
     1:97     │      [call]
     1:17     │        Identifier       ✔
    18:18     │        (
    19:70     │        [::]
    19:20     │          Identifier     ✔
    21:22     │          ::
    23:70     │          [curly]
    23:27     │            Identifier   ✔
    28:28     │            {
    29:46     │            Identifier   ✔
    47:47     │            ,
    48:69     │            Identifier   ✔
    70:70     │            }
    71:71     │        ,
    72:72     │        Whitespace
    73:96     │        [::]
    73:79     │          Identifier     ✔
    80:81     │          ::
    82:96     │          Identifier     ✔
    97:97     │        )
    98:99     │      ::
   100:103    │      Identifier         ✔
   104:104    │    Whitespace
   105:105    │    =
   106:106    │    Whitespace
   107:153    │    [call]
   107:123    │      Identifier         ✔
   124:124    │      (
   125:126    │      Identifier         ✔
   127:127    │      ,
   128:128    │      Whitespace
   129:135    │      Identifier         ✔
   136:136    │      ,
   137:137    │      Whitespace
   138:152    │      [.]
   138:144    │        Identifier       ✔
   145:145    │        .
   146:152    │        Identifier       ✔
   153:153    │      )
   154:154    │  NewlineWs
```

which causes `is_assignment()` to return false. The solution is to add `defines_function(cst)` to catch this case.