### PR TITLE
Do not force a line break after = when preserve_single_line_blocks is enabled

### DIFF
--- a/HISTORY_v2.md
+++ b/HISTORY_v2.md
@@ -1,3 +1,7 @@
+# v2.13.1
+
+When `preserve_single_line_blocks` is enabled (as in `MinimalStyle`), a line break is no longer forced after the `=` of a short-form function definition whose right-hand side is a block construct (`try`, `let`, `if`, `for`, `while`, `do`). For example `getallns() = let allns = Base.IdSet{Symbol}(); ...; allns end` is now left unchanged under `MinimalStyle`. (#594, #1255)
+
 # v2.13.0
 
 Added a new formatting option, `preserve_single_line_blocks` (default `false`; `true` for `MinimalStyle`). When enabled, block constructs written entirely on a single source line — e.g. `try isfile(x); catch; false end` or `let x = 1; x end` — are kept on one line, with their statements separated by semicolons, instead of being expanded onto multiple lines. This applies to `function`/`macro` definitions, `for`/`while` loops, `if`, `let`, `try`, `do`, `struct`/`mutable struct`, `module`/`baremodule`, `begin`, and `quote`. (#593, #1254)

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JuliaFormatter"
 uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-version = "2.13.0"
+version = "2.13.1"
 authors = ["Dominique Luna <dluna132@gmail.com> and contributors"]
 
 [workspace]

--- a/src/styles/default/pretty.jl
+++ b/src/styles/default/pretty.jl
@@ -3034,6 +3034,19 @@ function p_binaryopcall(
     nonest = ctx.nonest || opkind === K":"
 
     nrhs = nest_rhs(cst, style)
+    # `nest_rhs` forces a line break after the `=` of a short-form function definition
+    # whose right-hand side is a block construct (if/do/try/for/while/let). Under
+    # `preserve_single_line_blocks` the source layout, not the presence of a block RHS,
+    # decides whether the RHS goes on its own line, so e.g.
+    #
+    #     safe_isfile(x) = try isfile(x); catch; false end
+    #
+    # is left completely unchanged. If the source *does* break the line after the `=`,
+    # `src_diff_line` in `n_binaryopcall!` preserves that break, so nothing is lost by
+    # not forcing AlwaysNest here. See issue #594.
+    if s.opts.preserve_single_line_blocks
+        nrhs = false
+    end
     if nrhs
         t.nest_behavior = AlwaysNest
     end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1418,11 +1418,11 @@ end
             test_format(c * "\n", c * "\n", MinimalStyle(); ast=true)
         end
 
-        # A short-form function def with a single-line block RHS keeps the block on one
-        # line. (The line break after `=` is a separate issue, #594.)
+        # A short-form function def with a single-line block RHS is left completely
+        # unchanged: no line break is forced after the `=` (see #594).
         test_format(
             "safe_isfile(x) = try isfile(x); catch; false end\n",
-            "safe_isfile(x) =\n    try isfile(x); catch; false end\n",
+            "safe_isfile(x) = try isfile(x); catch; false end\n",
             MinimalStyle();
             ast=true,
         )

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -1459,6 +1459,45 @@ end
         )
     end
 
+    @testset "594 no forced line break after =" begin
+        # With `preserve_single_line_blocks` (enabled for MinimalStyle), a short-form
+        # function definition whose right-hand side is a single-line block construct is
+        # left completely unchanged: no line break is forced after the `=`.
+        unchanged = [
+            "getallns() = let allns = Base.IdSet{Symbol}(); oneverything((m, s, x, state) -> push!(allns, s)); allns end",
+            "safe_isfile(x) = try isfile(x); catch; false end",
+            "f(x) = if x; 1 else 2 end",
+            "f() = for i in 1:10; g(i) end",
+        ]
+        for c in unchanged
+            test_format(c * "\n", c * "\n", MinimalStyle(); ast=true)
+        end
+
+        # If the source already breaks the line after the `=`, the break is preserved.
+        test_format(
+            "f() =\n    try isfile(x); catch; false end\n",
+            "f() =\n    try isfile(x); catch; false end\n",
+            MinimalStyle();
+            ast=true,
+        )
+
+        # A block RHS that starts on the `=` line but has a multi-line body: no break is
+        # inserted after the `=`, and the body stays expanded.
+        test_format(
+            "f() = let x = 1\n    x\nend\n",
+            "f() = let x = 1\n    x\nend\n",
+            MinimalStyle();
+            ast=true,
+        )
+
+        # The option is off by default: DefaultStyle still forces the break after `=`.
+        test_format(
+            "f(x) = if x; 1 else 2 end\n",
+            "f(x) =\n    if x\n        1\n    else\n        2\n    end\n";
+            ast=true,
+        )
+    end
+
     @testset "604" begin
         str = raw"""
         begin @foo a end


### PR DESCRIPTION
Closes #594

> **Stacked on #1254** (the `preserve_single_line_blocks` PR for #593) and targets its branch; retarget to `main` once #1254 merges. Without #1254 the `let` body in the example below would still be expanded.

## Problem

MinimalStyle inserted a line break after the `=` of a short-form function definition whose right-hand side is a block construct:

```julia
getallns() = let allns = Base.IdSet{Symbol}(); oneverything((m, s, x, state) -> push!(allns, s)); allns end
```

became

```julia
getallns() =
    let allns = Base.IdSet{Symbol}()
        oneverything((m, s, x, state) -> push!(allns, s))
        allns
    end
```

The agreed behavior in the issue discussion is no change at all.

## Fix

`nest_rhs` returns `true` for short-form defs with an `if`/`do`/`try`/`for`/`while`/`let` RHS, which sets `nest_behavior = AlwaysNest` on the `Binary` node and forces the newline after `=` in `n_binaryopcall!` regardless of margin or source.

This PR gates that at the call site in `p_binaryopcall`: when `preserve_single_line_blocks` is enabled, the source layout — not the presence of a block RHS — decides. If the source *does* break after the `=`, `src_diff_line` in `n_binaryopcall!` still preserves that break, so nothing is lost. `nest_rhs` itself (including its BlueStyle chained-ternary branch) is untouched, and the duplicate rule in `long_to_short_function_def!` is irrelevant here since MinimalStyle disables that pass.

With this, both `getallns() = let ...` and #593's `safe_isfile(x) = try ...` round-trip completely unchanged under MinimalStyle.

## Tests

New `@testset "594"` in `test/issues.jl`: the issue MWE and `try`/`if`/`for` RHS one-liners unchanged under MinimalStyle; a source with an existing break after `=` keeping it; a block RHS with a multi-line body (`f() = let x = 1\n    x\nend`) staying joined at the `=` with the body expanded; and DefaultStyle (option off) still forcing the break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
