### PR TITLE
Add format_docstrings to integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,7 +1,7 @@
 name: Integration
 
 env:
-  FORMATTER_OPTS: "--ignore-config --v2-stable-multiline-strings=true --conditional-to-if=false --pipe-to-function-call=false"
+  FORMATTER_OPTS: "--ignore-config --v2-stable-multiline-strings=true --conditional-to-if=false --pipe-to-function-call=false --format-docstrings=true"
 
 on:
   push:


### PR DESCRIPTION
Since CommonMark has a new release with the docstring bugfix, I'm hopeful that this should pass, at least with Default and Blue (YAS is known to fail)