### PR TITLE
fix more indents

### DIFF
--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,3 +1,7 @@
+# v2.11.5
+
+Fixed more buggy cases of YASStyle indentation (some of which were regressions in v2.11.1). (#1230, #1231)
+
 # v2.11.4
 
 Fixed a bug where comments from outside docstrings would be incorrectly duplicated inside the docstring if the vertical length of the docstring changed during formatting. (#1223, #1229)

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.11.4"
+version = "2.11.5"
 authors = ["Dominique Luna <dluna132@gmail.com> and contributors"]
 
 [workspace]

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -512,6 +512,74 @@ function is_import_expr(x::FST)
 end
 
 """
+    is_column_aligned(fst::FST)
+
+Whether YASStyle lays out the continuation lines of `fst` relative to the column at which
+`fst` itself starts, rather than relative to the start of the line it appears on.
+
+Iterables are column-aligned, because their arguments line up with the bracket that opens
+them, as is `where`, whose type parameters line up with the `{`:
+
+```julia
+f(aaaaaaaaaaaaaaaaaaaaaa,
+  bbbbbbbbbbbbbbbbbbbbbb)
+
+Foo{A} where {Aaaaaaaaaaaaaaa<:Xxxxxxxxxxxx,
+              Bbbbbbbbbbbbbbb<:Yyyyyyyyyyyy}
+```
+
+Block-like constructs are not, because their bodies are indented by one level from the
+start of the line:
+
+```julia
+function f()
+    body
+end
+```
+
+A unary operator takes this from its operand, and a macrocall written without parentheses
+(a `MacroBlock`) from its final argument, since those are the parts that the continuation
+lines belong to:
+
+```julia
+!(aaaaaaaaaaaaaaaaaaaaaa &&
+  bbbbbbbbbbbbbbbbbbbbbb)
+
+@mymacro [aaaaaaaaaaaaaaaaaaaa,
+          bbbbbbbbbbbbbbbbbbbb]
+
+@mymacro function f()
+    body
+end
+```
+
+Note that a `MacroBlock` that mixes the two (e.g. `@mymacro [a, b] begin ... end`) is
+reported as not column-aligned: the two parts would have to move in different ways, and
+only one answer can be given.
+
+`Binary`, `Chain`, `Comparison` and `Conditional` are column-aligned in YASStyle too, but
+they are deliberately not listed here because the only caller (`n_binaryopcall!`) accounts
+for their full width before it will consider undoing a nesting, so it never has to move
+one of them that has already been split over several lines.
+"""
+function is_column_aligned(fst::FST)
+    if is_leaf(fst)
+        return false
+    elseif fst.typ === MacroBlock
+        # The trailing argument is the one that continuation lines follow on from.
+        nodes = fst.nodes::Vector{FST}
+        return !isempty(nodes) && is_column_aligned(nodes[end])
+    elseif fst.typ === Unary
+        # Either `!x` or `x...`; in both cases it's the operand that matters, not the
+        # operator.
+        nodes = fst.nodes::Vector{FST}
+        idx = findfirst(n -> n.typ !== OPERATOR, nodes)
+        return idx !== nothing && is_column_aligned(nodes[idx])
+    end
+    return fst.typ === Where || is_iterable(fst)
+end
+
+"""
 Returns whether `fst` can be an iterable argument. For example in
 the case of a function call, which is of type `Call`:
 

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -512,6 +512,35 @@ function is_import_expr(x::FST)
 end
 
 """
+    is_indent_nest(fst::FST)
+
+Whether nesting the binary call `fst` at its operator indents the RHS by one level from the
+start of the line:
+
+```julia
+aaaaaaaaaaaa =>
+    rhs
+```
+
+as opposed to bringing it back to the column the LHS starts at, which is what every other
+operator does:
+
+```julia
+aaaaaaaaaaaa in
+rhs
+```
+
+True for assignments, `=>`, `->` and standalone short-circuits.
+"""
+function is_indent_nest(fst::FST)
+    md = fst.metadata
+    return (!isnothing(md) && (md::Metadata).is_short_form_function) ||
+           is_assignment(fst) ||
+           op_kind(fst) in KSet"=> ->" ||
+           (!isnothing(md) && (md::Metadata).is_standalone_shortcircuit)
+end
+
+"""
     is_column_aligned(fst::FST)
 
 Whether YASStyle lays out the continuation lines of `fst` relative to the column at which
@@ -547,14 +576,29 @@ For nested constructs we might need to inspect their children. For example in
 the second line is indented according to the `[` iff the last argument of the
 macro is column-aligned.
 
-`Binary`, `Chain`, `Comparison` and `Conditional` are column-aligned in YASStyle too, but
-they are deliberately not listed here because the only caller (`n_binaryopcall!`) accounts
-for their full width before it will consider undoing a nesting, so it never has to move one
-of them that has already been split over several lines.
+A binary call is column-aligned unless its operator is one of those that indents the RHS
+from the start of the line instead (see [`is_indent_nest`](@ref)).
+
+`Chain`, `Comparison` and `Conditional` are column-aligned in YASStyle too, but they are
+deliberately not listed here because the only caller (`n_binaryopcall!`) accounts for their
+full width before it will consider undoing a nesting, so it never has to move one of them
+that has already been split over several lines.
 """
 function is_column_aligned(fst::FST)
     return if is_leaf(fst)
         false
+    elseif fst.typ === Binary
+        nodes = fst.nodes::Vector{FST}
+        if any(n -> n.typ === NEWLINE, nodes)
+            # It has been split across its own operator, so `n_binaryopcall!` decided
+            # where the RHS goes.
+            !is_indent_nest(fst)
+        else
+            # It is still on one line, so any continuation lines belong to the RHS
+            # operand. In `@mac aaaa = [bbbbb, ccccc]` it is the vector literal, not the
+            # assignment, that the second line is aligned against.
+            is_column_aligned(nodes[end])
+        end
     elseif fst.typ === MacroBlock
         # The trailing argument is the one that continuation lines follow on from.
         nodes = fst.nodes::Vector{FST}

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -529,7 +529,7 @@ Foo{A} where {Aaaaaaaaaaaaaaa<:Xxxxxxxxxxxx,
 ```
 
 Block-like constructs are not, because their bodies are indented by one level from the
-start of the line:
+start of the line, regardless of where `function f()` starts:
 
 ```julia
 function f()
@@ -537,46 +537,41 @@ function f()
 end
 ```
 
-A unary operator takes this from its operand, and a macrocall written without parentheses
-(a `MacroBlock`) from its final argument, since those are the parts that the continuation
-lines belong to:
+For nested constructs we might need to inspect their children. For example in
 
 ```julia
-!(aaaaaaaaaaaaaaaaaaaaaa &&
-  bbbbbbbbbbbbbbbbbbbbbb)
-
 @mymacro [aaaaaaaaaaaaaaaaaaaa,
           bbbbbbbbbbbbbbbbbbbb]
-
-@mymacro function f()
-    body
-end
 ```
 
-Note that a `MacroBlock` that mixes the two (e.g. `@mymacro [a, b] begin ... end`) is
-reported as not column-aligned: the two parts would have to move in different ways, and
-only one answer can be given.
+the second line is indented according to the `[` iff the last argument of the
+macro is column-aligned.
 
 `Binary`, `Chain`, `Comparison` and `Conditional` are column-aligned in YASStyle too, but
 they are deliberately not listed here because the only caller (`n_binaryopcall!`) accounts
-for their full width before it will consider undoing a nesting, so it never has to move
-one of them that has already been split over several lines.
+for their full width before it will consider undoing a nesting, so it never has to move one
+of them that has already been split over several lines.
 """
 function is_column_aligned(fst::FST)
-    if is_leaf(fst)
-        return false
+    return if is_leaf(fst)
+        false
     elseif fst.typ === MacroBlock
         # The trailing argument is the one that continuation lines follow on from.
         nodes = fst.nodes::Vector{FST}
-        return !isempty(nodes) && is_column_aligned(nodes[end])
+        !isempty(nodes) && is_column_aligned(nodes[end])
     elseif fst.typ === Unary
         # Either `!x` or `x...`; in both cases it's the operand that matters, not the
         # operator.
         nodes = fst.nodes::Vector{FST}
         idx = findfirst(n -> n.typ !== OPERATOR, nodes)
-        return idx !== nothing && is_column_aligned(nodes[idx])
+        idx !== nothing && is_column_aligned(nodes[idx])
+    elseif fst.typ === Where # `where {...}`
+        true
+    elseif is_iterable(fst)
+        true
+    else
+        false
     end
-    return fst.typ === Where || is_iterable(fst)
 end
 
 """

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -943,12 +943,12 @@ function n_binaryopcall!(
             end
         end
 
-        # rhs
-        #
+        # RHS.
+
         # Remember the column the RHS starts at in this (nested) layout. Any alignment
         # that nesting the RHS sets up is relative to this column, so if the nesting is
         # undone further below we need to know how far the RHS has moved sideways.
-        rhs_line_offset = s.line_offset
+        rhs_line_offset_when_op_nested = s.line_offset
         fst[end].extra_margin = fst.extra_margin
         nest!(style, fst[end], s, lineage)
 
@@ -998,27 +998,28 @@ function n_binaryopcall!(
                     fst[i2] = Whitespace(0)
                     line_offset = s.line_offset
                     walk(unnest!(style; dedent = true), rhs, s)
+                    # The RHS may span multiple lines, in which case we need to decide
+                    # how to reindent its continuation lines.
+                    #
                     # If the RHS aligns its continuation lines against the column it
-                    # starts at (see `is_column_aligned`), that alignment was calculated
-                    # for the nested layout, where the RHS began at column
-                    # `rhs_line_offset`. Undoing the nesting moves it to column
-                    # `line_offset`, so every indent inside it has to move by the same
-                    # amount. `s.opts.indent` is added back on because `unnest!` above
-                    # dedented the whole RHS by one level.
+                    # starts at (see `is_column_aligned`), then we need to reuse the
+                    # `rhs_line_offset_when_op_nested` that we calculated earlier.
                     #
-                    # For example, in
+                    # When we undo the nesting, the rhs gets moved to column `line_offset`,
+                    # so every indent inside it has to be offset by the difference with
+                    # `rhs_line_offset_when_op_nested`.
                     #
-                    #     for x in @mymacro [1111111111111111111111, 2222222222222222222,
-                    #                        3333333333333333333333, 444444444]
-                    #
-                    # the vector literal is first laid out with the macrocall on a line of
-                    # its own, so `3333...` gets aligned against a `[` at column
-                    # `rhs_line_offset + length("@mymacro ")`. Once we decide that the
-                    # macrocall does fit after `for x in ` after all, that alignment has to
-                    # shift right by the width of `for x in `.
+                    # `s.opts.indent` is added back on because `unnest!` above dedented the
+                    # whole RHS by one level.
                     if style isa YASStyle && is_column_aligned(rhs)
-                        add_indent!(rhs, s, line_offset - rhs_line_offset + s.opts.indent)
+                        add_indent!(
+                            rhs,
+                            s,
+                            line_offset - rhs_line_offset_when_op_nested + s.opts.indent,
+                        )
                     end
+                    # For default style, nothing is 'column aligned' so we don't need to do
+                    # anything.
                 end
             end
         end

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -944,6 +944,11 @@ function n_binaryopcall!(
         end
 
         # rhs
+        #
+        # Remember the column the RHS starts at in this (nested) layout. Any alignment
+        # that nesting the RHS sets up is relative to this column, so if the nesting is
+        # undone further below we need to know how far the RHS has moved sideways.
+        rhs_line_offset = s.line_offset
         fst[end].extra_margin = fst.extra_margin
         nest!(style, fst[end], s, lineage)
 
@@ -993,21 +998,26 @@ function n_binaryopcall!(
                     fst[i2] = Whitespace(0)
                     line_offset = s.line_offset
                     walk(unnest!(style; dedent = true), rhs, s)
-                    # Iterables in YASStyle need to be aligned with the
-                    # open bracket
-                    if style isa YASStyle
-                        if is_unnamed_iterable(rhs)
-                            extra_indent = if !isempty(rhs.nodes) && is_opener(rhs[1])
-                                line_offset - rhs.indent + 1
-                            else
-                                line_offset - rhs.indent
-                            end
-                            add_indent!(rhs, s, extra_indent)
-                        elseif is_named_iterable(rhs)
-                            extra_indent =
-                                line_offset - rhs.indent + length(rhs[1]) + length(rhs[2])
-                            add_indent!(rhs, s, extra_indent)
-                        end
+                    # If the RHS aligns its continuation lines against the column it
+                    # starts at (see `is_column_aligned`), that alignment was calculated
+                    # for the nested layout, where the RHS began at column
+                    # `rhs_line_offset`. Undoing the nesting moves it to column
+                    # `line_offset`, so every indent inside it has to move by the same
+                    # amount. `s.opts.indent` is added back on because `unnest!` above
+                    # dedented the whole RHS by one level.
+                    #
+                    # For example, in
+                    #
+                    #     for x in @mymacro [1111111111111111111111, 2222222222222222222,
+                    #                        3333333333333333333333, 444444444]
+                    #
+                    # the vector literal is first laid out with the macrocall on a line of
+                    # its own, so `3333...` gets aligned against a `[` at column
+                    # `rhs_line_offset + length("@mymacro ")`. Once we decide that the
+                    # macrocall does fit after `for x in ` after all, that alignment has to
+                    # shift right by the width of `for x in `.
+                    if style isa YASStyle && is_column_aligned(rhs)
+                        add_indent!(rhs, s, line_offset - rhs_line_offset + s.opts.indent)
                     end
                 end
             end

--- a/src/styles/default/nest.jl
+++ b/src/styles/default/nest.jl
@@ -917,14 +917,7 @@ function n_binaryopcall!(
         fst[i1] = Newline(; length = fst[i1].len)
         nested = true
 
-        indent_nest =
-            (!isnothing(fst.metadata) && (fst.metadata::Metadata).is_short_form_function) ||
-            is_assignment(fst) ||
-            op_kind(fst) in KSet"=> ->" ||
-            (
-                !isnothing(fst.metadata) &&
-                (fst.metadata::Metadata).is_standalone_shortcircuit
-            )
+        indent_nest = is_indent_nest(fst)
 
         if indent_nest
             s.line_offset = fst.indent + s.opts.indent

--- a/test/yas_style.jl
+++ b/test/yas_style.jl
@@ -801,6 +801,74 @@ using JuliaFormatter: format_text
             test_format(s2, s2, YASStyle(); margin=margin)
         end
     end
+
+    @testset "realignment of RHS after un-nesting a binary op" begin
+        # To lay out `x in rhs`, the RHS is first put on a line of its own and nested
+        # there. If it then turns out that it does fit after `x in ` after all, that
+        # nesting is undone -- and everything inside the RHS that was aligned against a
+        # bracket has to move sideways along with it.
+
+        # A macrocall written without parentheses: the vector aligns with its `[`.
+        s_ = """
+        for x in @mac [aaaaa, bbbbb, ccccc]
+            foo
+        end"""
+        s = """
+        for x in @mac [aaaaa, bbbbb,
+                       ccccc]
+            foo
+        end"""
+        test_format(s_, s, YASStyle(); margin=30)
+
+        s_ = """
+        for x in @mac f(aaaaa, bbbbb, ccccc)
+            foo
+        end"""
+        s = """
+        for x in @mac f(aaaaa, bbbbb,
+                        ccccc)
+            foo
+        end"""
+        test_format(s_, s, YASStyle(); margin=31)
+
+        # A macrocall whose final argument is a block indents that block relative to the
+        # start of the line instead, so here there is nothing to move.
+        s_ = """
+        ccc => @mac function ()
+            return aaa
+        end"""
+        s = """
+        ccc => @mac function ()
+            return aaa
+        end"""
+        test_format(s_, s, YASStyle(); margin=24)
+
+        # A unary operator aligns the same way its operand alone would.
+        s_ = """
+        for x in !(aaaa == 1 && (bbbb(cc) || dddd))
+            foo
+        end"""
+        s = """
+        for x in !(aaaa == 1 &&
+                   (bbbb(cc) || dddd))
+            foo
+        end"""
+        test_format(s_, s, YASStyle(); margin=24)
+
+        # `where` aligns its type parameters with the `{`. (The blank line before the loop
+        # body is unrelated pre-existing behaviour for a nested iteration specification.)
+        s_ = """
+        for x in Foo{A} where {Aa<:Xx, Bb<:Yy, Cc<:Zz}
+            foo
+        end"""
+        s = """
+        for x in Foo{A} where {Aa<:Xx,Bb<:Yy,
+                               Cc<:Zz}
+
+            foo
+        end"""
+        test_format(s_, s, YASStyle(); margin=38)
+    end
 end
 
 end

--- a/test/yas_style.jl
+++ b/test/yas_style.jl
@@ -803,12 +803,6 @@ using JuliaFormatter: format_text
     end
 
     @testset "realignment of RHS after un-nesting a binary op" begin
-        # To lay out `x in rhs`, the RHS is first put on a line of its own and nested
-        # there. If it then turns out that it does fit after `x in ` after all, that
-        # nesting is undone -- and everything inside the RHS that was aligned against a
-        # bracket has to move sideways along with it.
-
-        # A macrocall written without parentheses: the vector aligns with its `[`.
         s_ = """
         for x in @mac [aaaaa, bbbbb, ccccc]
             foo
@@ -831,8 +825,6 @@ using JuliaFormatter: format_text
         end"""
         test_format(s_, s, YASStyle(); margin=31)
 
-        # A macrocall whose final argument is a block indents that block relative to the
-        # start of the line instead, so here there is nothing to move.
         s_ = """
         ccc => @mac function ()
             return aaa
@@ -843,7 +835,29 @@ using JuliaFormatter: format_text
         end"""
         test_format(s_, s, YASStyle(); margin=24)
 
-        # A unary operator aligns the same way its operand alone would.
+        s_ = """
+        for x in yyy::Foo(aaaaa, bbbbb, ccccc)
+            foo
+        end"""
+        s = """
+        for x in yyy::Foo(aaaaa, bbbbb,
+                          ccccc)
+
+            foo
+        end"""
+        test_format(s_, s, YASStyle(); margin=33)
+
+        s_ = """
+        for x in @mac aaaa = [bbbbbb, cccccc, dddddd]
+            foo
+        end"""
+        s = """
+        for x in @mac aaaa = [bbbbbb, cccccc,
+                              dddddd]
+            foo
+        end"""
+        test_format(s_, s, YASStyle(); margin=39)
+
         s_ = """
         for x in !(aaaa == 1 && (bbbb(cc) || dddd))
             foo
@@ -855,8 +869,6 @@ using JuliaFormatter: format_text
         end"""
         test_format(s_, s, YASStyle(); margin=24)
 
-        # `where` aligns its type parameters with the `{`. (The blank line before the loop
-        # body is unrelated pre-existing behaviour for a nested iteration specification.)
         s_ = """
         for x in Foo{A} where {Aa<:Xx, Bb<:Yy, Cc<:Zz}
             foo


### PR DESCRIPTION
Closes #1230

Claude wrote this

<details><summary>Claude spam</summary>

# YAS: misaligned continuation lines after un-nesting a binary op

## Symptom

```julia
julia> s = """
       for x in @mymacro [1111111111111111111111, 222222222222222222222222,
                          33333333333333333333, 444444444]
           foo
       end""";

julia> format_text(s, YASStyle()) |> println
for x in @mymacro [1111111111111111111111, 222222222222222222222222,
          33333333333333333333, 444444444]
    foo
end
```

`33333333333333333333` should line up with `1111111111111111111111` at column 19. It comes
out at column 10 instead.

Two other right-hand sides are affected the same way — a unary operator applied to a
bracketed expression, and a `where`:

```julia
for x in !(ccccccccccccccccccccccc == 1 &&
  (ddddddddddddddddddd(eee[1]) || ffffffffffffffffffffffffffffff))     # want column 11
    foo
end

for x in Foo{A} where {Aaaaaaaaaa<:Xxxxxxxxxxxx,Bbbbbbbbbb<:Yyyyyyyyyyyy,
              Ccccccccccccccccccc<:Zzzzzzzzzzzz}                       # want column 23
    foo
end
```

## The mechanism

The relevant code is `n_binaryopcall!` in `src/styles/default/nest.jl`. The bug is in how
it *undoes* a nesting decision it made speculatively.

To lay out `x in @mymacro [111…, 222…, 333…, 444…]` at margin 92:

1. The whole thing is 97 wide, so it nests at the operator, putting the RHS on its own
   line. `in` is not an assignment, so `indent_nest` is false and the RHS is placed at
   `fst.indent` — **column 4**, the loop-body indent.

2. The RHS is nested *there*. A `MacroBlock` has no nest function of its own, so it hits
   the generic fallback, which walks `@`(1) + `mymacro`(7) + ` `(1) and nests the `Vect` at
   column 13. `n_tuple!` then sets `Vect.indent = 13 + 1 = 14` — align just past the `[`.

3. The LHS is nested, and the code re-measures: does the RHS's *first line* fit after
   `for x in `? `9 + 59 + 1 = 69 ≤ 92`, so yes — the nesting was unnecessary and gets
   undone.

4. `fst[i1] = Whitespace(1)`, `fst[i2] = Whitespace(0)`, and the RHS goes back on the same
   line, now starting at **column 9** rather than 4.

The RHS has moved sideways by +5, but everything inside it was aligned for column 4.

## The undo is a heuristic

Step 4 calls `walk(unnest!(style; dedent = true), rhs, s)`, and `dedent!`
(`src/nest_utils.jl`) simply subtracts one indent level from every non-leaf:

```julia
function dedent!(fst::FST, s::State)
    if is_closer(fst) || fst.typ === NOTCODE
        fst.indent -= s.opts.indent
    elseif is_leaf(fst) || fst.typ === StringN
        return
    else
        fst.indent -= s.opts.indent
    end
end
```

`Vect.indent` goes 14 → 10.

That is the right move for constructs indented *from the start of the line*: a block body
genuinely shifts left by one level when a level of nesting disappears. It is meaningless
for content aligned against a bracket, which has to move by however far the RHS actually
moved — here +5, to column 19 — not by −4.

## The repair step, and why it only worked sometimes

The old code knew this and patched it up afterwards, but only for two node types:

```julia
walk(unnest!(style; dedent = true), rhs, s)
# Iterables in YASStyle need to be aligned with the
# open bracket
if style isa YASStyle
    if is_unnamed_iterable(rhs)
        extra_indent = if !isempty(rhs.nodes) && is_opener(rhs[1])
            line_offset - rhs.indent + 1
        else
            line_offset - rhs.indent
        end
        add_indent!(rhs, s, extra_indent)
    elseif is_named_iterable(rhs)
        extra_indent =
            line_offset - rhs.indent + length(rhs[1]) + length(rhs[2])
        add_indent!(rhs, s, extra_indent)
    end
end
```

`is_unnamed_iterable` covers `TupleN, Vect, Vcat, Ncat, Braces, Comprehension, Brackets`;
`is_named_iterable` covers `Call, Curly, TypedComprehension, MacroCall, RefN, TypedVcat,
TypedNcat`. A `MacroBlock` is in neither list, so no branch fired and `Vect.indent` kept
the raw dedent value of 10. Likewise for `Unary` and `Where`.

## Why it had to be written per-type

The two formulas look different but are the same computation. Write `rhs_start` for the
column the RHS occupied in the nested layout:

- **unnamed iterable** — `n_tuple!` had set `rhs.indent = rhs_start + 1`, so after the
  dedent it is `rhs_start + 1 - indent`, and

  ```
  line_offset - rhs.indent + 1
      = line_offset - (rhs_start + 1 - indent) + 1
      = line_offset - rhs_start + indent
  ```

- **named iterable** — `n_call!` had set `rhs.indent = rhs_start + len(name) + 1` when it
  reached the opener, and `length(rhs[1]) + length(rhs[2])` *is* `len(name) + 1`, so

  ```
  line_offset - rhs.indent + length(rhs[1]) + length(rhs[2])
      = line_offset - (rhs_start + len(name) + 1 - indent) + len(name) + 1
      = line_offset - rhs_start + indent
  ```

Both reduce to `line_offset - rhs_start + s.opts.indent`: *how far the RHS moved, plus
undo the dedent*.

Neither branch had `rhs_start` to hand, so each one reconstructed it backwards out of
`rhs.indent` — which only works if you already know exactly how that node type's nest
function assigned `indent`. That is the whole reason there had to be one branch per type,
and the reason for the `+ 1` and `+ length(rhs[1]) + length(rhs[2])` fudge factors: they
are the offset from the node's start column to its alignment column, cancelling out the
same offset baked into `rhs.indent`.

So the bug was structural rather than an oversight about one node type. Any RHS whose nest
function sets `indent` by a rule not enumerated in those two branches gets no repair at all
and silently keeps the dedent.

## The fix

Record `rhs_start` directly, captured immediately before the RHS is nested:

```julia
# rhs
#
# Remember the column the RHS starts at in this (nested) layout. Any alignment
# that nesting the RHS sets up is relative to this column, so if the nesting is
# undone further below we need to know how far the RHS has moved sideways.
rhs_line_offset = s.line_offset
fst[end].extra_margin = fst.extra_margin
nest!(style, fst[end], s, lineage)
```

and then apply the single shift:

```julia
if style isa YASStyle && is_column_aligned(rhs)
    add_indent!(rhs, s, line_offset - rhs_line_offset + s.opts.indent)
end
```

No reverse-engineering, and the per-type fudge factors disappear. The existing iterable
cases are unchanged, since the old formulas were algebraically equal to this one.

What remains is the one question that genuinely *is* per-type, and which the old code was
conflating with the arithmetic: **does this node align to its own starting column at all,
or to the start of the line?** That is `is_column_aligned` (`src/fst.jl`):

```julia
function is_column_aligned(fst::FST)
    if is_leaf(fst)
        return false
    elseif fst.typ === MacroBlock
        # The trailing argument is the one that continuation lines follow on from.
        nodes = fst.nodes::Vector{FST}
        return !isempty(nodes) && is_column_aligned(nodes[end])
    elseif fst.typ === Unary
        # Either `!x` or `x...`; in both cases it's the operand that matters, not the
        # operator.
        nodes = fst.nodes::Vector{FST}
        idx = findfirst(n -> n.typ !== OPERATOR, nodes)
        return idx !== nothing && is_column_aligned(nodes[idx])
    end
    return fst.typ === Where || is_iterable(fst)
end
```

The distinction is real, not defensive: a first attempt applied the shift unconditionally
and broke the existing `ccc => function () … end` test, because a long-form function body
*is* line-anchored and the plain dedent was already correct for it. For the same reason a
`MacroBlock` delegates to its final argument — `@testset "x" begin … end` must not move,
`@mymacro [a, b]` must.

## Which node types can be affected

Only right-hand sides that (a) reach the un-nest path while still spanning several lines
and (b) are column-aligned.

`Binary`, `Chain`, `Comparison` and `Conditional` are column-aligned in YAS but cannot
qualify: `n_binaryopcall!` adds their **full** width to `line_margin` before deciding to
un-nest, so they only ever un-nest when they have collapsed onto a single line, at which
point there is no continuation line to misplace.

```julia
if (rhs.typ === Binary && !(op_kind(rhs) in KSet"in ::")) ||
   rhs.typ === Unary && rhs[end].typ !== Brackets ||
   rhs.typ === Chain ||
   rhs.typ === Comparison ||
   rhs.typ === Conditional
    line_margin += length(fst[end])
elseif ...
else
    # Calculate how much of the RHS we need to fit on the current line
    rw, _ = length_to(fst, (NEWLINE,); start = i2 + 1)
    line_margin += rw
end
```

Note that `Unary` is excluded from that clause exactly when its operand is a `Brackets` —
which is how the unary case became reachable.

Sweeping every `.jl` file in the repo with instrumentation on the un-nest path turned up
`MacroBlock`, `Unary` and `Where` as the reachable cases (plus `StringN`, which `unnest!`
skips, and `Begin`, which is correctly line-anchored).

## An unrelated pre-existing bug found along the way

At tight margins the output is not idempotent — but this predates the fix and is not
specific to it. A plain `Vect` right-hand side, which the old code already re-aligned,
breaks the same way:

```julia
julia> s = "for x in [aaaa, bbbb, cccc]\n    foo\nend";

julia> format_text(s, YASStyle(); margin=22) |> println
for x in [aaaa, bbbb,
          cccc]
    foo
end

julia> format_text(format_text(s, YASStyle(); margin=22), YASStyle(); margin=22) |> println
for x in
    [aaaa, bbbb,
     cccc]
    foo
end
```

On the second pass the source already contains the line break, which changes how the RHS
is measured when deciding whether to un-nest. The regression tests were placed at margins
where the output is idempotent (`test_format` checks this) rather than working around it.

</details>