### PR TITLE
Opting out of `enforce_triplequote_docstring`.

### DIFF
--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,3 +1,9 @@
+# v2.11.0
+
+Added a new formatting option, `enforce_triplequoted_docstrings`, which controls whether single-quoted docstrings are expanded to triple-quoted docstrings.
+By default this option is `true`, which is consistent with preexisting behaviour.
+This option is only relevant if `format_docstrings` is also `true` (otherwise docstrings will always be ignored). (#1203, #1204)
+
 # v2.10.2
 
 Documentation improvements only.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.10.2"
+version = "2.11.0"
 authors = ["Dominique Luna <dluna132@gmail.com> and contributors"]
 
 [workspace]

--- a/docs/src/formatting_options.md
+++ b/docs/src/formatting_options.md
@@ -64,6 +64,7 @@ If you absolutely must enable them, you may need to run the formatter multiple t
 | [`annotate_untyped_fields_with_any`](@ref options-annotate-untyped-fields-with-any) | ⚠️    | `true`    | `true`      | **`false`** | `true`       | **`false`**   |
 | [`conditional_to_if`](@ref options-conditional-to-if)                               | 🪃 ♻️ | `false`   | `false`     | **`true`**  | `false`      | `false`       |
 | [`disallow_single_arg_nesting`](@ref options-disallow-single-arg-nesting)           | 📐    | `false`   | `false`     | `false`     | **`true`**   | `false`       |
+| [`enforce_triplequote_docstring`](@ref options-enforce-triplequote-docstring)       | ⚠️    | `true`    | `true`      | `true`      | `true`       | `true`        |
 | [`for_in_replacement`](@ref options-for-in-replacement)                             | ♻️    | `"in"`    | `"in"`      | `"in"`      | `"in"`       | `"in"`        |
 | [`force_long_function_def`](@ref options-force-long-function-def)                   | ⚠️    | `false`   | `false`     | `false`     | `false`      | `false`       |
 | [`format_docstrings`](@ref options-format-docstrings)                               | ⚠️    | `false`   | `false`     | `false`     | `false`      | `false`       |
@@ -329,6 +330,14 @@ function_call("String argument")
 [array_item(10)]
 {key => value("String value")}
 ```
+
+## [`enforce_triplequote_docstring`](@id options-enforce-triplequote-docstring)
+
+Default: `true`
+
+Ensure that docstrings always use triple `"""` quoting marks.
+
+Only useful if [`format_docstrings`](@ref options-format-docstrings) is on.
 
 ## [`for_in_replacement`](@id options-for-in-replacement)
 

--- a/docs/src/formatting_options.md
+++ b/docs/src/formatting_options.md
@@ -64,7 +64,7 @@ If you absolutely must enable them, you may need to run the formatter multiple t
 | [`annotate_untyped_fields_with_any`](@ref options-annotate-untyped-fields-with-any) | ⚠️    | `true`    | `true`      | **`false`** | `true`       | **`false`**   |
 | [`conditional_to_if`](@ref options-conditional-to-if)                               | 🪃 ♻️ | `false`   | `false`     | **`true`**  | `false`      | `false`       |
 | [`disallow_single_arg_nesting`](@ref options-disallow-single-arg-nesting)           | 📐    | `false`   | `false`     | `false`     | **`true`**   | `false`       |
-| [`enforce_triplequote_docstring`](@ref options-enforce-triplequote-docstring)       | ⚠️    | `true`    | `true`      | `true`      | `true`       | `true`        |
+| [`enforce_triplequoted_docstrings`](@ref options-enforce-triplequoted-docstrings)   | ⚠️    | `true`    | `true`      | `true`      | `true`       | `true`        |
 | [`for_in_replacement`](@ref options-for-in-replacement)                             | ♻️    | `"in"`    | `"in"`      | `"in"`      | `"in"`       | `"in"`        |
 | [`force_long_function_def`](@ref options-force-long-function-def)                   | ⚠️    | `false`   | `false`     | `false`     | `false`      | `false`       |
 | [`format_docstrings`](@ref options-format-docstrings)                               | ⚠️    | `false`   | `false`     | `false`     | `false`      | `false`       |
@@ -331,13 +331,28 @@ function_call("String argument")
 {key => value("String value")}
 ```
 
-## [`enforce_triplequote_docstring`](@id options-enforce-triplequote-docstring)
+## [`enforce_triplequoted_docstrings`](@id options-enforce-triplequoted-docstrings)
 
 Default: `true`
 
-Ensure that docstrings always use triple `"""` quoting marks.
+Convert docstrings with single quotes to the equivalent triple-quoted form.
 
 Only useful if [`format_docstrings`](@ref options-format-docstrings) is on.
+
+```@example enforce-triplequoted-docstrings
+using JuliaFormatter: format_text
+
+s = """
+"docstring"
+function foo end
+"""
+
+format_text(s; format_docstrings=true, enforce_triplequoted_docstrings=true) |> println
+```
+
+```@example enforce-triplequoted-docstrings
+format_text(s; format_docstrings=true, enforce_triplequoted_docstrings=false) |> println
+```
 
 ## [`for_in_replacement`](@id options-for-in-replacement)
 

--- a/src/argparse.jl
+++ b/src/argparse.jl
@@ -406,6 +406,13 @@ const PARSER = ArgParser(
         group = FormattingGroup,
     ),
     option(
+        "--enforce-triplequote-docstring";
+        dest = :enforce_triplequote_docstring,
+        type = Bool,
+        help = """Transform `"` into `\"""` in docstrings.""",
+        group = FormattingGroup,
+    ),
+    option(
         "--for-in-replacement";
         dest = :for_in_replacement,
         type = String,

--- a/src/argparse.jl
+++ b/src/argparse.jl
@@ -406,10 +406,10 @@ const PARSER = ArgParser(
         group = FormattingGroup,
     ),
     option(
-        "--enforce-triplequote-docstring";
-        dest = :enforce_triplequote_docstring,
+        "--enforce-triplequoted-docstrings";
+        dest = :enforce_triplequoted_docstrings,
         type = Bool,
-        help = """Transform `"` into `\"""` in docstrings.""",
+        help = """Transform `"..."` into `\"""...\"""` in docstrings.""",
         group = FormattingGroup,
     ),
     option(

--- a/src/format_docstring.jl
+++ b/src/format_docstring.jl
@@ -49,14 +49,10 @@ function block_modifier(rule::FormatRule)
 end
 
 function format_docstring(style::AbstractStyle, state::State, text::AbstractString)
-    state_indent = state.indent
+    is_triple_quoted =
+        state.opts.enforce_triplequote_docstring ||
+        (startswith(text, "\"\"\"") && endswith(text, "\"\"\""))
     start_boundary = findfirst(!=('"'), text)
-    is_triple_quoted = state.opts.enforce_triplequote_docstring || let
-        # Assuming well-formedness, the string is triple-quoted iif
-        # the chars after/before (o)pening/(c)losing quotes are also quotes.
-        o, c = map(f -> f(==('"'), text), (findfirst, findlast))
-        text[o+1] == text[c-1] == '"'
-    end
     # if the docstring is non-empty
     if !isnothing(start_boundary)
         _end_boundary = findlast(!=('"'), text)
@@ -127,22 +123,22 @@ function format_docstring(style::AbstractStyle, state::State, text::AbstractStri
     end
     # Render into text lines, taking care of original indentation,
     quot = is_triple_quoted ? "\"\"\"" : '"'
-    indentation = " "^state_indent
+    indentation = " "^state.indent
     indent(line) = indentation * line
     clean(line) = all(isspace, line) ? "" : line # don't write empty lines #667
-    lines = split(formatted, '\n') # Always contains at least an empty last line.
+    lines = split(formatted, '\n')
+    last(lines) == "" || # Legacy guarantee.
+        error("unreachable: `formatted` should end in empty string. Please report this at \
+               https://github.com/JuliaEditorSupport/JuliaFormatter.jl/issues!")
     if is_triple_quoted
         prep = line -> clean(indent(line)) # All lines are prepared the same way.
         lines = Iterators.map(prep, lines)
         quot * '\n' * join(lines, '\n') * indent(quot)
     else
         # The first line needs no indentation.
-        lines = Iterators.Stateful(lines[1:end-1]) # (drop last empty line)
-        first = popfirst!(lines) |> clean
-        isempty(lines) && return quot * first * quot
-        # Upcoming ones do.
+        first = clean(lines[1])
         prep = line -> '\n' * indent(line)
-        lines = Iterators.map(prep, lines)
+        lines = Iterators.map(prep, lines[2:(end-1)]) # (drop last empty line)
         quot * first * join(lines) * quot
     end
 end

--- a/src/format_docstring.jl
+++ b/src/format_docstring.jl
@@ -51,7 +51,7 @@ end
 function format_docstring(style::AbstractStyle, state::State, text::AbstractString)
     state_indent = state.indent
     start_boundary = findfirst(!=('"'), text)
-    is_triple_quoted = let
+    is_triple_quoted = state.opts.enforce_triplequote_docstring || let
         # Assuming well-formedness, the string is triple-quoted iif
         # the chars after/before (o)pening/(c)losing quotes are also quotes.
         o, c = map(f -> f(==('"'), text), (findfirst, findlast))

--- a/src/format_docstring.jl
+++ b/src/format_docstring.jl
@@ -51,6 +51,12 @@ end
 function format_docstring(style::AbstractStyle, state::State, text::AbstractString)
     state_indent = state.indent
     start_boundary = findfirst(!=('"'), text)
+    is_triple_quoted = let
+        # Assuming well-formedness, the string is triple-quoted iif
+        # the chars after/before (o)pening/(c)losing quotes are also quotes.
+        o, c = map(f -> f(==('"'), text), (findfirst, findlast))
+        text[o+1] == text[c-1] == '"'
+    end
     # if the docstring is non-empty
     if !isnothing(start_boundary)
         _end_boundary = findlast(!=('"'), text)
@@ -119,21 +125,24 @@ function format_docstring(style::AbstractStyle, state::State, text::AbstractStri
         # the docstring is empty
         formatted = ""
     end
-    # Indent all non-first lines to match the current parser indent
-    buf = IOBuffer()
-    indent = " "^state_indent
-    # This is the first line, so the rest have to be indented. A newline for it will be added below
-    write(buf, "\"\"\"")
-    for line in split(formatted, '\n')
-        # The last line will be empty and will turn into an indent, so no need to indent the last line below
-        write(buf, '\n')
-        # don't write empty lines #667
-        if !all(isspace, line)
-            write(buf, indent)
-            write(buf, line)
-        end
+    # Render into text lines, taking care of original indentation,
+    quot = is_triple_quoted ? "\"\"\"" : '"'
+    indentation = " "^state_indent
+    indent(line) = indentation * line
+    clean(line) = all(isspace, line) ? "" : line # don't write empty lines #667
+    lines = split(formatted, '\n') # Always contains at least an empty last line.
+    if is_triple_quoted
+        prep = line -> clean(indent(line)) # All lines are prepared the same way.
+        lines = Iterators.map(prep, lines)
+        quot * '\n' * join(lines, '\n') * indent(quot)
+    else
+        # The first line needs no indentation.
+        lines = Iterators.Stateful(lines[1:end-1]) # (drop last empty line)
+        first = popfirst!(lines) |> clean
+        isempty(lines) && return quot * first * quot
+        # Upcoming ones do.
+        prep = line -> '\n' * indent(line)
+        lines = Iterators.map(prep, lines)
+        quot * first * join(lines) * quot
     end
-    write(buf, indent)
-    write(buf, "\"\"\"")
-    String(take!(buf))
 end

--- a/src/format_docstring.jl
+++ b/src/format_docstring.jl
@@ -50,7 +50,7 @@ end
 
 function format_docstring(style::AbstractStyle, state::State, text::AbstractString)
     is_triple_quoted =
-        state.opts.enforce_triplequote_docstring ||
+        state.opts.enforce_triplequoted_docstrings ||
         (startswith(text, "\"\"\"") && endswith(text, "\"\"\""))
     start_boundary = findfirst(!=('"'), text)
     # if the docstring is non-empty

--- a/src/options.jl
+++ b/src/options.jl
@@ -37,7 +37,7 @@ Base.@kwdef struct Options{T<:_Unset}
     annotate_untyped_fields_with_any::Union{T,Bool} = true
     conditional_to_if::Union{T,Bool} = false
     disallow_single_arg_nesting::Union{T,Bool} = false
-    enforce_triplequote_docstring::Union{T,Bool} = true
+    enforce_triplequoted_docstrings::Union{T,Bool} = true
     for_in_replacement::Union{T,String} = "in"
     force_long_function_def::Union{T,Bool} = false
     format_docstrings::Union{T,Bool} = false

--- a/src/options.jl
+++ b/src/options.jl
@@ -37,6 +37,7 @@ Base.@kwdef struct Options{T<:_Unset}
     annotate_untyped_fields_with_any::Union{T,Bool} = true
     conditional_to_if::Union{T,Bool} = false
     disallow_single_arg_nesting::Union{T,Bool} = false
+    enforce_triplequote_docstring::Union{T,Bool} = true
     for_in_replacement::Union{T,String} = "in"
     force_long_function_def::Union{T,Bool} = false
     format_docstrings::Union{T,Bool} = false

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -933,7 +933,9 @@ function p_globalrefdoc(
                 max_padding = 0,
             )
         elseif i == length(childs)
-            add_node!(t, pretty(style, c, s, ctx, lineage), s; max_padding = 0)
+            end_node = pretty(style, c, s, ctx, lineage)
+            end_node.startline = t.endline
+            add_node!(t, end_node, s; max_padding = 0)
         else
             add_node!(t, pretty(style, c, s, ctx, lineage), s)
         end

--- a/test/argparse.jl
+++ b/test/argparse.jl
@@ -268,6 +268,8 @@ using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyl
             @test parse_args(["--conditional-to-if=false"]).config.options.conditional_to_if == false
             @test parse_args(["--disallow-single-arg-nesting=true"]).config.options.disallow_single_arg_nesting == true
             @test parse_args(["--disallow-single-arg-nesting=false"]).config.options.disallow_single_arg_nesting == false
+            @test parse_args(["--enforce-triplequote-docstring=true"]).config.options.enforce_triplequote_docstring == true
+            @test parse_args(["--enforce-triplequote-docstring=false"]).config.options.enforce_triplequote_docstring == false
             @test parse_args(["--force-long-function-def=true"]).config.options.force_long_function_def == true
             @test parse_args(["--force-long-function-def=false"]).config.options.force_long_function_def == false
             @test parse_args(["--format-docstrings=true"]).config.options.format_docstrings == true

--- a/test/argparse.jl
+++ b/test/argparse.jl
@@ -268,8 +268,8 @@ using JuliaFormatter: DefaultStyle, YASStyle, BlueStyle, SciMLStyle, MinimalStyl
             @test parse_args(["--conditional-to-if=false"]).config.options.conditional_to_if == false
             @test parse_args(["--disallow-single-arg-nesting=true"]).config.options.disallow_single_arg_nesting == true
             @test parse_args(["--disallow-single-arg-nesting=false"]).config.options.disallow_single_arg_nesting == false
-            @test parse_args(["--enforce-triplequote-docstring=true"]).config.options.enforce_triplequote_docstring == true
-            @test parse_args(["--enforce-triplequote-docstring=false"]).config.options.enforce_triplequote_docstring == false
+            @test parse_args(["--enforce-triplequoted-docstrings=true"]).config.options.enforce_triplequoted_docstrings == true
+            @test parse_args(["--enforce-triplequoted-docstrings=false"]).config.options.enforce_triplequoted_docstrings == false
             @test parse_args(["--force-long-function-def=true"]).config.options.force_long_function_def == true
             @test parse_args(["--force-long-function-def=false"]).config.options.force_long_function_def == false
             @test parse_args(["--format-docstrings=true"]).config.options.format_docstrings == true

--- a/test/options.jl
+++ b/test/options.jl
@@ -711,65 +711,6 @@ end
         end
     end
 
-    @testset "issue 1203" begin
-
-        opts = (; format_docstrings = true)
-
-        # (use begin blocks to check indentation)
-        triple = """
-        begin
-            \"""
-            doc
-            \"""
-            f() = 0
-        end
-        """
-
-        single = """
-        begin
-            "doc"
-            f() = 0
-        end
-        """
-
-        # Normalize to triple by default.
-        test_format(triple, triple; opts...)
-        test_format(single, triple; opts...)
-
-        # Unless we opt out.
-        opts = (; enforce_triplequote_docstring = false, opts...)
-        test_format(single, single; opts...)
-
-        # Not exactly good taste, but the option leaves it alone as promised.
-        single_multiline = """
-        begin
-            "line1\\n\\
-            line2"
-            f() = 0
-        end
-        """
-        test_format(single_multiline, single_multiline; opts...)
-
-        # Still drop trailing whitespace on the first line (#667).
-        test_format(
-            """
-            begin
-                "$("  ")
-                doc
-                "
-                f() = 0
-            end
-            """,
-            """
-            begin
-                "doc"   # <- This docstring is correctly formatted.
-                f() = 0 # Can somebody help explain why newlines are being inserted here?
-            end
-            """,
-            ; opts...)
-
-    end
-
     @testset "align struct fields" begin
         str_ = """
         struct Foo

--- a/test/options.jl
+++ b/test/options.jl
@@ -711,6 +711,59 @@ end
         end
     end
 
+    @testset "issue 1203" begin
+
+        # Use let blocks to check indentation.
+        triple = """
+        begin
+            \"""
+            doc
+            \"""
+            f() = 0
+        end
+        """
+
+        single = """
+        begin
+            "doc"
+            f() = 0
+        end
+        """
+
+        test_format(triple, triple; format_docstrings=true)
+        test_format(single, triple; format_docstrings=true)
+        test_format(single, single; format_docstrings=true)
+
+        # Not exactly good taste, but the option leaves it alone as promised.
+        single_multiline = """
+        begin
+            "line1\\n\\
+            line2"
+            f() = 0
+        end
+        """
+        test_format(single_multiline, single_multiline; format_docstrings=true)
+
+        # Still drop trailing whitespace on the first line (#667).
+        test_format(
+            """
+            begin
+                "$("  ")
+                doc
+                "
+                f() = 0
+            end
+            """,
+            """
+            begin
+                "doc"   # <- This docstring is correctly formatted.
+                f() = 0 # Can somebody help explain why newlines are being inserted here?
+            end
+            """,
+            ; format_docstrings=true)
+
+    end
+
     @testset "align struct fields" begin
         str_ = """
         struct Foo

--- a/test/options.jl
+++ b/test/options.jl
@@ -713,7 +713,9 @@ end
 
     @testset "issue 1203" begin
 
-        # Use let blocks to check indentation.
+        opts = (; format_docstrings = true)
+
+        # (use begin blocks to check indentation)
         triple = """
         begin
             \"""
@@ -730,9 +732,13 @@ end
         end
         """
 
-        test_format(triple, triple; format_docstrings=true)
-        test_format(single, triple; format_docstrings=true)
-        test_format(single, single; format_docstrings=true)
+        # Normalize to triple by default.
+        test_format(triple, triple; opts...)
+        test_format(single, triple; opts...)
+
+        # Unless we opt out.
+        opts = (; enforce_triplequote_docstring = false, opts...)
+        test_format(single, single; opts...)
 
         # Not exactly good taste, but the option leaves it alone as promised.
         single_multiline = """
@@ -742,7 +748,7 @@ end
             f() = 0
         end
         """
-        test_format(single_multiline, single_multiline; format_docstrings=true)
+        test_format(single_multiline, single_multiline; opts...)
 
         # Still drop trailing whitespace on the first line (#667).
         test_format(
@@ -760,7 +766,7 @@ end
                 f() = 0 # Can somebody help explain why newlines are being inserted here?
             end
             """,
-            ; format_docstrings=true)
+            ; opts...)
 
     end
 

--- a/test/options/enforce_triplequote_docstring.jl
+++ b/test/options/enforce_triplequote_docstring.jl
@@ -1,10 +1,9 @@
-module OptionEnforceTriplequoteDocstring
+module OptionsEnforceTriplequotedDocstringsTests
 
 using JuliaFormatter.Internal: test_format
 using Test
 
 @testset "Basic" begin
-
     opts = (; format_docstrings=true)
 
     # (use begin blocks to check indentation)
@@ -29,7 +28,7 @@ using Test
     test_format(single, triple; opts...)
 
     # Unless we opt out.
-    opts = (; format_docstrings=true, enforce_triplequote_docstring=false)
+    opts = (; format_docstrings=true, enforce_triplequoted_docstrings=false)
     test_format(single, single; opts...)
 
     # Not exactly good taste, but the option leaves it alone as promised.
@@ -59,7 +58,6 @@ using Test
         end
         """,
         ; opts...)
-
 end
 
 end

--- a/test/options/enforce_triplequote_docstring.jl
+++ b/test/options/enforce_triplequote_docstring.jl
@@ -1,0 +1,65 @@
+module OptionEnforceTriplequoteDocstring
+
+using JuliaFormatter.Internal: test_format
+using Test
+
+@testset "Basic" begin
+
+    opts = (; format_docstrings=true)
+
+    # (use begin blocks to check indentation)
+    triple = """
+    begin
+        \"""
+        doc
+        \"""
+        f() = 0
+    end
+    """
+
+    single = """
+    begin
+        "doc"
+        f() = 0
+    end
+    """
+
+    # Normalize to triple by default.
+    test_format(triple, triple; opts...)
+    test_format(single, triple; opts...)
+
+    # Unless we opt out.
+    opts = (; format_docstrings=true, enforce_triplequote_docstring=false)
+    test_format(single, single; opts...)
+
+    # Not exactly good taste, but the option leaves it alone as promised.
+    single_multiline = """
+    begin
+        "line1\\n\\
+        line2"
+        f() = 0
+    end
+    """
+    test_format(single_multiline, single_multiline; opts...)
+
+    # Still drop trailing whitespace on the first line (#667).
+    test_format(
+        """
+        begin
+            "$(" \t \t ")
+            doc
+            "
+            f() = 0
+        end
+        """,
+        """
+        begin
+            "doc"
+            f() = 0
+        end
+        """,
+        ; opts...)
+
+end
+
+end


### PR DESCRIPTION
Here is a first shot at addressing #1203 it @penelopeysm.
I am happy with it yet except that I don't understand why [this (new) test](https://github.com/JuliaEditorSupport/JuliaFormatter.jl/pull/1204#discussion_r3613772816) is failing..?
It seems that it is failing due to something outside the strict `format_docstring()` function, because this one does return the correct result IIUC.
Maybe that leading whitespace is preventing the docstring to be recognized as such?