### PR TITLE
Drop semicolons when expanding single-line constructs to blocks

### DIFF
--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,3 +1,8 @@
+# v2.12.0
+
+JuliaFormatter now removes superfluous semicolons inside block expressions.
+For example, `for x in y; z; end` is now formatted as `for x in y\n    z\nend`, rather than `for x in y\n    ;\n    z;\nend` (which is pretty ugly). (#1237)
+
 # v2.11.5
 
 Fixed more buggy cases of YASStyle indentation (some of which were regressions in v2.11.1). (#1230, #1231)

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.11.5"
+version = "2.12.0"
 authors = ["Dominique Luna <dluna132@gmail.com> and contributors"]
 
 [workspace]

--- a/src/fst.jl
+++ b/src/fst.jl
@@ -323,7 +323,21 @@ is_comment(fst::FST) = fst.typ in (INLINECOMMENT, NOTCODE, HASHEQCOMMENT)
 
 is_identifier(x) = kind(x) === K"Identifier" && !haschildren(x)
 
-is_ws(x) = JuliaSyntax.is_whitespace(x)
+"""
+    block_has_statements(cst) -> Bool
+
+Whether the `block` node `cst` contains any statements.
+
+Semicolons don't count. They are only statement separators and are dropped when the block
+is printed (see `p_block`), so `function f(); end` is just as empty as `function f() end`
+and both are printed the same way. Counting the `;` as a statement would instead give
+`function f()\\nend` on the first pass, which the empty-block handling then collapses to
+`function f() end` on the second — i.e. not idempotent.
+"""
+function block_has_statements(cst)
+    haschildren(cst) || return false
+    any(c -> !Shims.is_really_whitespace(c) && kind(c) !== K";", children(cst))
+end
 
 function is_multiline(fst::FST)
     fst.endline > fst.startline &&

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -21,11 +21,11 @@ options(::DefaultStyle) = Options()
     # indicates whether newlines inside are semantically meaningful
     from_nrow::Bool = false
     # indicates whether newlines at the end are semantically meaningful
-    is_last_ncat_or_nrow_arg::Bool=false
+    is_last_ncat_or_nrow_arg::Bool = false
 
     # indicates whether the caller in a function definition has been parenthesised
     # see p_call for explanation
-    is_parenthesised_caller::Bool=false
+    is_parenthesised_caller::Bool = false
 
     ignore_single_line::Bool = false
     from_quote::Bool = false
@@ -1220,7 +1220,7 @@ function p_block(
         if kind(a) === K"Comment"
             add_hasheq_comment!(t, pretty(style, a, s, ctx, lineage), s)
             continue
-        elseif is_ws(a)
+        elseif JuliaSyntax.is_whitespace(a)
             s.offset += span(a)
             continue
         end
@@ -1260,8 +1260,13 @@ function p_block(
                     add_node!(t, Placeholder(1), s)
                 end
             elseif kind(a) === K";"
-                n = pretty(style, a, s, ctx, lineage)
-                add_node!(t, n, s; join_lines = true)
+                if join_body
+                    # Collapsing the statements onto a single line, so print the semicolon
+                    add_node!(t, pretty(style, a, s, ctx, lineage), s; join_lines = true)
+                else
+                    # Breaking onto multiple lines so just skip over it
+                    s.offset += span(a)
+                end
             elseif join_body
                 n = pretty(style, a, s, ctx, lineage)
                 add_node!(t, n, s; join_lines = true)
@@ -1311,7 +1316,7 @@ function p_block(
         if kind(a) === K"Comment"
             add_hasheq_comment!(t, pretty(style, a, s, ctx, lineage), s)
             continue
-        elseif is_ws(a)
+        elseif JuliaSyntax.is_whitespace(a) || kind(a) === K";"
             s.offset += span(a)
             continue
         end
@@ -1454,7 +1459,7 @@ function p_functiondef(
                 end
             end
         elseif kind(c) === K"block" && haschildren(c)
-            block_has_contents = any(cc -> !Shims.is_really_whitespace(cc), children(c))
+            block_has_contents = block_has_statements(c)
             s.indent += s.opts.indent
             n = pretty(style, c, s, newctx(ctx; ignore_single_line = true), lineage)
             add_node!(t, n, s; max_padding = s.opts.indent)
@@ -1528,8 +1533,7 @@ function p_struct(
                 add_node!(t, n, s; join_lines = true)
             end
         elseif kind(c) === K"block" && haschildren(c)
-            block_has_contents =
-                length(filter(cc -> !JuliaSyntax.is_whitespace(cc), children(c))) > 0
+            block_has_contents = block_has_statements(c)
             s.indent += s.opts.indent
             n = pretty(style, c, s, newctx(ctx; ignore_single_line = true), lineage)
             if s.opts.annotate_untyped_fields_with_any && can_transform_syntax(s, true)
@@ -1582,8 +1586,7 @@ function p_mutable(
                 add_node!(t, n, s; join_lines = true)
             end
         elseif kind(c) === K"block" && haschildren(c)
-            block_has_contents =
-                length(filter(cc -> !JuliaSyntax.is_whitespace(cc), children(c))) > 0
+            block_has_contents = block_has_statements(c)
             s.indent += s.opts.indent
             n = pretty(style, c, s, newctx(ctx; ignore_single_line = true), lineage)
             if s.opts.annotate_untyped_fields_with_any && can_transform_syntax(s, true)
@@ -1639,8 +1642,7 @@ function p_module(
                 add_node!(t, n, s; join_lines = true)
             end
         elseif kind(c) === K"block" && haschildren(c)
-            block_has_contents =
-                length(filter(cc -> !JuliaSyntax.is_whitespace(cc), children(c))) > 0
+            block_has_contents = block_has_statements(c)
 
             if indent_module
                 s.indent += s.opts.indent
@@ -1772,6 +1774,8 @@ function p_toplevel(
     for a in children(cst)
         n = pretty(style, a, s, ctx, lineage)
         if kind(a) === K";"
+            # Can't drop top-level semicolons as that leads to different behaviour
+            # in REPL for example
             add_node!(t, n, s; join_lines = true)
         else
             add_node!(t, n, s; max_padding = 0)
@@ -1795,20 +1799,21 @@ function p_begin(
 
     childs = children(cst)
     add_node!(t, pretty(style, childs[1], s, ctx, lineage), s)
-    empty_body = length(filter(n -> !Shims.is_really_whitespace(n), childs)) == 2
+
+    # == 2 because the two children are `begin` and `end`
+    empty_body = count(n -> !Shims.is_really_whitespace(n) && kind(n) !== K";", childs) == 2
 
     if empty_body && !s.opts.join_lines_based_on_source
         for c in childs[2:(end-1)]
             pretty(style, c, s, ctx, lineage)
         end
         add_node!(t, Whitespace(1), s)
-        # Override the `end` keyword's startline to match `begin`, so that
-        # add_node! doesn't detect a source line gap and insert a NEWLINE.
-        # Without this, `begin\n\nend` → `begin\nend` (pass 1) → `begin end`
-        # (pass 2), i.e. non-idempotent.
+        # Override the `end` keyword's startline to match `begin`, so that add_node! doesn't
+        # detect a source line gap and insert a NEWLINE. Without this, `begin\n\nend` is
+        # formatted to `begin\nend` and then `begin end`
         end_node = pretty(style, cst[end], s)
         end_node.startline = t.endline
-        # but don't override endline or else that inserts extra newlines at the end
+        # But don't override endline or else that inserts extra newlines at the end
         add_node!(t, end_node, s; join_lines = true)
     else
         push!(lineage, (K"block", false, false))
@@ -1956,6 +1961,15 @@ function p_let(
             end
         elseif kind(c) === K"end"
             add_node!(t, pretty(style, c, s, ctx, lineage), s)
+        elseif kind(c) === K";"
+            # The `;` between the binding list and the body of `let x = 1; body; end`.
+            # The body is always emitted on its own line, so the newline separates the
+            # two and the `;` is redundant:
+            #
+            #     let x = 1; body; end  ->  let x = 1
+            #                                   body
+            #                               end
+            s.offset += span(c)
         else
             add_node!(
                 t,

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1429,8 +1429,11 @@ function p_functiondef(
         caller_idx = nothing
     end
 
-    block_has_contents = false
+    collapse_end_onto_same_line = true
     childs = children(cst)
+    seen_body = false
+    extra_block_node = nothing
+
     for (i, c) in enumerate(childs)
         if i == function_or_macro_keyword_idx
             n = pretty(style, c, s, ctx, lineage)
@@ -1438,10 +1441,12 @@ function p_functiondef(
             add_node!(t, Whitespace(1), s)
         elseif kind(c) === K"end"
             n = pretty(style, c, s, ctx, lineage)
-            if block_has_contents
-                add_node!(t, n, s)
-            else
-                # Empty block
+            if extra_block_node !== nothing
+                add_node!(t, extra_block_node, s)
+                s.indent -= s.opts.indent
+                collapse_end_onto_same_line = false
+            end
+            if collapse_end_onto_same_line
                 if s.opts.join_lines_based_on_source
                     join_lines = t.endline == n.startline
                     if join_lines
@@ -1457,13 +1462,26 @@ function p_functiondef(
                     n.startline = t.endline
                     add_node!(t, n, s; join_lines = true)
                 end
+            else
+                add_node!(t, n, s)
             end
+        elseif seen_body
+            if !JuliaSyntax.is_whitespace(c)
+                error("Unexpected node after function body: $(kind(c))")
+            end
+            if extra_block_node === nothing
+                s.indent += s.opts.indent
+                extra_block_node = FST(Block, nspaces(s))
+            end
+            n = pretty(style, c, s, ctx, lineage)
+            add_node!(extra_block_node, n, s)
         elseif kind(c) === K"block" && haschildren(c)
-            block_has_contents = block_has_statements(c)
+            collapse_end_onto_same_line = !block_has_statements(c)
             s.indent += s.opts.indent
             n = pretty(style, c, s, newctx(ctx; ignore_single_line = true), lineage)
             add_node!(t, n, s; max_padding = s.opts.indent)
             s.indent -= s.opts.indent
+            seen_body = true
         elseif i === caller_idx
             n = pretty(style, c, s, newctx(ctx; can_separate_kwargs = false), lineage)
             add_node!(t, n, s; join_lines = true)
@@ -1998,6 +2016,8 @@ function p_for(
 
     ends_in_iterable = false
     is_while_cond = false
+    seen_body = false
+    extra_block_node = nothing
 
     for c in children(cst)
         if kind(c) in KSet"for while" && !haschildren(c)
@@ -2006,7 +2026,29 @@ function p_for(
                 is_while_cond = true
             end
         elseif kind(c) === K"end"
+            if extra_block_node !== nothing
+                add_node!(t, extra_block_node, s)
+                s.indent -= s.opts.indent
+            end
             add_node!(t, pretty(style, c, s), s)
+        elseif seen_body
+            # These are things that came after the loop body, but somehow aren't `end`.
+            # This can happen with constructs such as `for i in 1:10; #= hello =# end`,
+            # where JuliaSyntax parses the comment as a child of the `for` node instead
+            # of the block.
+            #
+            # To handle such cases, we create a fake block node that contains the remaining
+            # children. It's hacky, but I strongly suspect that the only thing that can
+            # occur here is whitespace / comments so it might be fine.
+            if !JuliaSyntax.is_whitespace(c)
+                error("Unexpected child after loop body: $(kind(c))")
+            end
+            if extra_block_node === nothing
+                s.indent += s.opts.indent
+                extra_block_node = FST(Block, nspaces(s))
+            end
+            n = pretty(style, c, s, ctx, lineage)
+            add_node!(extra_block_node, n, s)
         elseif kind(c) === K"block"
             # We need `is_while_cond` to determine whether the block we see is the body of
             # the loop, or the condition of a while loop such as `while (a; b; c) ... end`.
@@ -2025,6 +2067,7 @@ function p_for(
                 if !ends_in_iterable && (t.nodes::Vector{FST})[end-2].typ !== NOTCODE
                     insert!(t, length(t.nodes) - 1, Placeholder(0))
                 end
+                seen_body = true
             end
         elseif JuliaSyntax.is_whitespace(c)
             add_node!(t, pretty(style, c, s, ctx, lineage), s)
@@ -2268,13 +2311,21 @@ function p_if(
 
     # Flag to indicate when we are processing the condition of an if or elseif.
     is_cond = false
+    # Whether or not we've read in a body following the if/elseif/else yet.
+    seen_body = false
+    extra_block_node = nothing
 
     for c in children(cst)
         if kind(c) in KSet"if elseif else"
             if !haschildren(c)
                 add_node!(t, pretty(style, c, s, ctx, lineage), s; max_padding = 0)
             else
-                # TODO(penelopeysm) how can an if/elseif/else keyword have a child?
+                if extra_block_node !== nothing
+                    add_node!(t, extra_block_node, s)
+                    s.indent -= s.opts.indent
+                    extra_block_node = nothing
+                    seen_body = false
+                end
                 len = length(t)
                 n = pretty(style, c, s, ctx, lineage)
                 add_node!(t, n, s)
@@ -2285,7 +2336,23 @@ function p_if(
                 is_cond = true
             end
         elseif kind(c) === K"end"
+            if extra_block_node !== nothing
+                add_node!(t, extra_block_node, s)
+                s.indent -= s.opts.indent
+                extra_block_node = nothing
+            end
             add_node!(t, pretty(style, c, s, ctx, lineage), s)
+        elseif seen_body
+            # See comments in `p_for` for explanation of this
+            if !JuliaSyntax.is_whitespace(c)
+                error("Unexpected child after if body: $(kind(c))")
+            end
+            if extra_block_node === nothing
+                s.indent += s.opts.indent
+                extra_block_node = FST(Block, nspaces(s))
+            end
+            n = pretty(style, c, s, ctx, lineage)
+            add_node!(extra_block_node, n, s)
         elseif kind(c) === K"block"
             # This block could either be the condition (if it immediatelly follows an `if`
             # or `elseif`, ignoring whitespace), or it could be the actual body. This is
@@ -2304,6 +2371,7 @@ function p_if(
                     max_padding = s.opts.indent,
                 )
                 s.indent -= s.opts.indent
+                seen_body = true
             end
         elseif !JuliaSyntax.is_whitespace(c)
             # This branch is hit for non-block conditions (i.e. simple things like the `x`
@@ -2316,6 +2384,17 @@ function p_if(
         else
             add_node!(t, pretty(style, c, s, ctx, lineage), s)
         end
+    end
+
+    # This branch can be hit in cases like
+    #     s = "if x; elseif y; #= comment =# end"
+    # because `comment` is the final child of the elseif and there's no node after it to
+    # trigger addition of `extra_block_node`.
+    if extra_block_node !== nothing
+        add_node!(t, extra_block_node, s)
+        s.indent -= s.opts.indent
+        extra_block_node = nothing
+        seen_body = false
     end
 
     return t

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -2319,6 +2319,7 @@ function p_if(
         if kind(c) in KSet"if elseif else"
             if !haschildren(c)
                 add_node!(t, pretty(style, c, s, ctx, lineage), s; max_padding = 0)
+                seen_body = false
             else
                 if extra_block_node !== nothing
                     add_node!(t, extra_block_node, s)

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -1465,8 +1465,8 @@ function p_functiondef(
             else
                 add_node!(t, n, s)
             end
-        elseif seen_body
-            if !JuliaSyntax.is_whitespace(c)
+        elseif seen_body && !Shims.is_really_whitespace(c)
+            if kind(c) !== K"Comment"
                 error("Unexpected node after function body: $(kind(c))")
             end
             if extra_block_node === nothing
@@ -2031,7 +2031,7 @@ function p_for(
                 s.indent -= s.opts.indent
             end
             add_node!(t, pretty(style, c, s), s)
-        elseif seen_body
+        elseif seen_body && !Shims.is_really_whitespace(c)
             # These are things that came after the loop body, but somehow aren't `end`.
             # This can happen with constructs such as `for i in 1:10; #= hello =# end`,
             # where JuliaSyntax parses the comment as a child of the `for` node instead
@@ -2040,8 +2040,8 @@ function p_for(
             # To handle such cases, we create a fake block node that contains the remaining
             # children. It's hacky, but I strongly suspect that the only thing that can
             # occur here is whitespace / comments so it might be fine.
-            if !JuliaSyntax.is_whitespace(c)
-                error("Unexpected child after loop body: $(kind(c))")
+            if kind(c) !== K"Comment"
+                error("Unexpected node after loop body: $(kind(c))")
             end
             if extra_block_node === nothing
                 s.indent += s.opts.indent
@@ -2343,10 +2343,10 @@ function p_if(
                 extra_block_node = nothing
             end
             add_node!(t, pretty(style, c, s, ctx, lineage), s)
-        elseif seen_body
+        elseif seen_body && !Shims.is_really_whitespace(c)
             # See comments in `p_for` for explanation of this
-            if !JuliaSyntax.is_whitespace(c)
-                error("Unexpected child after if body: $(kind(c))")
+            if kind(c) !== K"Comment"
+                error("Unexpected node after if body: $(kind(c))")
             end
             if extra_block_node === nothing
                 s.indent += s.opts.indent

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -3,7 +3,7 @@ module DefaultTests
 using Test
 using JuliaSyntax
 using JuliaFormatter: JuliaFormatter, DefaultStyle, Options, format_file
-using JuliaFormatter.Internal: test_format
+using JuliaFormatter.Internal: test_format, ALL_STYLES
 
 function run_pretty(text::String; style = DefaultStyle(), opts = Options())
     d = JuliaFormatter.Document(text)

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -2328,7 +2328,7 @@ run_nest(text::String, margin::Int) = run_nest(text, opts = Options(margin = mar
         @test length(t) == 18
 
         str = """function foo()
-                     10;
+                     10
                      20
                  end"""
         test_format("""function foo() 10;  20 end""", str)
@@ -2347,15 +2347,15 @@ run_nest(text::String, margin::Int) = run_nest(text, opts = Options(margin = mar
                 end""", str)
 
         str = """for i = 1:10
-                     1;
-                     2;
+                     1
+                     2
                      3
                  end"""
         test_format("""for i=1:10 1; 2; 3 end""", str)
 
         str = """while true
-                     1;
-                     2;
+                     1
+                     2
                      3
                  end"""
         test_format("""while true 1; 2; 3 end""", str)
@@ -2368,13 +2368,13 @@ run_nest(text::String, margin::Int) = run_nest(text, opts = Options(margin = mar
         test_format("""try a catch e b end""", str)
 
         str = """try
-                     a1;
+                     a1
                      a2
                  catch e
-                     b1;
+                     b1
                      b2
                  finally
-                     c1;
+                     c1
                      c2
                  end"""
         test_format("""try a1;a2 catch e b1;b2 finally c1;c2 end""", str)
@@ -2386,8 +2386,8 @@ run_nest(text::String, margin::Int) = run_nest(text, opts = Options(margin = mar
                      e end""", str)
 
         str = """let a=b, c = d
-                     e1;
-                     e2;
+                     e1
+                     e2
                      e3
                  end"""
         test_format("""let a=b,c  =  d  \ne1; e2; e3 end""", str)
@@ -2403,8 +2403,8 @@ run_nest(text::String, margin::Int) = run_nest(text, opts = Options(margin = mar
                      c""", str)
 
         str = """begin
-                     a;
-                     b;
+                     a
+                     b
                      c
                  end"""
         test_format("""begin a; b; c end""", str)
@@ -2413,8 +2413,8 @@ run_nest(text::String, margin::Int) = run_nest(text, opts = Options(margin = mar
         test_format("""begin \n            end""", str)
 
         str = """quote
-                     a;
-                     b;
+                     a
+                     b
                      c
                  end"""
         test_format("""quote a; b; c end""", str)
@@ -2423,32 +2423,32 @@ run_nest(text::String, margin::Int) = run_nest(text, opts = Options(margin = mar
         test_format("""quote \n end""", str)
 
         str = """if cond1
-                     e1;
+                     e1
                      e2
                  end"""
         test_format("if cond1 e1;e2 end", str)
 
         str = """if cond1
-                     e1;
+                     e1
                      e2
                  else
-                     e3;
+                     e3
                      e4
                  end"""
         test_format("if cond1 e1;e2 else e3;e4 end", str)
 
         str = """begin
                      if cond1
-                         e1;
+                         e1
                          e2
                      elseif cond2
-                         e3;
+                         e3
                          e4
                      elseif cond3
-                         e5;
+                         e5
                          e6
                      else
-                         e7;
+                         e7
                          e8
                      end
                  end"""
@@ -2457,10 +2457,10 @@ run_nest(text::String, margin::Int) = run_nest(text, opts = Options(margin = mar
             str)
 
         str = """if cond1
-                     e1;
+                     e1
                      e2
                  elseif cond2
-                     e3;
+                     e3
                      e4
                  end"""
         test_format("if cond1 e1;e2 elseif cond2 e3; e4 end", str)
@@ -2640,7 +2640,7 @@ run_nest(text::String, margin::Int) = run_nest(text, opts = Options(margin = mar
                 C,
             },
         }
-            10;
+            10
             20
         end"""
         str_ = "function f(arg1::A,key1=val1;key2=val2) where {A,F{B,C}} 10; 20 end"
@@ -2655,7 +2655,7 @@ run_nest(text::String, margin::Int) = run_nest(text, opts = Options(margin = mar
             A,
             F{B,C},
         }
-            10;
+            10
             20
         end"""
         test_format(str_, str; indent=4, margin=17)
@@ -2666,7 +2666,7 @@ run_nest(text::String, margin::Int) = run_nest(text, opts = Options(margin = mar
             key1 = val1;
             key2 = val2,
         ) where {A,F{B,C}}
-            10;
+            10
             20
         end"""
         test_format(str_, str; indent=4, margin=18)

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -5007,7 +5007,6 @@ some_function(
         test_format("while a; b; end", "while a\n    b\nend")
         test_format("struct A; x; end", "struct A\n    x::Any\nend")
         test_format("quote; x = 1; end", "quote\n    x = 1\nend")
-        test_format("begin; end", "begin\nend")
 
         # The separator between the binding list and the body of a `let` is a child of
         # the `let` node rather than of a block, but goes the same way.

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -2296,18 +2296,14 @@ run_nest(text::String, margin::Int) = run_nest(text, opts = Options(margin = mar
         # issue 152
         str = """
         try
-            ;
         catch
-            ;
         end   # comment"""
         str_ = """try; catch;  end   # comment"""
         test_format(str_, str)
 
         str = """
         try
-            ;
         catch
-            ;
         end   # comment
         a = 10"""
         str_ = """
@@ -5000,6 +4996,51 @@ some_function(
             c
         """
         test_format(str_, str; indent=4, margin=1)
+    end
+
+    @testset "semicolon statement separators are dropped" begin
+        # A `;` inside a block only separates statements. Once the block is laid out
+        # one statement per line the newline does that job, so the `;` goes away.
+        test_format("for i = 1:10; x = 1; y = 2; end", "for i = 1:10\n    x = 1\n    y = 2\nend")
+        test_format("function f(); x = 1; end", "function f()\n    x = 1\nend")
+        test_format("if a; b; else; c; end", "if a\n    b\nelse\n    c\nend")
+        test_format("while a; b; end", "while a\n    b\nend")
+        test_format("struct A; x; end", "struct A\n    x::Any\nend")
+        test_format("quote; x = 1; end", "quote\n    x = 1\nend")
+        test_format("begin; end", "begin\nend")
+
+        # The separator between the binding list and the body of a `let` is a child of
+        # the `let` node rather than of a block, but goes the same way.
+        test_format("let a = 1; b = 2; x; end", "let a = 1\n    b = 2\n    x\nend")
+        test_format("let a = 1, b = 2; x; end", "let a = 1, b = 2\n    x\nend")
+
+        # Not at top level though: there a `;` suppresses display of the result, so
+        # removing it would change behaviour in the REPL and in notebooks.
+        test_format("hello();", "hello();")
+        test_format("x = 1; y = 2", "x = 1;\ny = 2")
+
+        # A `;` that is part of the syntax rather than a separator also has to stay.
+        test_format("(a; b)", "(a; b)")
+        test_format("f(a; b = 1)", "f(a; b = 1)")
+
+        # A body of nothing but semicolons is an empty body, so these take the same path
+        # as `begin end` / `function f() end` rather than being printed over two lines
+        # and then collapsed on the next pass.
+        test_format("begin; end", "begin end")
+        test_format("quote; end", "quote end")
+        test_format("function f(); end", "function f() end")
+        test_format("macro m(); end", "macro m() end")
+        test_format("module A; end", "module A end")
+        test_format("struct A; end", "struct A end")
+        test_format("mutable struct A; end", "mutable struct A end")
+
+        # These constructs don't collapse an empty body onto one line, with or without
+        # the semicolon.
+        test_format("let; end", "let\nend")
+        test_format("for i = 1:2; end", "for i = 1:2\nend")
+        test_format("while a; end", "while a\nend")
+        test_format("if a; end", "if a\nend")
+        test_format("try; catch; end", "try\ncatch\nend")
     end
 end
 

--- a/test/default_style.jl
+++ b/test/default_style.jl
@@ -4999,47 +4999,63 @@ some_function(
     end
 
     @testset "semicolon statement separators are dropped" begin
-        # A `;` inside a block only separates statements. Once the block is laid out
-        # one statement per line the newline does that job, so the `;` goes away.
+        test_format("begin; end", "begin end")
         test_format("for i = 1:10; x = 1; y = 2; end", "for i = 1:10\n    x = 1\n    y = 2\nend")
+        test_format("for i = 1:2; end", "for i = 1:2\nend")
+        test_format("function f(); end", "function f() end")
         test_format("function f(); x = 1; end", "function f()\n    x = 1\nend")
         test_format("if a; b; else; c; end", "if a\n    b\nelse\n    c\nend")
-        test_format("while a; b; end", "while a\n    b\nend")
-        test_format("struct A; x; end", "struct A\n    x::Any\nend")
-        test_format("quote; x = 1; end", "quote\n    x = 1\nend")
-
-        # The separator between the binding list and the body of a `let` is a child of
-        # the `let` node rather than of a block, but goes the same way.
-        test_format("let a = 1; b = 2; x; end", "let a = 1\n    b = 2\n    x\nend")
+        test_format("if a; end", "if a\nend")
         test_format("let a = 1, b = 2; x; end", "let a = 1, b = 2\n    x\nend")
-
-        # Not at top level though: there a `;` suppresses display of the result, so
-        # removing it would change behaviour in the REPL and in notebooks.
-        test_format("hello();", "hello();")
-        test_format("x = 1; y = 2", "x = 1;\ny = 2")
-
-        # A `;` that is part of the syntax rather than a separator also has to stay.
-        test_format("(a; b)", "(a; b)")
-        test_format("f(a; b = 1)", "f(a; b = 1)")
-
-        # A body of nothing but semicolons is an empty body, so these take the same path
-        # as `begin end` / `function f() end` rather than being printed over two lines
-        # and then collapsed on the next pass.
-        test_format("begin; end", "begin end")
-        test_format("quote; end", "quote end")
-        test_format("function f(); end", "function f() end")
+        test_format("let a = 1; b = 2; x; end", "let a = 1\n    b = 2\n    x\nend")
+        test_format("let; end", "let\nend")
         test_format("macro m(); end", "macro m() end")
         test_format("module A; end", "module A end")
-        test_format("struct A; end", "struct A end")
         test_format("mutable struct A; end", "mutable struct A end")
-
-        # These constructs don't collapse an empty body onto one line, with or without
-        # the semicolon.
-        test_format("let; end", "let\nend")
-        test_format("for i = 1:2; end", "for i = 1:2\nend")
-        test_format("while a; end", "while a\nend")
-        test_format("if a; end", "if a\nend")
+        test_format("mutable struct A; x::Int; end", "mutable struct A\n    x::Int\nend")
+        test_format("quote; end", "quote end")
+        test_format("quote; x = 1; end", "quote\n    x = 1\nend")
+        test_format("struct A; end", "struct A end")
+        test_format("struct A; x::Int; end", "struct A\n    x::Int\nend")
         test_format("try; catch; end", "try\ncatch\nend")
+        test_format("while a; b; end", "while a\n    b\nend")
+        test_format("while a; end", "while a\nend")
+
+        @testset "top-level semicolons aren't dropped" begin
+            test_format("hello();", "hello();")
+            test_format("x = 1; y = 2", "x = 1;\ny = 2")
+        end
+
+        @testset "semantically significant semicolons aren't dropped" begin
+            test_format("(a; b)", "(a; b)")
+            test_format("f(a; b = 1)", "f(a; b = 1)")
+        end
+    end
+
+    @testset "comments after empty block body" begin
+        for style in ALL_STYLES
+            for loop_start in ("for x in y", "while x", "if x", "if x\n    f\nelseif x", "let x = y", "function f()", "macro m()")
+                s_ = "$(loop_start); #= comment =# end"
+                s = """
+                $(loop_start)
+                    #= comment =#
+                end"""
+                test_format(s_, s, style)
+
+                s_ = "$(loop_start); #= comment1 =# #= comment2 =# end"
+                s = """
+                $(loop_start)
+                    #= comment1 =# #= comment2 =#
+                end"""
+                test_format(s_, s, style)
+
+                s_ = "$(loop_start); # comment\n end"
+                s = """
+                $(loop_start) # comment
+                end"""
+                test_format(s_, s, style)
+            end
+        end
     end
 end
 

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -533,7 +533,7 @@ end
     @testset "264 - `let` empty block body" begin
         str_ = "let; end"
         str = """
-        let;
+        let
         end"""
         test_format(str_, str)
     end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1798,7 +1798,7 @@ end
         let hello() =
                 print(
                     "ok",
-                );
+                )
             hello()
         end
         """

--- a/test/sciml_style.jl
+++ b/test/sciml_style.jl
@@ -66,7 +66,7 @@ using JuliaFormatter.Internal: test_format
     """
     formatted_str = raw"""
     begin
-        include("hi");
+        include("hi")
         1
     end
     """


### PR DESCRIPTION
This PR tweaks the output of JuliaFormatter to strip needless semicolons inside block constructs.

For example, with this PR:

```julia
julia> s = "for x in y; foo; end"
"for x in y; foo; end"

julia> format_text(s) |> println
for x in y
    foo
end
```

On main:

```julia
julia> format_text(s) |> println
for x in y
    ;
    foo;
end
```

Top-level semicolons are not removed because they carry meaning (they suppress output in the REPL). For example, this semicolon is preserved:

```julia
julia> s = "x; y"
"x; y"

julia> format_text(s)
"x;\ny"
```